### PR TITLE
feat(thumbnail): 候補をWeb比較して安全に確定する (#4017)

### DIFF
--- a/.claude/skills/thumbnail/SKILL.md
+++ b/.claude/skills/thumbnail/SKILL.md
@@ -140,23 +140,23 @@ uv run python .claude/skills/thumbnail/references/share_thumbnail_as_main.py <co
 スクリプトは `thumbnail.jpg` を一時ファイルへ `shutil.copyfile()` でコピーし、SHA-256 一致後に `10-assets/main.jpg` へ置換する。既存 `main.jpg` は更新し、競合する `main.png` は削除する。exit 0 と JSON の `status: SHARED`、同一 SHA-256、`main.png` 不在を確認するまで `assets.thumbnail = true` にしない。`thumbnail-prompts.md` には textless 生成プロンプトを捏造せず、`textless.enabled=false`、`source=10-assets/thumbnail.jpg`、`destination=10-assets/main.jpg`、検証済み SHA-256 を記録する。 thumbnail analysis JSON+HTML pair が存在する場合は、`read_published_json_document(..., RepositorySchema.CHANNEL_RESEARCH_REPORT)` が返す JSON の `winning_patterns` と `application_candidates` だけを、参照画像選定と差分プロンプトの入力にする。pair を検証できず競合サムネイルの勝ちパターンを先に深掘りする場合は `/channel-research --thumbnail` を実行する。
 1. 「thumbnail-text-profile 適用」節の手順で、フォント選定・コピー生成制約・配置を確定する（profile 不在なら実効デフォルト値のまま進む。エラーにしない）。
 2. ベンチマーク先サムネを参照画像にして、検証済み thumbnail analysis JSON がある場合はその勝ちパターンも使い、構図・色温度・主役スケール・背景テクスチャを踏襲した textless 背景候補 `main-v*.png/jpg` を生成する。差分プロンプトには `single_step.text_strip_clause` 相当の除去指示を展開し、タイトル文字・字幕・ロゴ・透かしを焼き込ませない（参照画像の選定・プロンプト構築・CLI 引数は「Single-Step / TTP モード」章の機構を流用する）。
-3. 背景候補は「手動候補の比較選択 Hard Gate」に従い、各候補を thumbnail check CLI で検証してから比較・選択する。候補が 1 枚なら `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json` の成功とユーザー承認後に `cp main-v1.png main.png` で確定する。`mode: full` では `open` と AskUserQuestion を省略し、check が exit 0 かつ期待した画像ファイルが存在するときに既存の自動経路で確定する。
+3. 背景候補は「手動候補の比較選択 Hard Gate」に従い、各候補を thumbnail check CLI で検証してから `yt-thumbnail-review --artifact main` で比較・選択・確定する。候補が1枚でも同じWeb reviewで承認する。`mode: full` ではWeb reviewとAskUserQuestionを省略し、checkがexit 0かつ期待した画像ファイルが存在するときに既存の自動経路で確定する。
 4. 承認済み textless 背景に、profile 適用済みの実効 config で実フォントのタイトルを合成し、テキスト付き候補を作る:
 ```bash
 uv run yt-thumbnail-text --background <collection-path>/10-assets/main.png --title "<Title Line 1>" --title "<Title Line 2>" --channel-name "<channel_name>" --output <collection-path>/10-assets/thumbnail-v1.jpg
 ```
-5. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、選択された 1 枚を `10-assets/thumbnail.jpg` として確定する。候補が 1 枚なら `/thumbnail --compare` とユーザー承認後に `cp thumbnail-v1.jpg thumbnail.jpg` で確定する。`auto_selection.enabled: true` では手動比較を行わず「自動選択」章の `yt-thumbnail-auto-select <collection-path> --apply` で確定する。手動・自動とも確定後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` が成功したことを確認する。自動確定後の `/thumbnail --compare` は省略せず別途実行する。
+5. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、`yt-thumbnail-review --artifact thumbnail` で選択された1枚だけを `10-assets/thumbnail.jpg` として確定する。候補が1枚でも同じWeb reviewを使う。`auto_selection.enabled: true` では手動比較を行わず「自動選択」章の `yt-thumbnail-auto-select <collection-path> --apply` で確定する。手動Web reviewは確定とarchiveを同じtransactionで行う。自動確定では既存archive処理を維持する。自動確定後の `/thumbnail --compare` は省略せず別途実行する。
 6. `config/skills/loop-video.yaml::enabled: true` ならテキストなし `main.png/jpg` を `/thumbnail --loop` に渡して `loop.mp4` を生成し、`false` なら Veo を実行せず静止画背景として `/video --generate` に渡す。
 `thumbnail.jpg` はアップロード用、`main.png/jpg` は動画背景・loop-video 入力用の成果物とする。`textless.enabled` が未設定または `true` では文字入りと文字なしを分離し、両者を同一画像で代用しない。`false` だけは上記の検証済みコピーを正規契約とする。symlink や拡張子偽装では代用しない。 決定的合成経路は `text_render.mode: deterministic` の場合だけ使う。未設定 / `ai_burn_in` では上記の textless 先行手順へ入らず、AI 焼き込み経路を実行する。
 #### 手動候補の比較選択 Hard Gate
 この契約は `thumbnail-v*.jpg/png` と `main-v*.png/jpg` のどちらにも適用する。`auto_selection.enabled: false` / 未設定で、生成に成功した候補が 2 枚以上ある場合は、次の比較選択が完了するまで `thumbnail.jpg` または `main.png/jpg` を確定してはならない。
-1. 成功した全候補を `open` で同時に開く。3 枚の JPEG サムネ候補なら `open <collection-path>/10-assets/thumbnail-v{1,2,3}.jpg` とし、候補数・拡張子・`main-v*` に応じてブレース展開を調整する。
-2. Read（Codex では同等の画像閲覧機能）でも成功した候補を 1 枚ずつ表示する。期待した attempt のファイルがない場合は候補から黙って除外せず、該当番号を「生成失敗」と明記する。
-3. テキスト付き候補では、ユーザー選択より前に全候補を `/thumbnail --compare` へ渡し、320px 視認性を比較検証する。textless 背景候補では、各候補を thumbnail check CLI で検証する。
-4. 構図・可読性・検証結果を並べて示し、採用する候補番号（`v1` / `v2` / `v3`）をユーザーから受け取る。番号を受け取る前に先頭候補を暗黙採用しない。
-5. 選択後だけ、成果物の種類と実拡張子に合わせて `cp thumbnail-v<選択番号>.jpg thumbnail.jpg` または `cp main-v<選択番号>.png main.png` を実行する。JPEG の textless 背景なら `.jpg` 同士で確定し、拡張子を偽装しない。
-6. 全案 NG の場合は確定せず、別の `--reference-index` で再生成するか、`diff_prompt_template` の差分指示を見直して再生成する経路を示す。
-成功候補が 1 枚だけなら、従来どおりその 1 枚をプレビュー・検証して Yes/No 承認を受け、承認後だけ確定する。`auto_selection.enabled: true` の `selection_only` / `full` ではテキスト付き候補の比較提示・番号選択を行わず、既存の `yt-thumbnail-auto-select` 経路を使う。`full` は既存どおり textless 背景承認も省略し、`selection_only` の textless 背景承認は維持する。
+1. 期待した attempt の欠落を「生成失敗」と報告し、成功候補ごとに既存 `yt-thumbnail-check` と比較 QA を完了する。候補画像の SHA-256、artifact、AB pattern、両 QA を固定 sidecarへ記録する。書式とコマンドは [Web review](references/web-review.md) を正とする。候補または sidecar が欠ける場合は確定せず停止する。
+2. 通常thumbnailは `uv run yt-thumbnail-review --collection <collection-path> --artifact thumbnail`、textless背景は `--artifact main`、ABは `--artifact thumbnail --pattern <name>` を実行する。CLIは全候補を1ページにまとめ、各cardに原寸画像、実幅320px表示、候補ID、filename、dimensions、`yt-thumbnail-check`、比較QAを表示する。thumbnailとmainを同じreviewへ混在させない。
+3. Webでは各cardのbuttonから共通selection brokerへmanifest内のcandidate IDだけを送る。CLIはbroker結果、artifact、pattern、画像/QA digestを再検証してからだけ既存のatomic copy、archive、workflow-state ownerを実行する。HTMLからpath、command、採点値、state patchを受け取らない。
+4. browserを利用できない場合だけ `--transport terminal` を使う。初回に表示されたallowlist IDを会話で選び、同じcommandへ `--candidate-id <ID>` を追加する。terminalも同じdigest検証/finalizerを通り、黙ってfallbackしない。
+5. 全案NGなら選択buttonを押さず、別の `--reference-index` または `diff_prompt_template` で再生成する。表示後の画像/QA変更、token replay、symlink、scope外候補は正規成果物とstateを変更せず停止する。
+
+成功候補が1枚だけでも同じHTML cardでYes/No判断し、直接 `cp` しない。`auto_selection.enabled: true` の `selection_only` / `full` ではテキスト付き候補のWeb reviewを生成せず、既存 `yt-thumbnail-auto-select --apply` ownerを使う。`full` は既存どおりtextless背景承認も省略し、`selection_only` のtextless背景だけは上記Web reviewを維持する。
 ### Test & compare 用 A/B pattern（opt-in）
 `ab_test` 未設定または `enabled: false` では、この節を実行せず標準の `thumbnail.jpg` 1 枚だけを確定する。既存コマンド・ファイル・承認・state 契約は変えない。 有効化はチャンネル側 `config/skills/thumbnail.yaml` で行う。`patterns` は YouTube Studio の上限に合わせて 1〜3 件、`name` は英小文字・数字・ハイフン・アンダースコアの一意な名前、`variation` は空でない pattern 固有 clause とする。0 件・4 件以上・不正 name・重複 name・空 variation は、画像生成 API を呼ぶ前に `ConfigError` で理由付き停止する。
 ```yaml
@@ -182,7 +182,7 @@ uv run yt-generate-image \
 `/channel-research --market` が生成する `docs/channel-research.json` + `.html` pair を `read_published_json_document(..., RepositorySchema.CHANNEL_RESEARCH_REPORT)` で検証し、JSON の `thumbnail_text_profile`（`schema_version: 1`。キーの単一ソースは `.claude/skills/channel-research/references/market.md` の Step 4）を決定的合成の入力へ変換する。これは前提ガードではない。pair が存在しない、検証できない、または必須キーを満たさない場合は「thumbnail-text-profile なし」と表示し、エラーで停止しない。`config.default.yaml` の現行デフォルト値（チャンネル上書きがあれば deep-merge 後の実効値)のまま標準フローを続行する。変換表、ローカルフォント選定、`unknown` の扱いは [quality / operations 詳細](references/quality-and-operations.md) を読む。変換値は設定内容と根拠をユーザーに提示し、**承認を得てから** `config/skills/thumbnail.yaml` へ書き込む。書き込み後は deep-merge 後の実効値を再確認する。
 ### 承認済みサムネイルのアーカイブ
 `archive.enabled: false` が既定で、従来どおりギャラリーを作成しない。過去作サムネを TTP テンプレートとして蓄積するチャンネルだけ、`config/skills/thumbnail.yaml` で opt-in する:
-決定的合成（フォント固定・標準）、AI 焼き込みの手動承認、codex、Two-Phase の各経路では、それぞれの既存の検証・承認順序を変えず、最終 `10-assets/thumbnail.jpg` または `thumbnail.png` の確定直後に次の共通コマンドを 1 回実行する:
+旧互換の手動確定経路では、それぞれの既存の検証・承認順序を変えず、最終 `10-assets/thumbnail.jpg` または `thumbnail.png` の確定直後に次の共通コマンドを1回実行する。新しい `yt-thumbnail-review` 手動経路は同じarchive ownerをtransaction内で呼ぶため重ねて実行しない:
 ```bash
 uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>
 ```
@@ -224,7 +224,7 @@ uv run yt-generate-image \
   --output <collection-path>/10-assets/thumbnail-v1.jpg -y
 ```
 stock 画像を別スコープとして混ぜたい場合だけ、`config/skills/thumbnail.yaml` の `image_generation.gemini.reference_images.stock.enabled: true` を明示し、採用ログ stderr の `[INFO] stock 採用: ...` を保存する。stock を混ぜると「同じベンチマークチャンネルの別サムネ」ではなくなるため、生成後の `thumbnail-prompts.md` に attempt ごとの参照元を必ず記録する。
-4. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、`/thumbnail --compare` 後にユーザーが指定した候補だけを `thumbnail.jpg` として確定する。成功候補が `thumbnail-v1.jpg` の 1 枚だけなら、単一候補の承認後に `cp thumbnail-v1.jpg thumbnail.jpg` で確定する。確定後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。
+4. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、QA sidecar作成後に `yt-thumbnail-review --artifact thumbnail` でユーザーが指定した候補だけを `thumbnail.jpg` として確定・archiveする。成功候補が1枚でも同じWeb reviewを使う。
 5. 承認済み `thumbnail.jpg` を参照画像にして、textless 動画背景を AI 再生成:
 ```bash
 COLLECTION_PATH="<collection-path>"
@@ -238,7 +238,7 @@ uv run yt-generate-image \
   --output "${COLLECTION_PATH}/10-assets/main-v1.png" -y
 ```
 textless 再生成プロンプトでは、承認済みサムネの構図・主役スケール・光・色温度・背景テクスチャを維持し、タイトル文字・字幕・ロゴ・透かし・タイポグラフィだけを除去する。新しい文字や主役を追加しないことを明示する。
-6. `open` でプレビュー → `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json` → ユーザー承認 → `cp main-v1.png main.png`（JPEG で確定する運用では `main-v1.jpg` → `main.jpg` に揃える。拡張子を偽装しない）
+6. `uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json` と比較QAをsidecarへ固定し、`yt-thumbnail-review --artifact main` のWeb reviewで承認・確定する（JPEG候補は`main.jpg`へ揃え、拡張子を偽装しない）
 7. `20-documentation/thumbnail-prompts.md` に、テキストなし背景生成プロンプトとテキスト付き生成プロンプトの両方を保存する
 #### 運用上の注意
 - **リトライ前提**: 画像生成プロバイダーは同一プロンプトでも瞬発的にエラーを返す。各 attempt 内で内蔵リトライ最大 2 回が走る
@@ -279,10 +279,10 @@ Two-Phase は旧チャンネル向けのフォールバック。使う場合も�
 2. テキストオーバーレイプロンプトを構築:
 **`thumbnail_text.text_overlay_prompt` が定義されている場合（推奨）:** テンプレート内の `{title_line1}`, `{title_line2}`, `{channel_name}` をコレクションのタイトルとチャンネル名で置換して使用。 **未定義の場合（フォールバック）:** [generation workflow 詳細](references/generation-workflows.md) から正規の sample prompt へルーティングする。 `text_overlay_prompt` が実質単一の入口。旧個別フィールド（`channel_name_style` / `title_format` / `title_prefix` / `copy_position` / `color` / `decoration`）は deprecated で、位置・色・装飾の意図は `text_overlay_prompt` の本文に直接書く（段階的廃止 #1702）。
 3. 生成: `uv run yt-generate-image --reference <既存参照画像> --prompt <テキスト指示> --output 10-assets/thumbnail-v1.jpg -y`
-4. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、`/thumbnail --compare` 後にユーザーが指定した候補だけを `thumbnail.jpg` として確定する。確定後に `uv run python .claude/skills/thumbnail/references/archive-approved-thumbnail.py <collection-path>` を実行する。
+4. テキスト付き候補は「手動候補の比較選択 Hard Gate」に従い、QA sidecar作成後に `yt-thumbnail-review --artifact thumbnail` でユーザーが指定した候補だけを `thumbnail.jpg` として確定・archiveする。
 #### Phase 3: 承認済み thumbnail から textless main を再生成
 1. 承認済み `thumbnail.jpg` を参照して textless `main-v1.png` を AI 再生成する。
-2. `open` でプレビュー → ユーザー承認 → `cp main-v1.png main.png` で動画背景を確定する（JPEG で確定する運用では `main-v1.jpg` → `main.jpg` に揃える）。
+2. QA結果をsidecarへ固定し、`yt-thumbnail-review --artifact main` のWeb reviewで承認して動画背景を確定する（JPEG候補は`main.jpg`へ揃え、拡張子を偽装しない）。
 ## フォント安定化（#1332 / #1907）
 「サムネの文字フォントが毎回バラバラになる」問題への対処。フォントの扱いは 2 経路あり、`text_render.mode` で選択する。
 | 経路 | 仕組み | フォント再現性 |

--- a/.claude/skills/thumbnail/references/operator-guide.md
+++ b/.claude/skills/thumbnail/references/operator-guide.md
@@ -2,10 +2,10 @@
 
 ## 共通Web review lifecycle
 
-手動候補選択は生成・機械検証後、確定copyやstate更新前に `uv run yt-document-review --collection <collection-path> --artifact thumbnail --select` を実行する。
-受け取るのはallowlist済みのopaqueな `candidate_id` とartifact digestだけで、対応する現在の候補fileを再hashしてから既存確定処理を呼ぶ。
+手動候補選択は生成・機械検証後、確定copyやstate更新前に `uv run yt-thumbnail-review --collection <collection-path> --artifact thumbnail` を実行する。AB patternは `--pattern <name>`、textless背景は `--artifact main` でscopeを固定する。
+受け取るのはallowlist済みのopaqueな `candidate_id` とartifact digestだけで、対応する現在の候補画像と固定QA sidecarを再hashしてから既存確定処理を呼ぶ。
 HTML・brokerから任意path、command、state patchは受理しない。失敗は未選択のまま停止し、terminal会話へ黙ってfallbackしない。
-browserなしは `--transport terminal` を明示する。auto-selectionの `selection_only` / `full` ではCLIを呼ばずreview HTMLを生成しない。
+browserなしは `--transport terminal` を明示し、同じcommandへ会話確認済み `--candidate-id` を渡す。auto-selectionの `selection_only` / `full` ではCLIを呼ばずreview HTMLを生成しない。
 Codex / Claudeとも同じproduct-neutral CLIを使い、製品固有session APIへmessageを注入しない。
 
 ## Eligibility

--- a/.claude/skills/thumbnail/references/web-review.md
+++ b/.claude/skills/thumbnail/references/web-review.md
@@ -1,0 +1,43 @@
+# Thumbnail Web review
+
+手動承認は、成功候補と既存QAを固定してから `yt-thumbnail-review` へ渡す。HTMLは表示とmanifest内IDの選択だけを担い、正本・採点入力・path入力にはしない。
+
+## 候補QA sidecar
+
+各候補と同じdirectoryに `<画像filename>.review.json` を置く。たとえば `thumbnail-v1.jpg.review.json`。UTF-8 JSONの必須形は次のとおり。
+
+```json
+{
+  "schema_version": 1,
+  "candidate_id": "thumbnail-v1",
+  "artifact": "thumbnail",
+  "pattern": null,
+  "image_sha256": "<64 lowercase hex>",
+  "thumbnail_check": {"status": "not_applicable", "summary": "text付き候補は比較QAで確認"},
+  "comparison_qa": {"status": "passed", "summary": "320px可読性、コントラスト、主役認識を確認"},
+  "metadata": {"attempt": 1, "provider": "gemini"},
+  "evidence": ["採用TTPの構図を維持"],
+  "constraints": ["16:9", "logoなし", "署名なし"]
+}
+```
+
+- `candidate_id`: run内で一意なopaque ID。filenameやpathとして解釈しない。
+- `artifact`: `thumbnail` または `main`。候補名から判定した種別と一致させる。
+- `pattern`: 通常thumbnail/mainは `null`、`thumbnail-<pattern>-vN.*` は `<pattern>`。
+- `image_sha256`: QAを実行した画像そのもののSHA-256。
+- `thumbnail_check` / `comparison_qa`: 両方必須。`status` は `passed` / `failed` / `not_applicable`、`summary` は非空文字列。CLIのJSON出力と目視比較結果を要約し、自由編集可能なHTMLへは保存しない。
+- `metadata` / `evidence` / `constraints`: 候補の生成attempt/provider、採用根拠、制約確認を空でない値として固定する。同じcardへescapeして表示する。
+
+候補画像・sidecar・`10-assets`・正規出力のsymlinkは禁止する。候補名は `thumbnail-vN.*` / `thumbnail-codex-vN.png` / `thumbnail-<pattern>-vN.*` / `main-vN.*` の固定形だけを列挙する。外部URL、absolute path、`..`、sidecar内の任意pathは入力契約に存在しない。
+
+## 実行
+
+```bash
+uv run yt-thumbnail-review --collection <collection-path> --artifact thumbnail
+uv run yt-thumbnail-review --collection <collection-path> --artifact thumbnail --pattern a
+uv run yt-thumbnail-review --collection <collection-path> --artifact main
+```
+
+出力は固定名 `tmp/reviews/thumbnail-selection.html` へatomic overwriteする。各候補を原寸と実幅320pxで並べ、filename、dimensions、QA summaryを同じcardに表示する。CSPはscript/外部resourceを拒否し、文字列はescapeする。
+
+browserが使えない場合は `--transport terminal` でID一覧を出し、会話確認後に `--candidate-id <ID>` を追加する。Web/terminalとも選択直前に画像とsidecarを再hashし、scopeとdigestが一致した場合だけ確定する。automatic modeはこのHTML/brokerを通さず、既存 `yt-thumbnail-auto-select --apply` を使う。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
 - `refactor(workflow-state)`: 旧 top-level `video_id` fallback と typed accessor を削除し、公開済み動画の正準 read を `upload.video_id` に限定する（#3893）。
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(documents)`: 生成運用成果物の owner・schema・consumer inventory を正本化し、`yt-skills lint` で Markdown writer、JSON/HTML pair 欠落、orphan、未検証 consumer、stale allowlist を具体 path 付きで拒否する（#4031）。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ yt-thumbnail-auto-select = "youtube_automation.entrypoints:yt_thumbnail_auto_sel
 yt-thumbnail-check = "youtube_automation.entrypoints:yt_thumbnail_check"
 yt-thumbnail-compare = "youtube_automation.entrypoints:yt_thumbnail_compare"
 yt-thumbnail-correlate = "youtube_automation.entrypoints:yt_thumbnail_correlate"
+yt-thumbnail-review = "youtube_automation.entrypoints:yt_thumbnail_review"
 yt-thumbnail-text = "youtube_automation.entrypoints:yt_thumbnail_text"
 yt-title-duplicate-check = "youtube_automation.entrypoints:yt_title_duplicate_check"
 yt-traffic-trend = "youtube_automation.entrypoints:yt_traffic_trend"

--- a/src/youtube_automation/application/thumbnail_review.py
+++ b/src/youtube_automation/application/thumbnail_review.py
@@ -1,0 +1,434 @@
+"""Safe thumbnail candidate review and approval finalization."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import tempfile
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Literal
+
+from PIL import Image, UnidentifiedImageError
+
+from youtube_automation.core.errors import ConfigError, ReviewError, ValidationError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
+from youtube_automation.domains.documents.review import ReviewCandidate, SelectionManifest
+from youtube_automation.domains.documents.review_rendering import render_review_html, validate_review_html
+from youtube_automation.domains.thumbnail.archive import (
+    ThumbnailArchiveUpdate,
+    archive_approved_thumbnail_transaction,
+)
+from youtube_automation.infrastructure.browser import open_local_file
+from youtube_automation.infrastructure.browser.selection_broker import SelectionBroker
+from youtube_automation.infrastructure.documents.publishing import publish_html_snapshot
+
+ThumbnailArtifact = Literal["thumbnail", "main"]
+ThumbnailReviewSource = Literal["web", "terminal", "automatic"]
+ThumbnailReviewTransport = Literal["web", "terminal"]
+
+_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_THUMBNAIL = re.compile(r"^thumbnail-(?:codex-)?v[1-9][0-9]*\.(?:jpg|jpeg|png|webp)$", re.IGNORECASE)
+_AB_THUMBNAIL = re.compile(
+    r"^thumbnail-(?P<pattern>[A-Za-z0-9][A-Za-z0-9_-]{0,63})-v[1-9][0-9]*\.(?:jpg|jpeg|png|webp)$",
+    re.IGNORECASE,
+)
+_MAIN = re.compile(r"^main-v[1-9][0-9]*\.(?:jpg|jpeg|png|webp)$", re.IGNORECASE)
+_DIGEST = re.compile(r"^[a-f0-9]{64}$")
+
+
+@dataclass(frozen=True)
+class ThumbnailReviewCandidate:
+    candidate_id: str
+    artifact: ThumbnailArtifact
+    pattern: str | None
+    image: Path
+    qa_path: Path
+    image_digest: str
+    qa_digest: str
+    width: int
+    height: int
+    thumbnail_check: str
+    comparison_qa: str
+    metadata: str
+    evidence: str
+    constraints: str
+
+    @property
+    def digest(self) -> str:
+        value = ":".join((self.candidate_id, self.artifact, self.pattern or "-", self.image_digest, self.qa_digest))
+        return hashlib.sha256(value.encode()).hexdigest()
+
+
+@dataclass(frozen=True)
+class ThumbnailReviewResult:
+    status: Literal["skipped", "terminal_required", "selected"]
+    artifact_digest: str | None = None
+    candidate_id: str | None = None
+    candidates: tuple[str, ...] = ()
+    html_path: Path | None = None
+
+
+@dataclass(frozen=True)
+class _Snapshot:
+    manifest: SelectionManifest
+    candidates: tuple[ThumbnailReviewCandidate, ...]
+
+    def media(self) -> dict[str, Path]:
+        return {candidate.candidate_id: candidate.image for candidate in self.candidates}
+
+
+def run_thumbnail_review(
+    collection: Path,
+    artifact: ThumbnailArtifact,
+    *,
+    pattern: str | None = None,
+    automatic: bool = False,
+    transport: ThumbnailReviewTransport = "web",
+    timeout: float = 300,
+    now: datetime | None = None,
+) -> ThumbnailReviewResult:
+    """Review fixed local candidates and return only a broker-validated ID."""
+    if automatic:
+        return ThumbnailReviewResult(status="skipped")
+    instant = now or datetime.now(UTC)
+    snapshot = build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=instant)
+    candidate_ids = tuple(candidate.candidate_id for candidate in snapshot.candidates)
+    if transport == "terminal":
+        return ThumbnailReviewResult(
+            status="terminal_required",
+            artifact_digest=snapshot.manifest.artifact_digest,
+            candidates=candidate_ids,
+        )
+
+    with SelectionBroker(snapshot.manifest) as broker:
+        destination = _display(collection, snapshot, broker.endpoint)
+        selection = broker.wait(timeout=timeout)
+    current = build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=instant)
+    if current.manifest.artifact_digest != selection.artifact_digest:
+        raise ReviewError("review表示後に画像またはQA結果が変わりました。正規成果物は更新していません")
+    selected = next((item for item in current.candidates if item.candidate_id == selection.candidate_id), None)
+    original = next((item for item in snapshot.candidates if item.candidate_id == selection.candidate_id), None)
+    if selected is None or original is None or selected.digest != original.digest:
+        raise ReviewError("review表示後に候補digestが変わりました。正規成果物は更新していません")
+    return ThumbnailReviewResult(
+        status="selected",
+        artifact_digest=current.manifest.artifact_digest,
+        candidate_id=selected.candidate_id,
+        candidates=candidate_ids,
+        html_path=destination,
+    )
+
+
+def build_thumbnail_review_snapshot(
+    collection: Path,
+    artifact: ThumbnailArtifact,
+    *,
+    pattern: str | None,
+    now: datetime,
+) -> _Snapshot:
+    root = _collection_root(collection)
+    if artifact == "main" and pattern is not None:
+        raise ReviewError("textless mainにAB patternは指定できません")
+    if pattern is not None and not _PATTERN.fullmatch(pattern):
+        raise ReviewError(f"AB patternが不正です: {pattern}")
+    candidates = _load_candidates(root, artifact, pattern)
+    review_candidates = tuple(
+        ReviewCandidate(
+            item.candidate_id,
+            item.image.name,
+            item.digest,
+            details=(
+                ("確認目的", "文字付きthumbnail" if artifact == "thumbnail" else "textless main"),
+                ("AB pattern", item.pattern or "なし"),
+                ("画像寸法", f"{item.width} × {item.height}px"),
+                ("yt-thumbnail-check", item.thumbnail_check),
+                ("比較QA", item.comparison_qa),
+                ("候補metadata", item.metadata),
+                ("根拠", item.evidence),
+                ("制約", item.constraints),
+                ("画像SHA-256", item.image_digest),
+            ),
+        )
+        for item in candidates
+    )
+    manifest = SelectionManifest.create(
+        artifact="thumbnail",
+        artifact_digest=_artifact_digest(candidates),
+        candidates=review_candidates,
+        now=now,
+        lifetime=timedelta(minutes=5),
+    )
+    return _Snapshot(manifest, candidates)
+
+
+def finalize_thumbnail_review_selection(
+    collection: Path,
+    *,
+    artifact: ThumbnailArtifact,
+    pattern: str | None,
+    candidate_id: str,
+    source: ThumbnailReviewSource,
+    expected_artifact_digest: str,
+    archive_config: Mapping[str, object] | None = None,
+    channel_root: Path | None = None,
+) -> Path:
+    """Revalidate all evidence, then atomically copy and update the existing state owner."""
+    if source not in {"web", "terminal", "automatic"}:
+        raise ValidationError(f"thumbnail review sourceが不正です: {source}")
+    if (archive_config is None) != (channel_root is None):
+        raise ValidationError("archive_configとchannel_rootは両方指定するか両方省略してください")
+    snapshot = build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=datetime.now(UTC))
+    if not _DIGEST.fullmatch(expected_artifact_digest) or snapshot.manifest.artifact_digest != expected_artifact_digest:
+        raise ValidationError("画像またはQA結果のdigestがreview時点と一致しません")
+    selected = next((item for item in snapshot.candidates if item.candidate_id == candidate_id), None)
+    if selected is None or selected.artifact != artifact or selected.pattern != pattern:
+        raise ValidationError("候補ID / artifact / patternの組がreview manifest allowlistと一致しません")
+
+    target = _target_path(_collection_root(collection), selected)
+    if target.is_symlink() or (target.exists() and not target.is_file()):
+        raise ValidationError(f"正規成果物は通常fileまたは未作成pathである必要があります: {target}")
+    original = target.read_bytes() if target.is_file() else None
+    archive_update: ThumbnailArchiveUpdate | None = None
+    try:
+        _copy_candidate(selected, target)
+        if artifact == "thumbnail" and pattern is None and archive_config is not None and channel_root is not None:
+            archive_update = archive_approved_thumbnail_transaction(
+                collection, archive_config=archive_config, channel_root=channel_root
+            )
+
+        def record(state: WorkflowState) -> None:
+            state["thumbnail_review_selection"] = {
+                "schema_version": 1,
+                "source": source,
+                "candidate_id": candidate_id,
+                "artifact": artifact,
+                "pattern": pattern,
+                "image_sha256": selected.image_digest,
+                "qa_sha256": selected.qa_digest,
+                "artifact_digest": expected_artifact_digest,
+                "selected_at": datetime.now(UTC).isoformat(),
+            }
+
+        update_workflow_state(_collection_root(collection) / "workflow-state.json", record)
+    except (OSError, ConfigError, ValidationError, WorkflowStateError) as exc:
+        if archive_update is not None:
+            archive_update.rollback()
+        _restore_target(target, original)
+        if isinstance(exc, ValidationError):
+            raise
+        raise ValidationError(f"thumbnail承認の確定に失敗しました: {exc}") from exc
+    return target
+
+
+def _load_candidates(
+    collection: Path, artifact: ThumbnailArtifact, pattern: str | None
+) -> tuple[ThumbnailReviewCandidate, ...]:
+    assets = collection / "10-assets"
+    if assets.is_symlink() or not assets.is_dir():
+        raise ReviewError(f"10-assets directoryが不正です: {assets}")
+    result: list[ThumbnailReviewCandidate] = []
+    for image in sorted(assets.iterdir()):
+        if image.is_symlink() or not image.is_file():
+            continue
+        parsed = _candidate_kind(image.name)
+        if parsed != (artifact, pattern):
+            continue
+        result.append(_load_candidate(image, artifact, pattern))
+    if not result:
+        raise ReviewError(f"review候補がありません: artifact={artifact}, pattern={pattern or '-'}")
+    if len({item.candidate_id for item in result}) != len(result):
+        raise ReviewError("thumbnail review candidate IDが重複しています")
+    return tuple(result)
+
+
+def _candidate_kind(name: str) -> tuple[ThumbnailArtifact, str | None] | None:
+    if _THUMBNAIL.fullmatch(name):
+        return "thumbnail", None
+    if match := _AB_THUMBNAIL.fullmatch(name):
+        pattern = match.group("pattern")
+        if pattern.lower() != "codex":
+            return "thumbnail", pattern
+    if _MAIN.fullmatch(name):
+        return "main", None
+    return None
+
+
+def _load_candidate(image: Path, artifact: ThumbnailArtifact, pattern: str | None) -> ThumbnailReviewCandidate:
+    qa_path = image.with_suffix(f"{image.suffix}.review.json")
+    if qa_path.is_symlink() or not qa_path.is_file():
+        raise ReviewError(f"候補QA結果がありません: {qa_path}")
+    try:
+        document: object = json.loads(qa_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise ReviewError(f"候補QA結果を読み込めません: {qa_path}: {exc}") from exc
+    if not isinstance(document, dict):
+        raise ReviewError(f"候補QA結果のrootはobjectである必要があります: {qa_path}")
+    candidate_id = document.get("candidate_id")
+    recorded_artifact = document.get("artifact")
+    recorded_pattern = document.get("pattern")
+    recorded_digest = document.get("image_sha256")
+    thumbnail_check = document.get("thumbnail_check")
+    comparison_qa = document.get("comparison_qa")
+    metadata = document.get("metadata")
+    evidence = document.get("evidence")
+    constraints = document.get("constraints")
+    image_digest = _sha256(image)
+    if not isinstance(candidate_id, str) or not _ID.fullmatch(candidate_id):
+        raise ReviewError(f"候補QAのcandidate_idが不正です: {qa_path}")
+    if recorded_artifact != artifact or recorded_pattern != pattern:
+        raise ReviewError(f"候補QAのartifact / patternが画像名と一致しません: {qa_path}")
+    if recorded_digest != image_digest:
+        raise ReviewError(f"候補QAの画像digestが実画像と一致しません: {image.name}")
+    thumbnail_summary = _qa_summary(thumbnail_check, "thumbnail_check", qa_path)
+    comparison_summary = _qa_summary(comparison_qa, "comparison_qa", qa_path)
+    metadata_summary = _mapping_summary(metadata, "metadata", qa_path)
+    evidence_summary = _string_list_summary(evidence, "evidence", qa_path)
+    constraints_summary = _string_list_summary(constraints, "constraints", qa_path)
+    try:
+        with Image.open(image) as opened:
+            width, height = opened.size
+            opened.verify()
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ReviewError(f"候補画像を検証できません: {image}: {exc}") from exc
+    return ThumbnailReviewCandidate(
+        candidate_id=candidate_id,
+        artifact=artifact,
+        pattern=pattern,
+        image=image.resolve(),
+        qa_path=qa_path.resolve(),
+        image_digest=image_digest,
+        qa_digest=_sha256(qa_path),
+        width=width,
+        height=height,
+        thumbnail_check=thumbnail_summary,
+        comparison_qa=comparison_summary,
+        metadata=metadata_summary,
+        evidence=evidence_summary,
+        constraints=constraints_summary,
+    )
+
+
+def _qa_summary(value: object, name: str, path: Path) -> str:
+    if not isinstance(value, dict) or not value:
+        raise ReviewError(f"候補QAの{name}が欠落しています: {path}")
+    status = value.get("status")
+    summary = value.get("summary")
+    if status not in {"passed", "failed", "not_applicable"} or not isinstance(summary, str) or not summary.strip():
+        raise ReviewError(f"候補QAの{name}はstatusと非空summaryが必要です: {path}")
+    return f"{status}: {summary.strip()}"
+
+
+def _mapping_summary(value: object, name: str, path: Path) -> str:
+    if not isinstance(value, dict) or not value or any(not isinstance(key, str) or not key for key in value):
+        raise ReviewError(f"候補QAの{name}は非空objectである必要があります: {path}")
+    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+
+
+def _string_list_summary(value: object, name: str, path: Path) -> str:
+    if not isinstance(value, list) or not value or any(not isinstance(item, str) or not item.strip() for item in value):
+        raise ReviewError(f"候補QAの{name}は非空文字列listである必要があります: {path}")
+    return " / ".join(item.strip() for item in value)
+
+
+def _display(collection: Path, snapshot: _Snapshot, endpoint: str) -> Path:
+    destination = _collection_root(collection) / "tmp" / "reviews" / "thumbnail-selection.html"
+    media = snapshot.media()
+    compact = frozenset(media)
+    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media, compact_image_ids=compact)
+    publish_html_snapshot(
+        destination,
+        html,
+        lambda persisted: validate_review_html(
+            persisted,
+            manifest=snapshot.manifest,
+            endpoint=endpoint,
+            media=media,
+            compact_image_ids=compact,
+        ),
+    )
+    if not open_local_file(destination.resolve()):
+        raise ReviewError(f"browserでthumbnail review HTMLを開けません: {destination.resolve()}")
+    return destination.resolve()
+
+
+def _target_path(collection: Path, candidate: ThumbnailReviewCandidate) -> Path:
+    assets = collection / "10-assets"
+    if candidate.artifact == "thumbnail":
+        return assets / (f"thumbnail-{candidate.pattern}.jpg" if candidate.pattern else "thumbnail.jpg")
+    return assets / f"main{candidate.image.suffix.lower()}"
+
+
+def _copy_candidate(candidate: ThumbnailReviewCandidate, target: Path) -> None:
+    if target.is_symlink():
+        raise ValidationError(f"正規成果物にsymlinkは指定できません: {target}")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.stem}-review-", suffix=target.suffix, dir=target.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        if candidate.artifact == "thumbnail" and candidate.image.suffix.lower() not in {".jpg", ".jpeg"}:
+            with Image.open(candidate.image) as opened:
+                opened.convert("RGB").save(temporary, "JPEG", quality=95)
+        else:
+            shutil.copyfile(candidate.image, temporary)
+        os.replace(temporary, target)
+    except (OSError, UnidentifiedImageError) as exc:
+        raise ValidationError(f"候補画像を正規成果物へ確定できません: {candidate.image} -> {target}: {exc}") from exc
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _restore_target(target: Path, original: bytes | None) -> None:
+    if original is None:
+        target.unlink(missing_ok=True)
+        return
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{target.stem}-rollback-", suffix=target.suffix, dir=target.parent
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        temporary.write_bytes(original)
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _collection_root(collection: Path) -> Path:
+    if collection.is_symlink() or not collection.is_dir():
+        raise ReviewError(f"collection directoryが不正です: {collection}")
+    return collection.resolve()
+
+
+def _artifact_digest(candidates: tuple[ThumbnailReviewCandidate, ...]) -> str:
+    value = "\n".join(f"{candidate.candidate_id}:{candidate.digest}" for candidate in candidates)
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise ReviewError(f"review fileを読み込めません: {path}: {exc}") from exc
+    return digest.hexdigest()
+
+
+__all__ = [
+    "ThumbnailReviewCandidate",
+    "ThumbnailReviewResult",
+    "build_thumbnail_review_snapshot",
+    "finalize_thumbnail_review_selection",
+    "run_thumbnail_review",
+]

--- a/src/youtube_automation/commands/thumbnail/thumbnail_review.py
+++ b/src/youtube_automation/commands/thumbnail/thumbnail_review.py
@@ -1,0 +1,126 @@
+"""Review thumbnail candidates in one safe HTML page and finalize one ID."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from youtube_automation.application.thumbnail_review import (
+    ThumbnailReviewResult,
+    finalize_thumbnail_review_selection,
+    run_thumbnail_review,
+)
+from youtube_automation.commands._shared.cli_harness import run_cli
+from youtube_automation.configuration import channel_dir
+from youtube_automation.configuration.skills import load_skill_config
+from youtube_automation.core.errors import ValidationError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="thumbnail/main候補と固定QAを安全な比較HTMLで確認し、候補IDだけを確定する"
+    )
+    parser.add_argument("--collection", type=Path, required=True, help="対象collection directory")
+    parser.add_argument("--artifact", choices=("thumbnail", "main"), required=True)
+    parser.add_argument("--pattern", help="AB thumbnailのpattern。mainには指定不可")
+    parser.add_argument("--transport", choices=("web", "terminal"), default="web")
+    parser.add_argument("--candidate-id", help="terminal fallbackで会話確認済みの候補ID")
+    parser.add_argument(
+        "--automatic",
+        action="store_true",
+        help="HTML/brokerを生成せず既存yt-thumbnail-auto-select ownerへ委譲する",
+    )
+    return parser
+
+
+def run(args: argparse.Namespace) -> int:
+    collection = args.collection.resolve()
+    if args.automatic:
+        if (
+            args.transport != "web"
+            or args.candidate_id is not None
+            or args.pattern is not None
+            or args.artifact != "thumbnail"
+        ):
+            raise ValidationError("--automaticは通常thumbnailのweb既定値とだけ併用できます")
+        run_thumbnail_review(collection, "thumbnail", automatic=True)
+        print(json.dumps({"status": "skipped", "owner": "yt-thumbnail-auto-select"}, sort_keys=True))
+        return 0
+    if args.transport == "web" and args.candidate_id is not None:
+        raise ValidationError("--candidate-idは--transport terminal専用です")
+
+    artifact = args.artifact
+    pattern = args.pattern
+    if args.transport == "web":
+        result = run_thumbnail_review(collection, artifact, pattern=pattern, transport="web")
+        candidate_id, digest = _selected_result(result)
+        source = "web"
+    else:
+        result = run_thumbnail_review(collection, artifact, pattern=pattern, transport="terminal")
+        digest = _required_digest(result)
+        if args.candidate_id is None:
+            print(
+                json.dumps(
+                    {
+                        "status": "terminal_required",
+                        "artifact": artifact,
+                        "pattern": pattern,
+                        "candidates": list(result.candidates),
+                        "artifact_digest": digest,
+                    },
+                    ensure_ascii=False,
+                    sort_keys=True,
+                )
+            )
+            print("候補を会話で確認後、--candidate-id <ID>を明示して再実行してください", file=sys.stderr)
+            return 2
+        candidate_id = args.candidate_id
+        if candidate_id not in result.candidates:
+            raise ValidationError(f"候補IDがreview manifest allowlistにありません: {candidate_id}")
+        source = "terminal"
+
+    root = channel_dir()
+    config = load_skill_config("thumbnail", channel_dir=root)
+    archive = config.get("archive", {})
+    if not isinstance(archive, dict):
+        raise ValidationError("thumbnail.archiveはmappingである必要があります")
+    target = finalize_thumbnail_review_selection(
+        collection,
+        artifact=artifact,
+        pattern=pattern,
+        candidate_id=candidate_id,
+        source=source,
+        expected_artifact_digest=digest,
+        archive_config=archive,
+        channel_root=root,
+    )
+    print(
+        json.dumps(
+            {"status": "selected", "candidate_id": candidate_id, "source": source, "target": str(target)},
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def _selected_result(result: ThumbnailReviewResult) -> tuple[str, str]:
+    if result.status != "selected" or result.candidate_id is None:
+        raise ValidationError("Web reviewからthumbnail候補IDを取得できません")
+    return result.candidate_id, _required_digest(result)
+
+
+def _required_digest(result: ThumbnailReviewResult) -> str:
+    if result.artifact_digest is None:
+        raise ValidationError("review manifestにartifact digestがありません")
+    return result.artifact_digest
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_cli(build_parser, run, argv, failure_message="thumbnail reviewに失敗しました")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/youtube_automation/domains/documents/resources/review.html
+++ b/src/youtube_automation/domains/documents/resources/review.html
@@ -9,6 +9,10 @@
   form { margin-top: 1rem; }
   button { background: #0066cc; border: 0; border-radius: .4rem; color: white; cursor: pointer; padding: .7rem 1rem; }
   img, audio, video { display: block; max-height: 70vh; max-width: 100%; }
+  .review-images { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); }
+  .review-images figure { margin: 0; }
+  .review-images figcaption { color: #52617a; font-weight: 650; margin-bottom: .5rem; }
+  .review-images .review-320 { height: auto; max-width: 100%; width: 320px; }
   </style>
 </head>
 <body><main><header class="document-header"><h1>$TITLE</h1><p>表示と候補選択だけを行います。成果物やworkflow stateは変更しません。</p></header>$CONTENT</main></body>

--- a/src/youtube_automation/domains/documents/review_rendering.py
+++ b/src/youtube_automation/domains/documents/review_rendering.py
@@ -19,13 +19,24 @@ def render_review_html(
     *,
     endpoint: str | None,
     media: Mapping[str, Path],
+    compact_image_ids: frozenset[str] = frozenset(),
 ) -> str:
     """Render only manifest candidates; no free-form input or executable script."""
     if set(media) - {candidate.id for candidate in manifest.candidates}:
         raise DocumentRenderError("review mediaは候補allowlistに含まれる必要があります")
+    if not compact_image_ids.issubset(media):
+        raise DocumentRenderError("320px表示は画像候補allowlistに含まれる必要があります")
     action = endpoint or ""
     cards = "".join(
-        _candidate_card(candidate.id, candidate.label, candidate.details, media.get(candidate.id), manifest, action)
+        _candidate_card(
+            candidate.id,
+            candidate.label,
+            candidate.details,
+            media.get(candidate.id),
+            manifest,
+            action,
+            compact_image=candidate.id in compact_image_ids,
+        )
         for candidate in manifest.candidates
     )
     package = "youtube_automation.domains.documents.resources"
@@ -38,7 +49,13 @@ def render_review_html(
         CSS=css,
         FORM_ACTION=escape(csp_action, quote=True),
     )
-    validate_review_html(html, manifest=manifest, endpoint=endpoint, media=media)
+    validate_review_html(
+        html,
+        manifest=manifest,
+        endpoint=endpoint,
+        media=media,
+        compact_image_ids=compact_image_ids,
+    )
     return html
 
 
@@ -49,8 +66,10 @@ def _candidate_card(
     media_path: Path | None,
     manifest: SelectionManifest,
     action: str,
+    *,
+    compact_image: bool,
 ) -> str:
-    preview = _preview(media_path, label) if media_path is not None else ""
+    preview = _preview(media_path, label, compact_image=compact_image) if media_path is not None else ""
     comparison = ""
     if details:
         rows = "".join(f"<dt>{escape(key)}</dt><dd>{escape(value)}</dd>" for key, value in details)
@@ -69,11 +88,21 @@ def _candidate_card(
     )
 
 
-def _preview(path: Path, label: str) -> str:
+def _preview(path: Path, label: str, *, compact_image: bool) -> str:
     uri = escape(path.resolve().as_uri(), quote=True)
     suffix = path.suffix.lower()
     if suffix in {".jpg", ".jpeg", ".png", ".webp"}:
-        return f'<img src="{uri}" alt="{escape(label, quote=True)}" loading="lazy">'
+        original = f'<img src="{uri}" alt="{escape(label, quote=True)} 原寸" loading="lazy">'
+        if not compact_image:
+            return original
+        compact = (
+            f'<img class="review-320" src="{uri}" alt="{escape(label, quote=True)} 320px表示" '
+            'width="320" loading="lazy">'
+        )
+        return (
+            f'<div class="review-images"><figure><figcaption>原寸</figcaption>{original}</figure>'
+            f"<figure><figcaption>320px表示</figcaption>{compact}</figure></div>"
+        )
     if suffix in {".mp3", ".wav", ".flac", ".m4a"}:
         return f'<audio src="{uri}" controls preload="metadata"></audio>'
     if suffix in {".mp4", ".mov", ".webm"}:
@@ -123,6 +152,7 @@ def validate_review_html(
     manifest: SelectionManifest,
     endpoint: str | None,
     media: Mapping[str, Path],
+    compact_image_ids: frozenset[str] = frozenset(),
 ) -> None:
     parser = _ReviewHTMLParser()
     parser.feed(html)
@@ -141,7 +171,12 @@ def validate_review_html(
         raise DocumentRenderError("review HTMLのloopback endpointが一致しません")
     if parser.digest_values != ([manifest.artifact_digest] * len(manifest.candidates) if endpoint is not None else []):
         raise DocumentRenderError("review HTMLのartifact digestが一致しません")
-    expected_media = [path.resolve().as_uri() for candidate in manifest.candidates if (path := media.get(candidate.id))]
+    expected_media = [
+        path.resolve().as_uri()
+        for candidate in manifest.candidates
+        if (path := media.get(candidate.id))
+        for _ in range(2 if candidate.id in compact_image_ids else 1)
+    ]
     if parser.media_uris != expected_media:
         raise DocumentRenderError("review HTMLのmedia allowlistが一致しません")
     if endpoint is not None:

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -152,6 +152,7 @@ yt_traffic_trend = _make_entrypoint("youtube_automation.commands.analytics.traff
 yt_thumbnail_check = _make_entrypoint("youtube_automation.commands.thumbnail.thumbnail_check")
 yt_thumbnail_compare = _make_entrypoint("youtube_automation.commands.thumbnail.compare_thumbnails")
 yt_thumbnail_correlate = _make_entrypoint("youtube_automation.commands.thumbnail.thumbnail_correlate")
+yt_thumbnail_review = _make_entrypoint("youtube_automation.commands.thumbnail.thumbnail_review")
 yt_thumbnail_text = _make_entrypoint("youtube_automation.commands.thumbnail.thumbnail_text")
 yt_title_duplicate_check = _make_entrypoint("youtube_automation.commands.metadata.title_duplicate_check")
 yt_video_analyze = _make_entrypoint("youtube_automation.commands.analytics.video_analyze")

--- a/tests/application/test_thumbnail_review.py
+++ b/tests/application/test_thumbnail_review.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from PIL import Image
+
+from youtube_automation.application import thumbnail_review
+from youtube_automation.core.errors import ReviewError, ValidationError
+
+NOW = datetime(2026, 8, 16, tzinfo=UTC)
+
+
+def _candidate(
+    collection: Path,
+    name: str,
+    *,
+    candidate_id: str,
+    artifact: str,
+    pattern: str | None = None,
+    summary: str = "all checks passed",
+) -> Path:
+    assets = collection / "10-assets"
+    assets.mkdir(parents=True, exist_ok=True)
+    image = assets / name
+    Image.new("RGB", (1280, 720), "#123456").save(image)
+    digest = hashlib.sha256(image.read_bytes()).hexdigest()
+    qa = {
+        "schema_version": 1,
+        "candidate_id": candidate_id,
+        "artifact": artifact,
+        "pattern": pattern,
+        "image_sha256": digest,
+        "thumbnail_check": {"status": "passed", "summary": summary},
+        "comparison_qa": {"status": "passed", "summary": "320px readable"},
+        "metadata": {"attempt": 1, "provider": "fixture"},
+        "evidence": ["benchmark layout retained"],
+        "constraints": ["no logo", "16:9"],
+    }
+    image.with_suffix(f"{image.suffix}.review.json").write_text(json.dumps(qa), encoding="utf-8")
+    return image
+
+
+def test_snapshot_lists_all_candidates_with_dimensions_qa_and_stable_scope(tmp_path: Path) -> None:
+    collection = tmp_path / "collection"
+    _candidate(collection, "thumbnail-v1.jpg", candidate_id="thumbnail-v1", artifact="thumbnail")
+    _candidate(collection, "thumbnail-v2.jpg", candidate_id="thumbnail-v2", artifact="thumbnail")
+    _candidate(collection, "main-v1.png", candidate_id="main-v1", artifact="main")
+
+    snapshot = thumbnail_review.build_thumbnail_review_snapshot(collection, "thumbnail", pattern=None, now=NOW)
+
+    assert [item.candidate_id for item in snapshot.candidates] == ["thumbnail-v1", "thumbnail-v2"]
+    details = dict(snapshot.manifest.candidates[0].details)
+    assert details["確認目的"] == "文字付きthumbnail"
+    assert details["画像寸法"] == "1280 × 720px"
+    assert details["yt-thumbnail-check"] == "passed: all checks passed"
+    assert details["比較QA"] == "passed: 320px readable"
+    assert details["候補metadata"] == '{"attempt":1,"provider":"fixture"}'
+    assert details["根拠"] == "benchmark layout retained"
+    assert details["制約"] == "no logo / 16:9"
+
+
+@pytest.mark.parametrize(
+    ("name", "artifact", "pattern", "target_name"),
+    [
+        ("thumbnail-v1.jpg", "thumbnail", None, "thumbnail.jpg"),
+        ("thumbnail-night-v1.jpg", "thumbnail", "night", "thumbnail-night.jpg"),
+        ("main-v1.png", "main", None, "main.png"),
+    ],
+)
+def test_finalizer_updates_only_artifact_pattern_target_after_digest_revalidation(
+    tmp_path: Path,
+    name: str,
+    artifact: str,
+    pattern: str | None,
+    target_name: str,
+) -> None:
+    collection = tmp_path / "collection"
+    image = _candidate(
+        collection,
+        name,
+        candidate_id="choice-1",
+        artifact=artifact,
+        pattern=pattern,
+    )
+    snapshot = thumbnail_review.build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=NOW)
+
+    target = thumbnail_review.finalize_thumbnail_review_selection(
+        collection,
+        artifact=artifact,
+        pattern=pattern,
+        candidate_id="choice-1",
+        source="terminal",
+        expected_artifact_digest=snapshot.manifest.artifact_digest,
+    )
+
+    assert target.name == target_name
+    assert target.read_bytes() == image.read_bytes()
+    state = json.loads((collection / "workflow-state.json").read_text())
+    assert state["thumbnail_review_selection"]["source"] == "terminal"
+    assert state["thumbnail_review_selection"]["pattern"] == pattern
+    assert "thumbnail" not in state.get("assets", {})
+
+
+def test_single_candidate_web_view_has_original_and_320px_preview_and_escaped_qa(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    collection = tmp_path / "collection"
+    _candidate(
+        collection,
+        "thumbnail-v1.jpg",
+        candidate_id="choice-1",
+        artifact="thumbnail",
+        summary="<script>alert(1)</script>",
+    )
+
+    class FakeBroker:
+        def __init__(self, manifest: object) -> None:
+            self.manifest = manifest
+            self.endpoint = f"http://127.0.0.1:32123/select/{manifest.token}"
+
+        def __enter__(self) -> "FakeBroker":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def wait(self, *, timeout: float) -> object:
+            del timeout
+            return SimpleNamespace(candidate_id="choice-1", artifact_digest=self.manifest.artifact_digest)
+
+    monkeypatch.setattr(thumbnail_review, "SelectionBroker", FakeBroker)
+    monkeypatch.setattr(thumbnail_review, "open_local_file", lambda _path: True)
+
+    result = thumbnail_review.run_thumbnail_review(collection, "thumbnail", now=NOW)
+    html = (collection / "tmp/reviews/thumbnail-selection.html").read_text()
+
+    assert result.status == "selected"
+    assert html.count("file://") == 2
+    assert 'class="review-320"' in html and 'width="320"' in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "<script>alert(1)</script>" not in html
+    assert "script-src 'none'" in html
+
+
+def test_changed_qa_after_display_rejects_selection_before_canonical_or_state_update(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    collection = tmp_path / "collection"
+    image = _candidate(collection, "thumbnail-v1.jpg", candidate_id="choice-1", artifact="thumbnail")
+    target = collection / "10-assets/thumbnail.jpg"
+    target.write_bytes(b"existing")
+
+    class MutatingBroker:
+        def __init__(self, manifest: object) -> None:
+            self.manifest = manifest
+            self.endpoint = f"http://127.0.0.1:32123/select/{manifest.token}"
+
+        def __enter__(self) -> "MutatingBroker":
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+        def wait(self, *, timeout: float) -> object:
+            del timeout
+            qa = image.with_suffix(f"{image.suffix}.review.json")
+            qa.write_text(qa.read_text() + "\n", encoding="utf-8")
+            return SimpleNamespace(candidate_id="choice-1", artifact_digest=self.manifest.artifact_digest)
+
+    monkeypatch.setattr(thumbnail_review, "SelectionBroker", MutatingBroker)
+    monkeypatch.setattr(thumbnail_review, "open_local_file", lambda _path: True)
+
+    with pytest.raises(ReviewError, match="画像またはQA結果が変わりました"):
+        thumbnail_review.run_thumbnail_review(collection, "thumbnail", now=NOW)
+    assert target.read_bytes() == b"existing"
+    assert not (collection / "workflow-state.json").exists()
+
+
+def test_missing_qa_symlink_and_artifact_pattern_mismatch_fail_closed(tmp_path: Path) -> None:
+    collection = tmp_path / "collection"
+    image = _candidate(
+        collection,
+        "thumbnail-night-v1.jpg",
+        candidate_id="choice-1",
+        artifact="thumbnail",
+        pattern="night",
+    )
+    qa = image.with_suffix(f"{image.suffix}.review.json")
+    qa.unlink()
+    qa.symlink_to(tmp_path / "outside.json")
+
+    with pytest.raises(ReviewError, match="QA結果がありません"):
+        thumbnail_review.build_thumbnail_review_snapshot(collection, "thumbnail", pattern="night", now=NOW)
+    with pytest.raises(ReviewError, match="AB pattern"):
+        thumbnail_review.build_thumbnail_review_snapshot(collection, "main", pattern="night", now=NOW)
+
+
+def test_finalizer_rejects_stale_digest_and_wrong_candidate_without_mutation(tmp_path: Path) -> None:
+    collection = tmp_path / "collection"
+    _candidate(collection, "thumbnail-v1.jpg", candidate_id="choice-1", artifact="thumbnail")
+    target = collection / "10-assets/thumbnail.jpg"
+    target.write_bytes(b"existing")
+
+    with pytest.raises(ValidationError, match="digest"):
+        thumbnail_review.finalize_thumbnail_review_selection(
+            collection,
+            artifact="thumbnail",
+            pattern=None,
+            candidate_id="choice-1",
+            source="web",
+            expected_artifact_digest="0" * 64,
+        )
+    assert target.read_bytes() == b"existing"
+    assert not (collection / "workflow-state.json").exists()
+
+
+def test_finalizer_rejects_canonical_symlink_without_reading_or_replacing_external_file(tmp_path: Path) -> None:
+    collection = tmp_path / "collection"
+    _candidate(collection, "thumbnail-v1.jpg", candidate_id="choice-1", artifact="thumbnail")
+    snapshot = thumbnail_review.build_thumbnail_review_snapshot(collection, "thumbnail", pattern=None, now=NOW)
+    external = tmp_path / "external.jpg"
+    external.write_bytes(b"secret-external-content")
+    (collection / "10-assets/thumbnail.jpg").symlink_to(external)
+
+    with pytest.raises(ValidationError, match="通常file"):
+        thumbnail_review.finalize_thumbnail_review_selection(
+            collection,
+            artifact="thumbnail",
+            pattern=None,
+            candidate_id="choice-1",
+            source="web",
+            expected_artifact_digest=snapshot.manifest.artifact_digest,
+        )
+    assert external.read_bytes() == b"secret-external-content"
+    assert not (collection / "workflow-state.json").exists()

--- a/tests/commands/thumbnail/test_thumbnail_review.py
+++ b/tests/commands/thumbnail/test_thumbnail_review.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.application.thumbnail_review import ThumbnailReviewResult
+from youtube_automation.commands.thumbnail import thumbnail_review
+
+
+def test_automatic_skips_html_broker_and_existing_auto_owner_remains_canonical(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    calls: list[bool] = []
+
+    def fake_review(*_args, automatic: bool = False, **_kwargs) -> ThumbnailReviewResult:
+        calls.append(automatic)
+        return ThumbnailReviewResult(status="skipped")
+
+    monkeypatch.setattr(thumbnail_review, "run_thumbnail_review", fake_review)
+    result = thumbnail_review.main(["--collection", str(tmp_path), "--artifact", "thumbnail", "--automatic"])
+
+    assert result == 0
+    assert calls == [True]
+    assert "yt-thumbnail-auto-select" in capsys.readouterr().out
+
+
+def test_terminal_fallback_lists_allowlisted_ids_without_finalizing(tmp_path: Path, monkeypatch, capsys) -> None:
+    monkeypatch.setattr(
+        thumbnail_review,
+        "run_thumbnail_review",
+        lambda *_args, **_kwargs: ThumbnailReviewResult(
+            status="terminal_required", artifact_digest="a" * 64, candidates=("choice-1",)
+        ),
+    )
+    monkeypatch.setattr(
+        thumbnail_review,
+        "finalize_thumbnail_review_selection",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not finalize")),
+    )
+
+    result = thumbnail_review.main(["--collection", str(tmp_path), "--artifact", "main", "--transport", "terminal"])
+
+    assert result == 2
+    assert '"candidate_id"' not in capsys.readouterr().out

--- a/tests/configuration/test_thumbnail_skill_assets.py
+++ b/tests/configuration/test_thumbnail_skill_assets.py
@@ -372,9 +372,8 @@ def test_thumbnail_skill_documents_ai_burn_in_default_and_deterministic_opt_in()
         "uv run yt-thumbnail-text",
         "--background <collection-path>/10-assets/main.png",
         "text_strip_clause",
-        "uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json",
-        "cp main-v1.png main.png",
-        "cp thumbnail-v1.jpg thumbnail.jpg",
+        "yt-thumbnail-review --artifact main",
+        "yt-thumbnail-review --artifact thumbnail",
         "/thumbnail --compare",
         "config/skills/loop-video.yaml::enabled: true",
         "/thumbnail --loop",
@@ -387,7 +386,7 @@ def test_thumbnail_skill_documents_ai_burn_in_default_and_deterministic_opt_in()
         assert required in standard_block
 
     # deterministic 経路では textless 背景の確定が実フォント合成より先
-    assert standard_block.find("cp main-v1.png main.png") < standard_block.find("uv run yt-thumbnail-text")
+    assert standard_block.find("yt-thumbnail-review --artifact main") < standard_block.find("uv run yt-thumbnail-text")
     # 既定は文字入り候補を先に生成し、決定的合成だけを明示 opt-in にする
     assert standard_block.find("AI 焼き込み経路（既定）") < standard_block.find(
         "決定的合成経路（`text_render.mode: deterministic`"
@@ -398,13 +397,13 @@ def test_thumbnail_skill_documents_ai_burn_in_default_and_deterministic_opt_in()
     assert "未設定 / `text_render.mode: ai_burn_in` の標準手順" in single_step_block
     for required in (
         "/thumbnail --compare",
-        "cp thumbnail-v1.jpg thumbnail.jpg",
+        "yt-thumbnail-review --artifact thumbnail",
         "TEXTLESS_PROMPT=\"$(cat <<'PROMPT'",
         '--reference "${COLLECTION_PATH}/10-assets/thumbnail.jpg"',
         '--prompt "$TEXTLESS_PROMPT"',
         '--output "${COLLECTION_PATH}/10-assets/main-v1.png"',
         "uv run yt-thumbnail-check <collection-path>/10-assets/main-v1.png --json",
-        "cp main-v1.png main.png",
+        "yt-thumbnail-review --artifact main",
         "テキストなし背景生成プロンプト",
         "テキスト付き生成プロンプト",
         "テキスト付き版の先行確定",
@@ -427,13 +426,17 @@ def test_thumbnail_skill_requires_manual_comparison_before_selecting_multiple_ca
     )
     for required in (
         "候補が 2 枚以上",
-        "open <collection-path>/10-assets/thumbnail-v{1,2,3}.jpg",
-        "Read（Codex では同等の画像閲覧機能）",
         "生成失敗",
-        "v1` / `v2` / `v3",
-        "cp thumbnail-v<選択番号>.jpg thumbnail.jpg",
-        "cp main-v<選択番号>.png main.png",
-        "候補が 1 枚",
+        "yt-thumbnail-review --collection <collection-path> --artifact thumbnail",
+        "--artifact main",
+        "--pattern <name>",
+        "原寸画像",
+        "実幅320px表示",
+        "candidate ID",
+        "--transport terminal",
+        "--candidate-id <ID>",
+        "直接 `cp` しない",
+        "成功候補が1枚",
         "auto_selection.enabled: true",
         "selection_only",
         "full",
@@ -442,11 +445,11 @@ def test_thumbnail_skill_requires_manual_comparison_before_selecting_multiple_ca
     ):
         assert required in comparison_contract
 
-    assert comparison_contract.find("`/thumbnail --compare`") < comparison_contract.find(
-        "候補番号（`v1` / `v2` / `v3`）"
+    assert comparison_contract.find("既存 `yt-thumbnail-check` と比較 QA") < comparison_contract.find(
+        "yt-thumbnail-review --collection"
     )
-    assert comparison_contract.find("候補番号（`v1` / `v2` / `v3`）") < comparison_contract.find(
-        "cp thumbnail-v<選択番号>.jpg thumbnail.jpg"
+    assert comparison_contract.find("共通selection broker") < comparison_contract.find(
+        "atomic copy、archive、workflow-state owner"
     )
 
     standard_block = _slice_between(
@@ -752,11 +755,11 @@ def test_thumbnail_archive_is_opt_in_and_wired_after_every_approval_path() -> No
     assert config["archive"] == {"enabled": False}
     assert "archive.enabled: false" in skill
     assert "assets/thumbnail-gallery/<collection-dir-name>.<ext>" in skill
-    # 標準（決定的合成）/ codex / Single-Step / Two-Phase の確定直後 + アーカイブ節本文 = 5
-    assert skill.count(archive_command) == 5
+    # Web reviewは同じarchive ownerをtransaction内で呼ぶ。文書上の旧互換/auto入口だけを保持する。
+    assert skill.count(archive_command) == 2
 
     approval_block = _slice_between(skill, "### 承認済みサムネイルのアーカイブ", "### Single-Step / TTP モード")
-    for approval_path in ("手動承認", "codex", "Two-Phase", "フォント固定", "自動選択"):
+    for approval_path in ("旧互換", "yt-thumbnail-review", "transaction", "自動選択"):
         assert approval_path in approval_block
     assert "確定直後" in approval_block
     assert "既存の検証・承認順序を変えず" in approval_block
@@ -784,8 +787,9 @@ def test_thumbnail_archive_is_opt_in_and_wired_after_every_approval_path() -> No
     )
     auto_selection_block = _slice_between(skill, "## 自動選択", "## 品質チェック")
 
-    for wired_block in (codex_block, standard_block, single_step_block, two_phase_block):
-        assert wired_block.find("thumbnail.jpg") < wired_block.find(archive_command)
+    assert codex_block.find("thumbnail.jpg") < codex_block.find(archive_command)
+    for wired_block in (standard_block, single_step_block, two_phase_block):
+        assert wired_block.find("thumbnail.jpg") < wired_block.find("yt-thumbnail-review --artifact thumbnail")
     assert "uv run yt-thumbnail-auto-select <collection-path> --apply" in auto_selection_block
     assert "--apply &&" not in auto_selection_block
     assert "候補生成後のユーザー承認を省略" in auto_selection_block
@@ -971,7 +975,7 @@ def test_thumbnail_skill_two_phase_keeps_thumbnail_and_main_separate() -> None:
     assert "--reference 10-assets/draft-background-v1.png" not in two_phase_block
     assert "#### Phase 3: 承認済み thumbnail から textless main を再生成" in two_phase_block
     assert "承認済み `thumbnail.jpg` を参照して textless `main-v1.png` を AI 再生成" in two_phase_block
-    assert "cp main-v1.png main.png" in two_phase_block
+    assert "yt-thumbnail-review --artifact main" in two_phase_block
     assert "参照素材を `main.png/jpg` へコピーしない" in reference_phase_block
     assert "cp main-v1.png main.png" not in reference_phase_block
     assert "#### Phase 1: 背景候補生成（draft main）" not in two_phase_block
@@ -1908,7 +1912,7 @@ def test_thumbnail_skill_routes_generation_details_without_moving_runtime_contra
     # #2950 adds one canonical non-interactive background-session invocation.
     assert skill.count("uv run yt-generate-image") == 12
     assert skill.count("uv run yt-thumbnail-text") == 1
-    assert skill.count("archive-approved-thumbnail.py") == 5
+    assert skill.count("archive-approved-thumbnail.py") == 2
     assert '### Single-Step / TTP モード（`generation_mode: "single_step"`、デフォルト・推奨）' in skill
     assert "### Two-Phase モード（従来方式・フォールバック）" in skill
     assert "/thumbnail --compare" in skill
@@ -1938,9 +1942,9 @@ def test_thumbnail_skill_routes_quality_details_without_moving_hard_gates() -> N
     route = "[quality / operations 詳細](references/quality-and-operations.md)"
 
     assert skill.index("## ワークフロー") < skill.index(route) < skill.index("## フォント安定化")
-    assert skill.count("uv run yt-thumbnail-check") == 5
+    assert skill.count("uv run yt-thumbnail-check") == 4
     assert skill.count("uv run yt-thumbnail-auto-select") == 3
-    assert skill.count("archive-approved-thumbnail.py") == 5
+    assert skill.count("archive-approved-thumbnail.py") == 2
     assert skill.count("uv run yt-stock-archive") == 1
     assert "## 完了条件" in skill
     assert "**Hard Gate**" in "\n".join(skill.splitlines()[:60])

--- a/tests/repo/test_review_lifecycle_skill_contract.py
+++ b/tests/repo/test_review_lifecycle_skill_contract.py
@@ -7,7 +7,7 @@ from tests.helpers.paths import REPO_ROOT
 _CONSUMERS = (
     (".claude/skills/wf-new/references/collection-plan-documents.md", "yt-collection-plan-select"),
     (".claude/skills/music/references/music-prompt-documents.md", "yt-document-review"),
-    (".claude/skills/thumbnail/references/operator-guide.md", "yt-document-review"),
+    (".claude/skills/thumbnail/references/operator-guide.md", "yt-thumbnail-review"),
     (".claude/skills/video/references/generate.md", "yt-document-review"),
 )
 

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -129,6 +129,7 @@ NON_BILLED_CLIS: dict[str, str] = {
     "yt-ttp-health": "収集済み benchmark_*.json のローカル分析のみ",
     "yt-thumbnail-auto-select": "ローカルのサムネイル採点・選定のみ",
     "yt-thumbnail-correlate": "CDN 画像 DL + ローカル相関計算のみ",
+    "yt-thumbnail-review": "ローカル候補画像とQAの比較・承認のみ",
     "yt-thumbnail-text": "ローカル PIL テキスト描画のみ",
     "yt-title-duplicate-check": "ローカルのタイトル照合のみ",
     "yt-traffic-trend": "収集済み analytics_data_*.json のローカル分析のみ",

--- a/tests/repo/test_thumbnail_web_review_contract.py
+++ b/tests/repo/test_thumbnail_web_review_contract.py
@@ -1,0 +1,27 @@
+from tests.helpers.paths import REPO_ROOT
+
+SKILL = (REPO_ROOT / ".claude/skills/thumbnail/SKILL.md").read_text(encoding="utf-8")
+REFERENCE = (REPO_ROOT / ".claude/skills/thumbnail/references/web-review.md").read_text(encoding="utf-8")
+
+
+def test_manual_thumbnail_review_uses_product_neutral_cli_and_fixed_sidecars() -> None:
+    assert "yt-thumbnail-review --collection <collection-path> --artifact thumbnail" in SKILL
+    assert "--artifact main" in SKILL
+    assert "--pattern <name>" in SKILL
+    assert "直接 `cp` しない" in SKILL
+    assert "<画像filename>.review.json" in REFERENCE
+    assert '"image_sha256"' in REFERENCE
+    assert '"thumbnail_check"' in REFERENCE
+    assert '"comparison_qa"' in REFERENCE
+    assert '"metadata"' in REFERENCE
+    assert '"evidence"' in REFERENCE
+    assert '"constraints"' in REFERENCE
+
+
+def test_review_contract_keeps_auto_and_terminal_paths_explicit() -> None:
+    assert "yt-thumbnail-auto-select --apply" in SKILL
+    assert "--transport terminal" in SKILL
+    assert "--candidate-id <ID>" in SKILL
+    assert "tmp/reviews/thumbnail-selection.html" in REFERENCE
+    assert "原寸と実幅320px" in REFERENCE
+    assert "外部URL" in REFERENCE and "symlink" in REFERENCE

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -88,6 +88,7 @@ EXPECTED_ENTRYPOINT_MODULES = {
     "yt-thumbnail-check": "youtube_automation.commands.thumbnail.thumbnail_check",
     "yt-thumbnail-compare": "youtube_automation.commands.thumbnail.compare_thumbnails",
     "yt-thumbnail-correlate": "youtube_automation.commands.thumbnail.thumbnail_correlate",
+    "yt-thumbnail-review": "youtube_automation.commands.thumbnail.thumbnail_review",
     "yt-thumbnail-text": "youtube_automation.commands.thumbnail.thumbnail_text",
     "yt-title-duplicate-check": "youtube_automation.commands.metadata.title_duplicate_check",
     "yt-traffic-trend": "youtube_automation.commands.analytics.traffic_trend",


### PR DESCRIPTION
## 概要

thumbnail候補を原寸・実幅320pxの安全なHTML比較viewで確認し、共通selection brokerからatomicに確定できるようにします。

## 変更内容

- 固定QA sidecarからimage digest、artifact/pattern、metadata/evidence/constraintsを検証
- candidate allowlist manifestとCSP/escape済み比較HTMLを生成
- 原寸と320px実表示を同一候補で比較
- single-use brokerからcandidate IDだけを受理
- selection後に画像・QA・manifestを再hash
- thumbnail/main/ABのatomic finalizerとarchive transaction
- source=webを監査記録
- terminal fallbackも同じfinalizer、automaticはHTML/brokerをskip
- symlink/scope/digest/QA欠落・改変ではcanonical/state不変
- CLI、entrypoint、thumbnail skill導線、wheel契約を追加

## 検証

- pre-rebase full: 9,470 passed / 3 skipped
- post-rebase focused: 266 passed
- ruff / format / Any / yt-skills: green
- wheel smoke: 2 passed
- site check/build + 53 tests: green
- ブラウザ実機・外部APIなし

Closes #4017
