### PR TITLE
feat(hybrid): 受け渡し manifest を完了マーカーにする (#4045)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
+- `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。
 - `feat(hybrid)`: 工程境界専用の `MediaStore` port と checksum 検証付き Local / Cloudflare R2 adapterを追加し、bucket・prefix・path・symlink 境界と secret 解決を fail-closed に固定する（#4044）。
 - `refactor(workflow-state)`: 旧 top-level `video_id` fallback と typed accessor を削除し、公開済み動画の正準 read を `upload.video_id` に限定する（#3893）。
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,7 +100,7 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 **サンドイッチ実行モデル**: クラウドジョブが Git clone + マニフェスト検証つき R2 pull でローカル FS を再構成し、既存のローカル前提コードを無改造で動かし、終了時に成果物 push + state commit する実行方式。MediaStore 抽象は pull / push を行う転送層としてのみ導入する（ADR-0024）。
 
-**受け渡しマニフェスト**: 境界を越えるメディア受け渡しの完了マーカー。ファイル一覧 + サイズ + SHA-256 checksum を持ち、全ファイル PUT + 検証後に最後に PUT する。後工程はマニフェスト経由でのみオブジェクトを読み、マニフェストが無ければ「存在しない」扱いとする。正本は R2 で、Git state にはキー + ルート checksum のみ記録する（ADR-0024）。
+**受け渡しマニフェスト**: 境界を越えるメディア受け渡しの完了マーカー。v1 は `<channel>/<collection>/<handoff>/manifest.json` に、path 昇順の正準ファイル一覧（相対 POSIX path・size・SHA-256）と、その一覧の canonical compact JSON に対する SHA-256 `root_sha256` を保持する。全 object の remote metadata と pull 後 content を検証した後、manifest を最後に atomic PUT する。R2 の強い read-after-write 整合性を completion marker 成立の必須前提とし、この保証を持たない MediaStore adapter は利用しない。後工程は bucket listing を行わず manifest 記載 key だけを検証付きで読み、manifest が無ければ「存在しない」扱いとする。正本は R2 で、Git state にはキー + root checksum のみ記録する（ADR-0024）。
 
 **MediaStore**: 境界を越えるメディアの pull / push を行う転送層の抽象。第一実装は R2 で、将来のストレージ交換点をここに限定する。工程や resolver へのストレージ抽象の注入は行わない（ADR-0024）。
 
@@ -225,6 +225,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.thumbnail` | サムネ特徴量、相関、参照、archive、選択 policy（Pillow） |
 | `domains.media` | 音声、字幕、画像、動画の provider-neutral model / policy |
 | `domains.media_store` | 工程境界の `<channel>/<collection>/<handoff>/` key、checksum metadata、push / pull / exists port |
+| `domains.media_handoff_manifest` | versioned handoff manifest schema、正準 file list、root checksum の typed owner |
 | `domains.distrokid` | DistroKid naming、metadata、specification、preparation、release policy |
 | `domains.collections.weekly_vote_log` | 週次投票ログ reader、initializer、schema、保存・検証 |
 | `domains.documents.schema_registry` | リポジトリ所有 JSON Schema の固定 inventory、Draft 7 compile cache、値非表示の検証エラー変換。外部 schema path は受け取らない |
@@ -233,6 +234,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `application.documents.migration` | skill 生成運用文書の new / Markdown 明示移行 / JSON+HTML 再更新を判定し、pair の検証付き transaction と旧 Markdown 削除を一操作として調停 |
 | `application.documents.channel_strategy` | direction / persona / scene / constraints の schema と文書間 ID 参照を検証し、共通 migration workflow による原子的保存を調停 |
 | `application.documents.collection_plan` | collection plan の schema・候補/evidence ID・選択状態を検証し、JSON+HTML pair 公開成功後の planning state 投影を調停 |
+| `application.media_handoff` | 全 object の remote metadata/content 検証、manifest-last push、manifest-only pull、local rollback を調停 |
 | `application.analytics.video_report` | 動画解析結果を audit report schema へ写像し、共通運用文書 migration による JSON+HTML 公開を調停 |
 | `.claude/skills/channel-research/references/channel-research-report.schema.json` | benchmark / market / viewer voice / thumbnail 調査の比較表・勝ちパターン・根拠・適用候補を共通定義し、skill writer と全 downstream reader の正本になる |
 | `infrastructure.filesystem` | provider-neutral な filesystem I/O と、複数 text file の fsync・rollback・公開後 verifier 付き transaction |

--- a/src/youtube_automation/application/media_handoff.py
+++ b/src/youtube_automation/application/media_handoff.py
@@ -1,0 +1,154 @@
+"""Manifest completion marker を使う境界メディア bundle 転送。"""
+
+from __future__ import annotations
+
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from youtube_automation.core.errors import MediaHandoffNotFoundError, MediaStoreError, ValidationError
+from youtube_automation.domains.media_handoff_manifest import (
+    MANIFEST_NAME,
+    HandoffFile,
+    HandoffIdentity,
+    HandoffManifest,
+)
+from youtube_automation.domains.media_store import (
+    MediaKey,
+    MediaObjectMetadata,
+    MediaStore,
+    validate_media_relative_path,
+)
+from youtube_automation.infrastructure.media_store import (
+    publish_staged_files,
+    require_regular_source,
+    sha256_file,
+)
+
+
+@dataclass(frozen=True)
+class HandoffSource:
+    source: Path
+    relative_path: str
+
+    def __post_init__(self) -> None:
+        try:
+            validate_media_relative_path("relative_path", self.relative_path)
+        except ValidationError as exc:
+            raise MediaStoreError(f"受け渡し source path が不正です: {self.relative_path!r}") from exc
+        if self.relative_path == MANIFEST_NAME:
+            raise MediaStoreError(f"{MANIFEST_NAME!r} は completion marker 用に予約されています")
+
+
+def _key(identity: HandoffIdentity, relative_path: str) -> MediaKey:
+    return MediaKey(identity.channel, identity.collection, identity.handoff, relative_path)
+
+
+def _assert_metadata(
+    expected: HandoffFile | MediaObjectMetadata,
+    actual: MediaObjectMetadata | None,
+    *,
+    object_path: str,
+    operation: str,
+) -> None:
+    if actual is None or actual.size != expected.size or actual.sha256 != expected.sha256:
+        raise MediaStoreError(
+            f"受け渡し object {operation} metadata/checksum が manifest と一致しません: {object_path}"
+        )
+
+
+def _assert_file(expected: HandoffFile, path: Path, *, operation: str) -> None:
+    size, checksum = sha256_file(path)
+    if size != expected.size or checksum != expected.sha256:
+        raise MediaStoreError(f"受け渡し object {operation} content checksum が一致しません: {expected.path}")
+
+
+def _manifest_file(path: Path) -> MediaObjectMetadata:
+    size, checksum = sha256_file(path)
+    return MediaObjectMetadata(size, checksum)
+
+
+def _build_manifest(identity: HandoffIdentity, sources: tuple[HandoffSource, ...]) -> HandoffManifest:
+    files: list[HandoffFile] = []
+    for source in sources:
+        require_regular_source(source.source)
+        size, checksum = sha256_file(source.source)
+        files.append(HandoffFile(source.relative_path, size, checksum))
+    return HandoffManifest.build(identity, tuple(files))
+
+
+def push_handoff(
+    store: MediaStore,
+    identity: HandoffIdentity,
+    sources: tuple[HandoffSource, ...],
+) -> HandoffManifest:
+    manifest = _build_manifest(identity, sources)
+    sources_by_path = {source.relative_path: source.source for source in sources}
+    with tempfile.TemporaryDirectory(prefix="yt-handoff-push-") as verification_directory:
+        verification_root = Path(verification_directory)
+        for entry in manifest.files:
+            key = _key(identity, entry.path)
+            pushed = store.push(sources_by_path[entry.path], key)
+            _assert_metadata(entry, pushed, object_path=entry.path, operation="push")
+            _assert_metadata(entry, store.metadata(key), object_path=entry.path, operation="remote")
+            verification_path = verification_root.joinpath(*entry.path.split("/"))
+            pulled = store.pull(key, verification_path)
+            _assert_metadata(entry, pulled, object_path=entry.path, operation="verification pull")
+            _assert_file(entry, verification_path, operation="verification")
+
+        manifest_path = verification_root / MANIFEST_NAME
+        manifest_path.write_bytes(manifest.to_json_bytes())
+        expected_manifest = _manifest_file(manifest_path)
+        manifest_key = _key(identity, MANIFEST_NAME)
+        pushed_manifest = store.push(manifest_path, manifest_key)
+        _assert_metadata(expected_manifest, pushed_manifest, object_path=MANIFEST_NAME, operation="manifest push")
+        _assert_metadata(
+            expected_manifest,
+            store.metadata(manifest_key),
+            object_path=MANIFEST_NAME,
+            operation="manifest remote",
+        )
+        verification_manifest = verification_root / "verified-manifest.json"
+        pulled_manifest = store.pull(manifest_key, verification_manifest)
+        _assert_metadata(
+            expected_manifest,
+            pulled_manifest,
+            object_path=MANIFEST_NAME,
+            operation="manifest verification pull",
+        )
+        _assert_file(expected_manifest, verification_manifest, operation="manifest verification")
+        if HandoffManifest.from_json_bytes(verification_manifest.read_bytes()) != manifest:
+            raise MediaStoreError("受け渡し manifest の remote content が生成内容と一致しません")
+    return manifest
+
+
+def pull_handoff(store: MediaStore, identity: HandoffIdentity, destination: Path) -> HandoffManifest:
+    manifest_key = _key(identity, MANIFEST_NAME)
+    manifest_metadata = store.metadata(manifest_key)
+    if manifest_metadata is None:
+        raise MediaHandoffNotFoundError(
+            f"受け渡し manifest が見つかりません: {identity.channel}/{identity.collection}/{identity.handoff}"
+        )
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="yt-handoff-pull-", dir=destination.parent) as staging_directory:
+        staging_root = Path(staging_directory)
+        manifest_path = staging_root / MANIFEST_NAME
+        pulled_manifest = store.pull(manifest_key, manifest_path)
+        if pulled_manifest != manifest_metadata:
+            raise MediaStoreError("受け渡し manifest metadata が読み取り中に変化しました")
+        size, checksum = sha256_file(manifest_path)
+        if size != manifest_metadata.size or checksum != manifest_metadata.sha256:
+            raise MediaStoreError("受け渡し manifest content checksum が一致しません")
+        manifest = HandoffManifest.from_json_bytes(manifest_path.read_bytes())
+        if manifest.identity != identity:
+            raise MediaStoreError("受け渡し manifest key と identity が一致しません")
+
+        for entry in manifest.files:
+            staging_path = staging_root.joinpath(*entry.path.split("/"))
+            pulled = store.pull(_key(identity, entry.path), staging_path)
+            _assert_metadata(entry, pulled, object_path=entry.path, operation="pull")
+            _assert_file(entry, staging_path, operation="pull")
+
+        publish_staged_files(staging_root, destination, tuple(entry.path for entry in manifest.files))
+    return manifest

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -129,6 +129,10 @@ class MediaStoreError(AutomationError):
     """境界メディアの転送・完全性検証エラー。"""
 
 
+class MediaHandoffNotFoundError(MediaStoreError):
+    """完了マーカーが無く、受け渡し物が未完成または存在しない。"""
+
+
 def _http_error_reason(error) -> str | None:
     content = getattr(error, "content", b"")
     if isinstance(content, bytes):

--- a/src/youtube_automation/domains/media_handoff_manifest.py
+++ b/src/youtube_automation/domains/media_handoff_manifest.py
@@ -1,0 +1,167 @@
+"""境界メディア受け渡し manifest v1 の typed owner。"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+
+from youtube_automation.core.errors import MediaStoreError, ValidationError
+from youtube_automation.domains.media_store import validate_media_relative_path, validate_media_segment
+
+MANIFEST_SCHEMA_VERSION = 1
+MANIFEST_NAME = "manifest.json"
+_SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
+_MANIFEST_FIELDS = {"schema_version", "channel", "collection", "handoff", "files", "root_sha256"}
+_FILE_FIELDS = {"path", "size", "sha256"}
+
+
+def _manifest_error(detail: str) -> MediaStoreError:
+    return MediaStoreError(f"受け渡し manifest v{MANIFEST_SCHEMA_VERSION} が不正です: {detail}")
+
+
+def _validate_identifier(field: str, value: str) -> None:
+    try:
+        validate_media_segment(field, value)
+    except ValidationError as exc:
+        raise _manifest_error(field) from exc
+
+
+def _validate_path(value: str) -> None:
+    try:
+        validate_media_relative_path("path", value)
+    except ValidationError as exc:
+        raise _manifest_error("path") from exc
+    if value == MANIFEST_NAME:
+        raise _manifest_error(f"path {MANIFEST_NAME!r} は completion marker 用に予約されています")
+
+
+@dataclass(frozen=True)
+class HandoffIdentity:
+    channel: str
+    collection: str
+    handoff: str
+
+    def __post_init__(self) -> None:
+        for field in ("channel", "collection", "handoff"):
+            _validate_identifier(field, getattr(self, field))
+
+
+@dataclass(frozen=True)
+class HandoffFile:
+    path: str
+    size: int
+    sha256: str
+
+    def __post_init__(self) -> None:
+        _validate_path(self.path)
+        if isinstance(self.size, bool) or not isinstance(self.size, int) or self.size < 0:
+            raise _manifest_error("size")
+        if not isinstance(self.sha256, str) or not _SHA256_RE.fullmatch(self.sha256):
+            raise _manifest_error("sha256")
+
+    def to_json_value(self) -> dict[str, object]:
+        return {"path": self.path, "size": self.size, "sha256": self.sha256}
+
+
+def _root_sha256(files: tuple[HandoffFile, ...]) -> str:
+    canonical = json.dumps(
+        [entry.to_json_value() for entry in files],
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+@dataclass(frozen=True)
+class HandoffManifest:
+    schema_version: int
+    identity: HandoffIdentity
+    files: tuple[HandoffFile, ...]
+    root_sha256: str
+
+    def __post_init__(self) -> None:
+        if self.schema_version != MANIFEST_SCHEMA_VERSION:
+            raise _manifest_error("schema_version")
+        if not self.files:
+            raise _manifest_error("files は1件以上必要です")
+        paths = [entry.path for entry in self.files]
+        if len(paths) != len(set(paths)):
+            raise _manifest_error("duplicate path")
+        if paths != sorted(paths):
+            raise _manifest_error("files は path 昇順の正準順序である必要があります")
+        if not _SHA256_RE.fullmatch(self.root_sha256) or self.root_sha256 != _root_sha256(self.files):
+            raise _manifest_error("root checksum")
+
+    @classmethod
+    def build(cls, identity: HandoffIdentity, files: tuple[HandoffFile, ...]) -> HandoffManifest:
+        canonical_files = tuple(sorted(files, key=lambda entry: entry.path))
+        return cls(
+            schema_version=MANIFEST_SCHEMA_VERSION,
+            identity=identity,
+            files=canonical_files,
+            root_sha256=_root_sha256(canonical_files),
+        )
+
+    def to_json_value(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "channel": self.identity.channel,
+            "collection": self.identity.collection,
+            "handoff": self.identity.handoff,
+            "files": [entry.to_json_value() for entry in self.files],
+            "root_sha256": self.root_sha256,
+        }
+
+    def to_json_bytes(self) -> bytes:
+        return (json.dumps(self.to_json_value(), ensure_ascii=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+    @classmethod
+    def from_json_bytes(cls, raw: bytes) -> HandoffManifest:
+        try:
+            value = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise _manifest_error("JSON") from exc
+        if not isinstance(value, dict) or set(value) != _MANIFEST_FIELDS:
+            raise _manifest_error("top-level field")
+        schema_version = value["schema_version"]
+        if isinstance(schema_version, bool) or schema_version != MANIFEST_SCHEMA_VERSION:
+            raise _manifest_error("schema_version")
+        identity = _parse_identity(value)
+        files = _parse_files(value["files"])
+        root_sha256 = value["root_sha256"]
+        if not isinstance(root_sha256, str):
+            raise _manifest_error("root checksum")
+        return cls(schema_version, identity, files, root_sha256)
+
+
+def _parse_identity(value: dict[object, object]) -> HandoffIdentity:
+    identifiers: dict[str, str] = {}
+    for field in ("channel", "collection", "handoff"):
+        item = value[field]
+        if not isinstance(item, str):
+            raise _manifest_error(field)
+        identifiers[field] = item
+    return HandoffIdentity(**identifiers)
+
+
+def _parse_files(value: object) -> tuple[HandoffFile, ...]:
+    if not isinstance(value, list):
+        raise _manifest_error("files")
+    files: list[HandoffFile] = []
+    for item in value:
+        if not isinstance(item, dict) or set(item) != _FILE_FIELDS:
+            raise _manifest_error("file field")
+        path = item["path"]
+        size = item["size"]
+        sha256 = item["sha256"]
+        if not isinstance(path, str):
+            raise _manifest_error("path")
+        if isinstance(size, bool) or not isinstance(size, int):
+            raise _manifest_error("size")
+        if not isinstance(sha256, str):
+            raise _manifest_error("sha256")
+        files.append(HandoffFile(path, size, sha256))
+    return tuple(files)

--- a/src/youtube_automation/domains/media_store.py
+++ b/src/youtube_automation/domains/media_store.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Protocol, runtime_checkable
 
 from youtube_automation.core.errors import ValidationError
@@ -12,9 +12,19 @@ from youtube_automation.core.errors import ValidationError
 _KEY_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 
 
-def _validate_segment(field: str, value: str) -> None:
+def validate_media_segment(field: str, value: str) -> None:
     if not _KEY_SEGMENT_RE.fullmatch(value) or value in {".", ".."}:
         raise ValidationError(f"MediaKey.{field} は安全な単一 path segment である必要があります: {value!r}")
+
+
+def validate_media_relative_path(field: str, value: str) -> None:
+    if not value or value.startswith("/") or "\\" in value:
+        raise ValidationError(f"MediaKey.{field} は安全な相対 POSIX path である必要があります: {value!r}")
+    path = PurePosixPath(value)
+    if path.as_posix() != value:
+        raise ValidationError(f"MediaKey.{field} は正規化済み path である必要があります: {value!r}")
+    for segment in path.parts:
+        validate_media_segment(field, segment)
 
 
 @dataclass(frozen=True)
@@ -27,8 +37,9 @@ class MediaKey:
     name: str
 
     def __post_init__(self) -> None:
-        for field in ("channel", "collection", "handoff", "name"):
-            _validate_segment(field, getattr(self, field))
+        for field in ("channel", "collection", "handoff"):
+            validate_media_segment(field, getattr(self, field))
+        validate_media_relative_path("name", self.name)
 
     def as_posix(self) -> str:
         return "/".join((self.channel, self.collection, self.handoff, self.name))

--- a/src/youtube_automation/infrastructure/media_store/__init__.py
+++ b/src/youtube_automation/infrastructure/media_store/__init__.py
@@ -1,6 +1,18 @@
 """MediaStore の local / R2 adapter。"""
 
+from youtube_automation.infrastructure.media_store._files import (
+    publish_staged_files,
+    require_regular_source,
+    sha256_file,
+)
 from youtube_automation.infrastructure.media_store.local import LocalMediaStore
 from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
 
-__all__ = ["LocalMediaStore", "R2MediaStore", "R2MediaStoreConfig"]
+__all__ = [
+    "LocalMediaStore",
+    "R2MediaStore",
+    "R2MediaStoreConfig",
+    "publish_staged_files",
+    "require_regular_source",
+    "sha256_file",
+]

--- a/src/youtube_automation/infrastructure/media_store/_files.py
+++ b/src/youtube_automation/infrastructure/media_store/_files.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -66,3 +67,37 @@ def atomic_destination(destination: Path) -> Iterator[Path]:
     except Exception:
         temporary.unlink(missing_ok=True)
         raise
+
+
+def publish_staged_files(staging: Path, destination: Path, relative_paths: tuple[str, ...]) -> None:
+    """検証済み staging files を既存成果物の rollback 付きで公開する。"""
+    if destination.is_symlink():
+        raise MediaStoreError("受け渡し先 root にシンボリックリンクは使えません")
+    destination.mkdir(parents=True, exist_ok=True)
+    backup_root = Path(tempfile.mkdtemp(prefix="yt-handoff-backup-", dir=destination.parent))
+    published: list[Path] = []
+    backed_up: list[tuple[Path, Path]] = []
+    try:
+        for relative_path in relative_paths:
+            source = staging.joinpath(*relative_path.split("/"))
+            target = destination.joinpath(*relative_path.split("/"))
+            reject_symlink_components(target, boundary=destination)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists():
+                if not target.is_file():
+                    raise MediaStoreError(f"受け渡し先が通常ファイルではありません: {relative_path}")
+                backup = backup_root.joinpath(*relative_path.split("/"))
+                backup.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(target, backup)
+                backed_up.append((target, backup))
+            os.replace(source, target)
+            published.append(target)
+    except Exception:
+        for target in reversed(published):
+            target.unlink(missing_ok=True)
+        for target, backup in reversed(backed_up):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.replace(backup, target)
+        raise
+    finally:
+        shutil.rmtree(backup_root)

--- a/tests/application/test_media_handoff.py
+++ b/tests/application/test_media_handoff.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
+from youtube_automation.core.errors import MediaHandoffNotFoundError, MediaStoreError
+from youtube_automation.domains.media_handoff_manifest import (
+    MANIFEST_NAME,
+    HandoffFile,
+    HandoffIdentity,
+    HandoffManifest,
+)
+from youtube_automation.domains.media_store import MediaKey, MediaObjectMetadata, MediaStore
+from youtube_automation.infrastructure.media_store.local import LocalMediaStore
+
+
+class RecordingStore:
+    def __init__(self, delegate: MediaStore) -> None:
+        self.delegate = delegate
+        self.pushes: list[str] = []
+        self.pulls: list[str] = []
+
+    def push(self, source: Path, key: MediaKey) -> MediaObjectMetadata:
+        self.pushes.append(key.name)
+        return self.delegate.push(source, key)
+
+    def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
+        self.pulls.append(key.name)
+        return self.delegate.pull(key, destination)
+
+    def exists(self, key: MediaKey) -> bool:
+        return self.delegate.exists(key)
+
+    def metadata(self, key: MediaKey) -> MediaObjectMetadata | None:
+        return self.delegate.metadata(key)
+
+
+def _identity() -> HandoffIdentity:
+    return HandoffIdentity("ambient-lab", "rain-night", "video-upload")
+
+
+def _sources(tmp_path: Path) -> tuple[HandoffSource, ...]:
+    video = tmp_path / "Master.mp4"
+    audio = tmp_path / "master.wav"
+    video.write_bytes(b"video-payload")
+    audio.write_bytes(b"audio-payload")
+    return (
+        HandoffSource(video, "video/Master.mp4"),
+        HandoffSource(audio, "audio/master.wav"),
+    )
+
+
+def _manifest_key() -> MediaKey:
+    identity = _identity()
+    return MediaKey(identity.channel, identity.collection, identity.handoff, MANIFEST_NAME)
+
+
+def test_push_verifies_every_object_then_puts_manifest_as_the_last_completion_marker(tmp_path: Path) -> None:
+    # R2 の read-after-write 強整合により、この最後の PUT が bundle 完了の観測点になる。
+    store = RecordingStore(LocalMediaStore(tmp_path / "store"))
+
+    manifest = push_handoff(store, _identity(), _sources(tmp_path))
+
+    assert store.pushes == ["audio/master.wav", "video/Master.mp4", MANIFEST_NAME]
+    assert store.pulls == ["audio/master.wav", "video/Master.mp4", MANIFEST_NAME]
+    assert store.metadata(_manifest_key()) is not None
+    assert HandoffManifest.from_json_bytes((tmp_path / "store" / _manifest_key().as_posix()).read_bytes()) == manifest
+
+
+def test_failed_object_content_verification_never_publishes_the_manifest(tmp_path: Path) -> None:
+    class CorruptingStore(RecordingStore):
+        def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
+            metadata = super().pull(key, destination)
+            if key.name != MANIFEST_NAME:
+                destination.write_bytes(b"corrupt")
+            return metadata
+
+    store = CorruptingStore(LocalMediaStore(tmp_path / "store"))
+
+    with pytest.raises(MediaStoreError, match="content"):
+        push_handoff(store, _identity(), _sources(tmp_path))
+    assert store.metadata(_manifest_key()) is None
+
+
+def test_pull_treats_objects_without_a_manifest_as_not_found_and_keeps_local_files(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    source = tmp_path / "remote.mp4"
+    source.write_bytes(b"partial-upload")
+    identity = _identity()
+    store.push(source, MediaKey(identity.channel, identity.collection, identity.handoff, "video/Master.mp4"))
+    destination = tmp_path / "destination"
+    destination.mkdir()
+    existing = destination / "existing.txt"
+    existing.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(MediaHandoffNotFoundError):
+        pull_handoff(store, identity, destination)
+    assert existing.read_text(encoding="utf-8") == "keep"
+    assert not (destination / "video" / "Master.mp4").exists()
+
+
+def test_pull_uses_only_manifest_entries_and_reconstructs_nested_files(tmp_path: Path) -> None:
+    store = RecordingStore(LocalMediaStore(tmp_path / "store"))
+    manifest = push_handoff(store, _identity(), _sources(tmp_path))
+    store.pulls.clear()
+    destination = tmp_path / "destination"
+
+    pulled = pull_handoff(store, _identity(), destination)
+
+    assert pulled == manifest
+    assert store.pulls == [MANIFEST_NAME, "audio/master.wav", "video/Master.mp4"]
+    assert (destination / "audio" / "master.wav").read_bytes() == b"audio-payload"
+    assert (destination / "video" / "Master.mp4").read_bytes() == b"video-payload"
+
+
+def test_pull_rejects_a_manifest_stored_under_a_different_identity_key(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    wrong_manifest = HandoffManifest.build(
+        HandoffIdentity("other-channel", "rain-night", "video-upload"),
+        (HandoffFile("video/Master.mp4", 1, "a" * 64),),
+    )
+    manifest_source = tmp_path / MANIFEST_NAME
+    manifest_source.write_bytes(wrong_manifest.to_json_bytes())
+    store.push(manifest_source, _manifest_key())
+    destination = tmp_path / "destination"
+
+    with pytest.raises(MediaStoreError, match="identity"):
+        pull_handoff(store, _identity(), destination)
+    assert not destination.exists()
+
+
+def test_pull_checksum_mismatch_fails_closed_and_preserves_existing_outputs(tmp_path: Path) -> None:
+    store_root = tmp_path / "store"
+    store = LocalMediaStore(store_root)
+    push_handoff(store, _identity(), _sources(tmp_path))
+    remote_video = store_root / _identity().channel / _identity().collection / _identity().handoff / "video/Master.mp4"
+    remote_video.write_bytes(b"tampered")
+    destination = tmp_path / "destination"
+    existing_video = destination / "video" / "Master.mp4"
+    existing_video.parent.mkdir(parents=True)
+    existing_video.write_bytes(b"existing-local-video")
+    unrelated = destination / "notes.txt"
+    unrelated.write_text("keep", encoding="utf-8")
+
+    with pytest.raises(MediaStoreError, match="checksum"):
+        pull_handoff(store, _identity(), destination)
+    assert existing_video.read_bytes() == b"existing-local-video"
+    assert unrelated.read_text(encoding="utf-8") == "keep"
+
+
+def test_pull_publish_failure_rolls_back_files_already_replaced(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    push_handoff(store, _identity(), _sources(tmp_path))
+    destination = tmp_path / "destination"
+    existing_audio = destination / "audio" / "master.wav"
+    existing_audio.parent.mkdir(parents=True)
+    existing_audio.write_bytes(b"existing-local-audio")
+    invalid_video_target = destination / "video" / "Master.mp4"
+    invalid_video_target.mkdir(parents=True)
+
+    with pytest.raises(MediaStoreError, match="通常ファイル"):
+        pull_handoff(store, _identity(), destination)
+    assert existing_audio.read_bytes() == b"existing-local-audio"
+    assert invalid_video_target.is_dir()

--- a/tests/domains/test_media_handoff_manifest.py
+++ b/tests/domains/test_media_handoff_manifest.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from youtube_automation.core.errors import MediaStoreError
+from youtube_automation.domains.media_handoff_manifest import (
+    MANIFEST_SCHEMA_VERSION,
+    HandoffFile,
+    HandoffIdentity,
+    HandoffManifest,
+)
+
+
+def _manifest() -> HandoffManifest:
+    return HandoffManifest.build(
+        HandoffIdentity("ambient-lab", "rain-night", "video-upload"),
+        (
+            HandoffFile("video/Master.mp4", 11, "a" * 64),
+            HandoffFile("audio/master.wav", 7, "b" * 64),
+        ),
+    )
+
+
+def test_manifest_builds_a_canonical_file_list_and_stable_root_checksum() -> None:
+    manifest = _manifest()
+
+    assert manifest.schema_version == MANIFEST_SCHEMA_VERSION
+    assert [entry.path for entry in manifest.files] == ["audio/master.wav", "video/Master.mp4"]
+    assert len(manifest.root_sha256) == 64
+    assert HandoffManifest.from_json_bytes(manifest.to_json_bytes()) == manifest
+
+
+@pytest.mark.parametrize(
+    ("mutation", "match"),
+    [
+        (lambda value: value.update(schema_version=2), "schema_version"),
+        (lambda value: value.update(channel="../escape"), "channel"),
+        (lambda value: value["files"][0].update(path="../escape.mp4"), "path"),
+        (lambda value: value["files"][0].update(size=-1), "size"),
+        (lambda value: value["files"][0].update(size=True), "size"),
+        (lambda value: value["files"][0].update(sha256="not-a-checksum"), "sha256"),
+        (lambda value: value["files"].append(dict(value["files"][0])), "duplicate"),
+        (lambda value: value.update(files=None), "files"),
+        (lambda value: value.update(files={}), "files"),
+        (lambda value: value.update(root_sha256="0" * 64), "root"),
+    ],
+)
+def test_manifest_parser_rejects_invalid_schema_paths_duplicates_and_checksums(mutation, match: str) -> None:
+    value = json.loads(_manifest().to_json_bytes())
+    mutation(value)
+
+    with pytest.raises(MediaStoreError, match=match):
+        HandoffManifest.from_json_bytes(json.dumps(value).encode())
+
+
+def test_manifest_parser_rejects_unknown_fields() -> None:
+    value = json.loads(_manifest().to_json_bytes())
+    value["unexpected"] = True
+
+    with pytest.raises(MediaStoreError, match="field"):
+        HandoffManifest.from_json_bytes(json.dumps(value).encode())
+
+
+def test_manifest_parser_rejects_unknown_file_fields() -> None:
+    value = json.loads(_manifest().to_json_bytes())
+    value["files"][0]["unexpected"] = True
+
+    with pytest.raises(MediaStoreError, match="file field"):
+        HandoffManifest.from_json_bytes(json.dumps(value).encode())

--- a/tests/domains/test_media_store.py
+++ b/tests/domains/test_media_store.py
@@ -7,9 +7,14 @@ from youtube_automation.domains.media_store import MediaKey
 
 
 def test_media_key_builds_the_canonical_handoff_path() -> None:
-    key = MediaKey(channel="ambient-lab", collection="rain-night", handoff="video-upload", name="Master.mp4")
+    key = MediaKey(
+        channel="ambient-lab",
+        collection="rain-night",
+        handoff="video-upload",
+        name="media/Master.mp4",
+    )
 
-    assert key.as_posix() == "ambient-lab/rain-night/video-upload/Master.mp4"
+    assert key.as_posix() == "ambient-lab/rain-night/video-upload/media/Master.mp4"
 
 
 @pytest.mark.parametrize(
@@ -18,7 +23,8 @@ def test_media_key_builds_the_canonical_handoff_path() -> None:
         ("channel", "../other-channel"),
         ("collection", "/absolute"),
         ("handoff", "video/upload"),
-        ("name", "nested/Master.mp4"),
+        ("name", "nested/../Master.mp4"),
+        ("name", "nested\\Master.mp4"),
         ("name", ".."),
     ],
 )


### PR DESCRIPTION
## 概要

MediaStore境界を越えるファイル群にversioned handoff manifestを導入し、manifestを最後に置く完了マーカーとして扱います。

## 変更内容

- manifest v1 typed schema、canonical file list、size、SHA-256、root checksum
- 全object PUT後にremote metadataとcontentを再検証
- manifestを最後にPUTしてcompletion marker化
- pullはbucket listingを使わずmanifest存在からのみ開始
- key/path/duplicate/size/hash/rootをfail-closed検証
- manifest無しはnot found、不完全uploadを不可視化
- download/公開失敗時に既存local成果物を保持・rollback
- R2 strong consistency前提と操作順をdocs/testで固定

## 検証

- full: 9,463 passed / 3 skipped
- post-rebase focused: 265 passed
- ruff / format / Any / lock / build: green
- isolated wheel manifest roundtrip: green
- 実R2・API・課金なし

Closes #4045
