### PR TITLE
feat(hybrid): 制御面JSONをGit管理へ移行する (#4049)

### DIFF
--- a/.claude/CLAUDE.template.md
+++ b/.claude/CLAUDE.template.md
@@ -66,5 +66,6 @@ Claude はこのリポジトリ上で **「BGM チャンネルを運営して収
 
 - **チャンネル固有値のハードコーディング禁止** — `config/channel/*.json` に集約する。コードから読むときは `from youtube_automation.configuration import load_config` を経由し、責務別ネームスペース（`config.meta.channel_name` / `config.content.tags.base` / `config.youtube.api.category_id`）でアクセスする
 - **`auth/client_secrets.json` / `auth/token.json` は絶対にコミットしない**。シークレット解決順序は `os.environ` → `op read`（1Password CLI）→ `ConfigError`
+- **`workflow-state.json` と upload / post-publish / pinned-comment の tracking JSON は Git 管理する**。既存チャンネルは `yt-skills migrate-state-git --channel-dir <path> --dry-run` で secret と差分を検査してから明示移行する
 - **スキル本体をローカルで書き換えない**。次回 `yt-skills sync` で上書きされる。変更は upstream `daiki-beppu/youtube-automation` の `.claude/skills/` に PR を出す
 - 設定ミスや欠損データは `infrastructure/errors.py` のドメイン例外で早期に止める。フォールバックで握りつぶさない

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。
 - `feat(hybrid)`: 工程境界専用の `MediaStore` port と checksum 検証付き Local / Cloudflare R2 adapterを追加し、bucket・prefix・path・symlink 境界と secret 解決を fail-closed に固定する（#4044）。
 - `feat(thumbnail)`: `/thumbnail --loop` の既存 engine 選択へ MiniMax H3 を追加し、検証・再開・課金記録を備えた `--engine h3` 経路を提供する（#4122）。
+- `feat(hybrid)`: `workflow-state.json` と upload / post-publish / pinned-comment tracking を下流Git管理対象にし、新規channel/sync用 `.gitignore` と、既存channelをsecret・symlink・作業ツリー状態のfail-closed検査付きで明示移行する `yt-skills migrate-state-git` を追加する（#4049）。
 - `refactor(workflow-state)`: 旧 top-level `video_id` fallback と typed accessor を削除し、公開済み動画の正準 read を `upload.video_id` に限定する（#3893）。
 - `refactor(workflow-state)`: writer のない `assets.video` typed accessor を削除し、動画化進捗を正準の `assets.master_video` だけで判定する（#3892）。
 - `feat(documents)`: 生成運用成果物の owner・schema・consumer inventory を正本化し、`yt-skills lint` で Markdown writer、JSON/HTML pair 欠落、orphan、未検証 consumer、stale allowlist を具体 path 付きで拒否する（#4031）。

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,6 +31,8 @@ uv run yt-skills list                                # 同梱スキル一覧
 uv run yt-skills list --asset claude-md              # 同梱 CLAUDE.md テンプレ一覧
 uv run yt-skills diff                                # 同梱版と target の差分確認
 uv run yt-skills diff --asset claude-md              # CLAUDE.md テンプレの差分確認
+uv run yt-skills migrate-state-git --channel-dir <path> --dry-run  # 既存channelの制御面Git移行を確認
+uv run yt-skills migrate-state-git --channel-dir <path> --check    # 制御面JSONがcommit済みか検査
 ```
 
 ## テスト実行（pytest-xdist による並列化）

--- a/docs/migration/state-git-control-plane.md
+++ b/docs/migration/state-git-control-plane.md
@@ -1,0 +1,25 @@
+# workflow state / tracking の Git 管理移行
+
+ADR-0024 の制御面として、次の JSON をチャンネルリポジトリで Git 管理します。
+
+- `collections/*/*/workflow-state.json`
+- `collections/*/*/20-documentation/upload_tracking.json`
+- `post_publish_history.json`
+- `pinned_comment_history.json`
+
+新規チャンネルは `yt-channel-init` と `yt-skills sync` が生成する `.gitignore` にこの規則を含みます。既存 `.gitignore` は `sync --force` でも上書きしません。
+
+既存チャンネルでは対象 root を必ず明示し、最初に読み取り専用の差分を確認します。
+
+```bash
+uv run yt-skills migrate-state-git --channel-dir /absolute/path/to/channel --dry-run
+uv run yt-skills migrate-state-git --channel-dir /absolute/path/to/channel
+git diff --cached --check
+git diff --cached
+git commit -m "chore: workflow stateをGit管理へ移行する"
+uv run yt-skills migrate-state-git --channel-dir /absolute/path/to/channel --check
+```
+
+移行コマンドはリポジトリ全域を再帰走査せず、指定した channel root の既知の配置だけを検査します。対象 JSON の symlink、壊れた JSON、secret 候補、移行対象外の staged / dirty / untracked 変更を検出した場合は `.gitignore` や Git index を変更せず停止します。`upload_tracking.json` に resumable upload session URI が残っている場合は、外部 write の再開状態を解消してから再実行してください。
+
+`--check` はポリシーと対象 JSON が commit 済みで、未追跡・staged・dirty でないことを検査します。対象ファイルがまだ生成されていない新規チャンネルでは、ポリシーが commit 済みなら合格します。pull / commit / push の実行時強制と non-fast-forward 停止は後続の Git state owner が担当します。

--- a/src/youtube_automation/commands/channel/channel_init_templates.py
+++ b/src/youtube_automation/commands/channel/channel_init_templates.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from youtube_automation.infrastructure.auth.client_secrets import template_bytes
+from youtube_automation.infrastructure.vcs.state_git import channel_gitignore_template
 
 CONFIG_DIR = Path("config")
 CONFIG_SUBDIR = CONFIG_DIR / "channel"
@@ -221,23 +222,7 @@ def _yaml_scalar(value: str) -> str:
 
 
 def _render_gitignore(_ctx: ChannelInitContext) -> str:
-    return "\n".join(
-        [
-            "# Local environment",
-            ".env",
-            ".direnv/",
-            ".venv/",
-            "",
-            "# Python",
-            "__pycache__/",
-            "*.pyc",
-            "",
-            "# OAuth credentials",
-            "auth/client_secrets.json",
-            "auth/token*.json",
-            "",
-        ]
-    )
+    return channel_gitignore_template()
 
 
 def _canonical_auth_template(_ctx: ChannelInitContext) -> str:

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -21,6 +21,7 @@ Asset 種別 (`--asset`):
     workflow-cheatsheet : workflow 使い分けチートシート (`docs/workflow-cheatsheet.md`、単一ファイル)
     features            : 全 skill カタログ (`docs/features.md`、単一ファイル)
     auth-template       : OAuth client secrets テンプレート (`auth/client_secrets.template.json`、単一ファイル)
+    channel-gitignore   : channel Git ignore テンプレート (`.gitignore`、単一ファイル・既存は上書きしない)
     settings            : Claude Code 設定 (`.claude/settings.json`、JSON merge)
 
 `yt-skills sync` (asset 未指定) は `--asset all` と同等で、配布物が `docs/`
@@ -86,6 +87,14 @@ _ASSET_SPECS: dict[str, dict[str, str]] = {
         "source_filename": "client_secrets.template.json",
         "default_target": "auth/client_secrets.template.json",
         "label": "OAuth client_secrets テンプレ",
+    },
+    "channel-gitignore": {
+        "kind": "file",
+        "resource_name": "infrastructure/resources/channel",
+        "source_subdir": "src/youtube_automation/infrastructure/resources/channel",
+        "source_filename": "gitignore.template",
+        "default_target": ".gitignore",
+        "label": "channel Git ignore テンプレ",
     },
     "settings": {
         "kind": "json-merge",

--- a/src/youtube_automation/commands/system/skills_sync/_parser.py
+++ b/src/youtube_automation/commands/system/skills_sync/_parser.py
@@ -13,6 +13,7 @@ from youtube_automation.commands.system.skills_sync._delegation import cmd_deleg
 from youtube_automation.commands.system.skills_sync._diff import cmd_diff
 from youtube_automation.commands.system.skills_sync._lint import cmd_lint
 from youtube_automation.commands.system.skills_sync._migrate_config import cmd_migrate_config
+from youtube_automation.commands.system.skills_sync._state_git import cmd_migrate_state_git
 from youtube_automation.commands.system.skills_sync._sync import cmd_sync
 
 
@@ -164,5 +165,28 @@ def build_parser() -> argparse.ArgumentParser:
         help="移行差分だけを表示し、ファイルを変更しない",
     )
     p_migrate_config.set_defaults(func=cmd_migrate_config, asset="skills")
+
+    p_migrate_state_git = sub.add_parser(
+        "migrate-state-git",
+        help="下流のworkflow state / tracking JSONをGit管理へ明示移行",
+    )
+    p_migrate_state_git.add_argument(
+        "--channel-dir",
+        type=Path,
+        required=True,
+        help="移行対象のチャンネルroot（誤走査防止のため必須）",
+    )
+    modes = p_migrate_state_git.add_mutually_exclusive_group()
+    modes.add_argument(
+        "--check",
+        action="store_true",
+        help="制御面JSONがcommit済みか読み取り専用で検査",
+    )
+    modes.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=".gitignore差分とGit追加対象だけを表示し変更しない",
+    )
+    p_migrate_state_git.set_defaults(func=cmd_migrate_state_git, asset="skills")
 
     return parser

--- a/src/youtube_automation/commands/system/skills_sync/_state_git.py
+++ b/src/youtube_automation/commands/system/skills_sync/_state_git.py
@@ -1,0 +1,64 @@
+"""Explicit migration of downstream workflow control-plane JSON into Git."""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import sys
+
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.infrastructure.vcs.state_git import (
+    STATE_GITIGNORE_MARKER,
+    StateGitContext,
+    apply_state_git,
+    build_context,
+    check_state_git,
+    planned_gitignore,
+)
+
+
+def _print_plan(context: StateGitContext) -> None:
+    before = context.gitignore.read_text(encoding="utf-8").splitlines(keepends=True)
+    after = planned_gitignore(context).splitlines(keepends=True)
+    print(
+        "".join(
+            difflib.unified_diff(
+                before,
+                after,
+                fromfile=f"{context.gitignore.relative_to(context.channel_dir)} (before)",
+                tofile=f"{context.gitignore.relative_to(context.channel_dir)} (after)",
+            )
+        ),
+        end="",
+    )
+    for path in context.control_files:
+        print(f"Git管理へ追加: {path.relative_to(context.channel_dir).as_posix()}")
+
+
+def cmd_migrate_state_git(args: argparse.Namespace) -> int:
+    try:
+        context = build_context(args.channel_dir)
+        if args.check:
+            diagnostics = check_state_git(context)
+            if diagnostics:
+                for diagnostic in diagnostics:
+                    print(f"error: {diagnostic}", file=sys.stderr)
+                return 1
+            print("state Git管理チェック合格")
+            return 0
+        from youtube_automation.infrastructure.vcs.state_git import validate_migration_worktree
+
+        validate_migration_worktree(context)
+        _print_plan(context)
+        if args.dry_run:
+            print("dry-run 完了（変更なし）")
+            return 0
+        apply_state_git(context)
+    except (ConfigError, OSError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    print("移行準備完了: 差分を確認してcommitしてください")
+    return 0
+
+
+__all__ = ["STATE_GITIGNORE_MARKER", "cmd_migrate_state_git"]

--- a/src/youtube_automation/commands/system/skills_sync/_sync.py
+++ b/src/youtube_automation/commands/system/skills_sync/_sync.py
@@ -133,6 +133,16 @@ def _sync_file_asset(
     target = _resolve_file_target(args.asset, spec, target)
     _ensure_target_parent(target)
 
+    if args.asset == "channel-gitignore" and (target.exists() or target.is_symlink()):
+        print(f"  {'skipped':>8}: {target.name}")
+        print(
+            "  既存 .gitignore は上書きしません。制御面JSONのGit管理移行は "
+            "`yt-skills migrate-state-git --channel-dir <path> --dry-run` で確認してください。"
+        )
+        print()
+        print("完了: 1 件処理 — {'skipped': 1}")
+        return 0
+
     op = _symlink_entry if args.symlink else _copy_entry
     result = op(src, target, force=args.force, dry_run=args.dry_run)
     prefix = "[dry-run] " if args.dry_run else ""

--- a/src/youtube_automation/infrastructure/resources/channel/__init__.py
+++ b/src/youtube_automation/infrastructure/resources/channel/__init__.py
@@ -1,0 +1,1 @@
+"""Downstream channel repository templates."""

--- a/src/youtube_automation/infrastructure/resources/channel/gitignore.template
+++ b/src/youtube_automation/infrastructure/resources/channel/gitignore.template
@@ -1,0 +1,20 @@
+# Local environment
+.env
+.direnv/
+.venv/
+
+# Python
+__pycache__/
+*.pyc
+
+# OAuth credentials
+auth/client_secrets.json
+auth/token*.json
+
+# yt-state-git control plane (ADR-0024)
+!collections/
+!collections/**/
+!collections/**/workflow-state.json
+!collections/**/20-documentation/upload_tracking.json
+!post_publish_history.json
+!pinned_comment_history.json

--- a/src/youtube_automation/infrastructure/vcs/state_git.py
+++ b/src/youtube_automation/infrastructure/vcs/state_git.py
@@ -1,0 +1,320 @@
+"""Git-managed workflow control-plane migration for downstream channels."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from importlib.resources import files
+from pathlib import Path
+from typing import Final
+
+from youtube_automation.core.errors import ConfigError
+
+STATE_GITIGNORE_MARKER: Final[str] = "# yt-state-git control plane (ADR-0024)"
+_ROOT_HISTORY_NAMES: Final[tuple[str, ...]] = (
+    "post_publish_history.json",
+    "pinned_comment_history.json",
+)
+_SENSITIVE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "access_token",
+        "api_key",
+        "authorization",
+        "client_secret",
+        "cookie",
+        "password",
+        "private_key",
+        "refresh_token",
+        "resume_session_uri",
+        "resumable_session_uri",
+        "upload_session_uri",
+    }
+)
+_SENSITIVE_VALUE_MARKERS: Final[tuple[str, ...]] = (
+    "-----BEGIN PRIVATE KEY-----",
+    "Bearer ",
+    "ya29.",
+)
+_MAX_CONTROL_FILE_BYTES: Final[int] = 16 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class StateGitContext:
+    channel_dir: Path
+    repository: Path
+    gitignore: Path
+    control_files: tuple[Path, ...]
+
+
+def channel_gitignore_template() -> str:
+    resource = files("youtube_automation.infrastructure.resources.channel").joinpath("gitignore.template")
+    return resource.read_text(encoding="utf-8")
+
+
+def state_gitignore_block() -> str:
+    template = channel_gitignore_template()
+    marker_at = template.index(STATE_GITIGNORE_MARKER)
+    return template[marker_at:].rstrip() + "\n"
+
+
+def _run_git(repository: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _regular_directory(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ConfigError(f"{label} に symlink は使えません: {path}")
+    if not path.is_dir():
+        raise ConfigError(f"{label} が存在しません: {path}")
+
+
+def _regular_file(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise ConfigError(f"{label} に symlink は使えません: {path}")
+    if not path.is_file():
+        raise ConfigError(f"{label} が存在しません: {path}")
+
+
+def _collection_control_files(channel_dir: Path) -> list[Path]:
+    collections = channel_dir / "collections"
+    if not collections.exists() and not collections.is_symlink():
+        return []
+    _regular_directory(collections, label="collections directory")
+    discovered: list[Path] = []
+    for stage in sorted(collections.iterdir(), key=lambda path: path.name):
+        if stage.is_symlink():
+            raise ConfigError(f"collections 配下に symlink は使えません: {stage}")
+        if not stage.is_dir():
+            continue
+        for collection in sorted(stage.iterdir(), key=lambda path: path.name):
+            if collection.is_symlink():
+                raise ConfigError(f"collection に symlink は使えません: {collection}")
+            if not collection.is_dir():
+                continue
+            state = collection / "workflow-state.json"
+            if state.exists() or state.is_symlink():
+                _regular_file(state, label="workflow-state.json")
+                discovered.append(state)
+            docs = collection / "20-documentation"
+            if docs.is_symlink():
+                raise ConfigError(f"20-documentation に symlink は使えません: {docs}")
+            tracking = docs / "upload_tracking.json"
+            if tracking.exists() or tracking.is_symlink():
+                _regular_file(tracking, label="upload_tracking.json")
+                discovered.append(tracking)
+    return discovered
+
+
+def _discover_control_files(channel_dir: Path) -> tuple[Path, ...]:
+    discovered = _collection_control_files(channel_dir)
+    for name in _ROOT_HISTORY_NAMES:
+        path = channel_dir / name
+        if path.exists() or path.is_symlink():
+            _regular_file(path, label=name)
+            discovered.append(path)
+    return tuple(sorted(discovered))
+
+
+def _contains_secret(value: object, *, key: str | None = None) -> bool:
+    normalized_key = re.sub(r"(?<!^)(?=[A-Z])", "_", key or "").lower().replace("-", "_")
+    key_is_sensitive = (
+        normalized_key in _SENSITIVE_KEYS
+        or normalized_key.endswith("_token")
+        or normalized_key.endswith("_session_uri")
+        or "secret" in normalized_key
+    )
+    if key_is_sensitive and value not in (None, "", [], {}):
+        return True
+    if isinstance(value, dict):
+        return any(_contains_secret(child, key=str(child_key).lower()) for child_key, child in value.items())
+    if isinstance(value, list):
+        return any(_contains_secret(child) for child in value)
+    if isinstance(value, str):
+        return any(marker in value for marker in _SENSITIVE_VALUE_MARKERS)
+    return False
+
+
+def _validate_control_file(path: Path) -> None:
+    try:
+        size = path.stat().st_size
+    except OSError as exc:
+        raise ConfigError(f"制御面JSONを検査できません: {path}") from exc
+    if size > _MAX_CONTROL_FILE_BYTES:
+        raise ConfigError(f"制御面JSONが上限を超えています: {path}")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"制御面JSONが不正です: {path}") from exc
+    if _contains_secret(value):
+        raise ConfigError(f"secretを含む可能性があるためGit管理へ移行できません: {path}")
+
+
+def build_context(channel_dir: Path) -> StateGitContext:
+    raw = channel_dir.expanduser()
+    if raw.is_symlink():
+        raise ConfigError(f"channel directory に symlink は使えません: {raw}")
+    _regular_directory(raw, label="channel directory")
+    channel = raw.resolve()
+    top_level = _run_git(channel, "rev-parse", "--show-toplevel")
+    if top_level.returncode != 0:
+        raise ConfigError(f"channel directory は Git repository 内でなければなりません: {channel}")
+    repository = Path(top_level.stdout.strip()).resolve()
+    if not channel.is_relative_to(repository):
+        raise ConfigError(f"channel directory が Git repository 外です: {channel}")
+    gitignore = channel / ".gitignore"
+    _regular_file(gitignore, label="channel .gitignore")
+    control_files = _discover_control_files(channel)
+    for path in control_files:
+        _validate_control_file(path)
+    return StateGitContext(channel, repository, gitignore, control_files)
+
+
+def _repo_relative(context: StateGitContext, path: Path) -> str:
+    return path.relative_to(context.repository).as_posix()
+
+
+def _read_gitignore(context: StateGitContext) -> str:
+    try:
+        return context.gitignore.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as exc:
+        raise ConfigError(f"channel .gitignoreを読み取れません: {context.gitignore}") from exc
+
+
+def _changed_paths(context: StateGitContext, *, cached: bool) -> set[str]:
+    args = ["diff", "--name-only"]
+    if cached:
+        args.insert(1, "--cached")
+    result = _run_git(context.repository, *args, "--")
+    if result.returncode != 0:
+        raise ConfigError("Gitの変更状態を確認できません")
+    return set(result.stdout.splitlines())
+
+
+def _untracked_paths(context: StateGitContext) -> set[str]:
+    result = _run_git(context.repository, "ls-files", "--others", "--exclude-standard")
+    if result.returncode != 0:
+        raise ConfigError("Gitの未追跡状態を確認できません")
+    return set(result.stdout.splitlines())
+
+
+def validate_migration_worktree(context: StateGitContext) -> None:
+    allowed = {
+        _repo_relative(context, context.gitignore),
+        *(_repo_relative(context, path) for path in context.control_files),
+    }
+    marker_present = STATE_GITIGNORE_MARKER in _read_gitignore(context)
+    unstaged = _changed_paths(context, cached=False)
+    staged = _changed_paths(context, cached=True)
+    untracked = _untracked_paths(context)
+    unrelated = (unstaged | staged | untracked) - allowed
+    if unrelated or (not marker_present and (_repo_relative(context, context.gitignore) in unstaged | staged)):
+        raise ConfigError("作業ツリーに移行対象外の staged / dirty / untracked 変更があります")
+
+
+def _is_tracked(context: StateGitContext, path: Path) -> bool:
+    result = _run_git(context.repository, "ls-files", "--error-unmatch", "--", _repo_relative(context, path))
+    return result.returncode == 0
+
+
+def _policy_probe_paths(context: StateGitContext) -> tuple[str, ...]:
+    probe_root = context.channel_dir / "collections" / "planning" / "__yt_state_git_probe__"
+    return (
+        _repo_relative(context, probe_root / "workflow-state.json"),
+        _repo_relative(context, probe_root / "20-documentation" / "upload_tracking.json"),
+        _repo_relative(context, context.channel_dir / "post_publish_history.json"),
+        _repo_relative(context, context.channel_dir / "pinned_comment_history.json"),
+    )
+
+
+def _ignored_policy_paths(context: StateGitContext) -> tuple[str, ...]:
+    ignored: list[str] = []
+    for relative in _policy_probe_paths(context):
+        result = _run_git(context.repository, "check-ignore", "--no-index", "--quiet", "--", relative)
+        if result.returncode == 0:
+            ignored.append(relative)
+        elif result.returncode != 1:
+            raise ConfigError(f"Git ignore状態を確認できません: {relative}")
+    return tuple(ignored)
+
+
+def check_state_git(context: StateGitContext) -> tuple[str, ...]:
+    diagnostics: list[str] = []
+    if STATE_GITIGNORE_MARKER not in _read_gitignore(context):
+        diagnostics.append(f"Git管理ポリシーがありません: {_repo_relative(context, context.gitignore)}")
+    for relative in _ignored_policy_paths(context):
+        diagnostics.append(f"制御面JSONがignoreされています: {relative}")
+    changed = _changed_paths(context, cached=False) | _changed_paths(context, cached=True)
+    untracked = _untracked_paths(context)
+    for path in context.control_files:
+        relative = _repo_relative(context, path)
+        if not _is_tracked(context, path):
+            diagnostics.append(f"未追跡の制御面JSONです: {relative}")
+        elif relative in changed:
+            diagnostics.append(f"未commitの制御面JSONです: {relative}")
+    gitignore_relative = _repo_relative(context, context.gitignore)
+    if gitignore_relative in changed or gitignore_relative in untracked:
+        diagnostics.append(f"Git管理ポリシーが未commitです: {gitignore_relative}")
+    unrelated = (changed | untracked) - {
+        gitignore_relative,
+        *(_repo_relative(context, path) for path in context.control_files),
+    }
+    if unrelated:
+        diagnostics.append("作業ツリーに未commitの変更があります")
+    return tuple(diagnostics)
+
+
+def planned_gitignore(context: StateGitContext) -> str:
+    current = _read_gitignore(context)
+    block = state_gitignore_block()
+    if current.endswith(block):
+        return current
+    if block in current:
+        current = current.replace(block, "").rstrip() + "\n"
+    separator = "" if not current or current.endswith("\n\n") else "\n" if current.endswith("\n") else "\n\n"
+    return current + separator + block
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    mode = path.stat().st_mode & 0o777
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=path.parent)
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            os.fchmod(stream.fileno(), mode)
+            stream.write(text)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+        raise
+
+
+def apply_state_git(context: StateGitContext) -> None:
+    validate_migration_worktree(context)
+    before = context.gitignore.read_bytes()
+    planned = planned_gitignore(context)
+    try:
+        if planned != before.decode("utf-8"):
+            _atomic_write(context.gitignore, planned)
+        paths = [context.gitignore, *context.control_files]
+        ignored_paths = _ignored_policy_paths(context)
+        if ignored_paths:
+            raise ConfigError(f"Git ignoreを解除できません: {ignored_paths[0]}")
+        added = _run_git(context.repository, "add", "--", *(_repo_relative(context, path) for path in paths))
+        if added.returncode != 0:
+            raise ConfigError("Git indexへ制御面JSONを追加できません")
+    except (ConfigError, OSError) as exc:
+        if context.gitignore.read_bytes() != before:
+            _atomic_write(context.gitignore, before.decode("utf-8"))
+        raise ConfigError("state Git管理への移行に失敗しました。既存.gitignoreを復元しました") from exc

--- a/tests/commands/channel/test_channel_init.py
+++ b/tests/commands/channel/test_channel_init.py
@@ -128,6 +128,17 @@ def test_main_does_not_create_setup_owned_directories_when_target_is_empty(tmp_p
     assert not (tmp_path / "auth" / ".gitkeep").exists()
 
 
+def test_new_channel_gitignore_keeps_control_plane_json_in_git(tmp_path):
+    assert main(_required_args(tmp_path)) == 0
+
+    gitignore = (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert "# yt-state-git control plane (ADR-0024)" in gitignore
+    assert "!collections/**/workflow-state.json" in gitignore
+    assert "!collections/**/20-documentation/upload_tracking.json" in gitignore
+    assert "!post_publish_history.json" in gitignore
+    assert "!pinned_comment_history.json" in gitignore
+
+
 # ===================== Case 3: --short / --name が meta.json に反映 =====================
 
 

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -42,6 +42,9 @@ def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     (tmp_path / ".claude" / "settings.template.json").write_text(
         '{"permissions": {"allow": [], "deny": []}, "hooks": {}}\n', encoding="utf-8"
     )
+    channel_resources = tmp_path / "src" / "youtube_automation" / "infrastructure" / "resources" / "channel"
+    channel_resources.mkdir(parents=True)
+    (channel_resources / "gitignore.template").write_text("# channel gitignore\n", encoding="utf-8")
 
     monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
     return tmp_path
@@ -144,6 +147,32 @@ def test_cmd_sync_default_all_includes_auth_template(
     assert (downstream / "docs" / "workflow-cheatsheet.md").exists()
     assert (downstream / "docs" / "features.md").exists()
     assert (downstream / "auth" / "client_secrets.template.json").exists()
+    assert "# yt-state-git control plane (ADR-0024)" in (downstream / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_cmd_sync_never_overwrites_existing_channel_gitignore_even_with_force(
+    fake_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    downstream = tmp_path / "downstream"
+    downstream.mkdir()
+    gitignore = downstream / ".gitignore"
+    gitignore.write_text("# local policy\n", encoding="utf-8")
+    monkeypatch.chdir(downstream)
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "channel-gitignore", "--force"])
+    skills_sync._resolve_default_target(args)
+    assert args.func(args) == 0
+
+    assert gitignore.read_text(encoding="utf-8") == "# local policy\n"
+    assert "migrate-state-git" in capsys.readouterr().out
+
+
+def test_migrate_state_git_requires_explicit_channel_dir() -> None:
+    parser = build_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["migrate-state-git", "--check"])
+    assert exc_info.value.code == 2
 
 
 def test_cmd_sync_all_keeps_target_unset_after_resolve() -> None:

--- a/tests/commands/system/test_skills_sync_package.py
+++ b/tests/commands/system/test_skills_sync_package.py
@@ -57,6 +57,18 @@ def test_default_all_assets_include_auth_template_target() -> None:
     all_targets = {spec["default_target"] for spec in _ASSET_SPECS.values()}
     assert "auth/client_secrets.template.json" in all_targets
     assert ".claude/settings.json" in all_targets
+    assert ".gitignore" in all_targets
+
+
+def test_channel_gitignore_asset_is_packaged_with_state_git_policy() -> None:
+    from youtube_automation.commands.system.skills_sync import _ASSET_SPECS, _asset_root
+
+    spec = _ASSET_SPECS["channel-gitignore"]
+    template = _asset_root("channel-gitignore") / spec["source_filename"]
+    text = template.read_text(encoding="utf-8")
+    assert spec["default_target"] == ".gitignore"
+    assert "# yt-state-git control plane (ADR-0024)" in text
+    assert "auth/token*.json" in text
 
 
 def test_auth_template_is_included_in_wheel_and_sdist_manifests() -> None:

--- a/tests/commands/system/test_state_git_migration.py
+++ b/tests/commands/system/test_state_git_migration.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.commands.system.skills_sync import main
+from youtube_automation.commands.system.skills_sync._state_git import STATE_GITIGNORE_MARKER
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _init_repo(path: Path, *, gitignore: str = "collections/**\n*.json\n") -> Path:
+    path.mkdir()
+    assert _git(path, "init", "-q").returncode == 0
+    assert _git(path, "config", "user.email", "test@example.com").returncode == 0
+    assert _git(path, "config", "user.name", "Test").returncode == 0
+    (path / ".gitignore").write_text(gitignore, encoding="utf-8")
+    (path / "config" / "channel").mkdir(parents=True)
+    (path / "config" / "channel" / "meta.json").write_text('{"channel": {"name": "test"}}\n', encoding="utf-8")
+    assert _git(path, "add", ".gitignore").returncode == 0
+    assert _git(path, "add", "-f", "config/channel/meta.json").returncode == 0
+    assert _git(path, "commit", "-qm", "initial").returncode == 0
+    return path
+
+
+def _write_control_files(channel: Path) -> tuple[Path, ...]:
+    collection = channel / "collections" / "planning" / "demo"
+    docs = collection / "20-documentation"
+    docs.mkdir(parents=True)
+    state = collection / "workflow-state.json"
+    tracking = docs / "upload_tracking.json"
+    post_publish = channel / "post_publish_history.json"
+    pinned = channel / "pinned_comment_history.json"
+    state.write_text('{"phase": "planning"}\n', encoding="utf-8")
+    tracking.write_text('{"schema_version": 3}\n', encoding="utf-8")
+    post_publish.write_text("[]\n", encoding="utf-8")
+    pinned.write_text("[]\n", encoding="utf-8")
+    return state, tracking, post_publish, pinned
+
+
+def test_dry_run_lists_only_channel_control_files_without_mutation(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    files = _write_control_files(channel)
+    nested = channel / ".claude" / "worktrees" / "other" / "collections" / "live" / "wrong"
+    nested.mkdir(parents=True)
+    (nested / "workflow-state.json").write_text('{"secret": "do-not-read"}\n', encoding="utf-8")
+    before_ignore = (channel / ".gitignore").read_bytes()
+    before_status = _git(channel, "status", "--porcelain=v1", "--ignored").stdout
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 0
+
+    output = capsys.readouterr().out
+    assert all(path.relative_to(channel).as_posix() in output for path in files)
+    assert ".claude/worktrees" not in output
+    assert (channel / ".gitignore").read_bytes() == before_ignore
+    assert _git(channel, "status", "--porcelain=v1", "--ignored").stdout == before_status
+
+
+def test_apply_stages_policy_and_control_files_then_check_passes_after_commit(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    files = _write_control_files(channel)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+
+    ignore = (channel / ".gitignore").read_text(encoding="utf-8")
+    assert STATE_GITIGNORE_MARKER in ignore
+    staged = set(_git(channel, "diff", "--cached", "--name-only").stdout.splitlines())
+    assert staged == {".gitignore", *(path.relative_to(channel).as_posix() for path in files)}
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 1
+    assert "commit" in capsys.readouterr().err
+
+    assert _git(channel, "commit", "-qm", "manage state").returncode == 0
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 0
+
+
+def test_apply_is_idempotent_while_generated_changes_are_staged(tmp_path: Path) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    _write_control_files(channel)
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+    before_ignore = (channel / ".gitignore").read_bytes()
+    before_index = _git(channel, "diff", "--cached", "--binary").stdout
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+
+    assert (channel / ".gitignore").read_bytes() == before_ignore
+    assert _git(channel, "diff", "--cached", "--binary").stdout == before_index
+
+
+@pytest.mark.parametrize("kind", ["staged", "dirty"])
+def test_apply_refuses_unrelated_repository_changes(tmp_path: Path, capsys, kind: str) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    _write_control_files(channel)
+    unrelated = channel / "notes.md"
+    unrelated.write_text("before\n", encoding="utf-8")
+    assert _git(channel, "add", "notes.md").returncode == 0
+    assert _git(channel, "commit", "-qm", "notes").returncode == 0
+    unrelated.write_text("after\n", encoding="utf-8")
+    if kind == "staged":
+        assert _git(channel, "add", "notes.md").returncode == 0
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 1
+
+    assert "作業ツリー" in capsys.readouterr().err
+    assert STATE_GITIGNORE_MARKER not in (channel / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_secret_bearing_tracking_fails_closed_without_leaking_value(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    _, tracking, *_ = _write_control_files(channel)
+    secret = "ya29.secret-value"
+    tracking.write_text(json.dumps({"resume_session_uri": secret}), encoding="utf-8")
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 1
+
+    captured = capsys.readouterr()
+    assert "secret" in captured.err.lower()
+    assert secret not in captured.out + captured.err
+    assert STATE_GITIGNORE_MARKER not in (channel / ".gitignore").read_text(encoding="utf-8")
+
+
+def test_missing_gitignore_and_non_repository_fail_closed(tmp_path: Path, capsys) -> None:
+    not_repo = tmp_path / "not-repo"
+    not_repo.mkdir()
+    assert main(["migrate-state-git", "--channel-dir", str(not_repo), "--check"]) == 1
+    assert "Git repository" in capsys.readouterr().err
+
+    channel = _init_repo(tmp_path / "channel")
+    (channel / ".gitignore").unlink()
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 1
+    assert ".gitignore" in capsys.readouterr().err
+
+
+def test_symlinked_collection_is_rejected_without_reading_external_data(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    outside = tmp_path / "real-data"
+    outside.mkdir()
+    (outside / "workflow-state.json").write_text('{"phase": "secret outside data"}\n', encoding="utf-8")
+    live = channel / "collections" / "live"
+    live.mkdir(parents=True)
+    (live / "linked").symlink_to(outside, target_is_directory=True)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 1
+
+    captured = capsys.readouterr()
+    assert "symlink" in captured.err
+    assert "secret outside data" not in captured.out + captured.err
+
+
+def test_check_rejects_untracked_control_file_even_when_policy_exists(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel", gitignore="")
+    state, *_ = _write_control_files(channel)
+    with (channel / ".gitignore").open("a", encoding="utf-8") as stream:
+        stream.write("\n" + STATE_GITIGNORE_MARKER + "\n")
+    assert _git(channel, "add", ".gitignore").returncode == 0
+    assert _git(channel, "commit", "-qm", "policy").returncode == 0
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 1
+
+    assert state.relative_to(channel).as_posix() in capsys.readouterr().err
+
+
+def test_apply_moves_existing_policy_to_end_when_later_rule_reignores_state(tmp_path: Path) -> None:
+    channel = _init_repo(tmp_path / "channel", gitignore="")
+    template = (
+        "# yt-state-git control plane (ADR-0024)\n"
+        "!collections/\n"
+        "!collections/**/\n"
+        "!collections/**/workflow-state.json\n"
+        "!collections/**/20-documentation/upload_tracking.json\n"
+        "!post_publish_history.json\n"
+        "!pinned_comment_history.json\n"
+    )
+    (channel / ".gitignore").write_text(template + "collections/**\n", encoding="utf-8")
+    assert _git(channel, "add", ".gitignore").returncode == 0
+    assert _git(channel, "commit", "-qm", "stale policy").returncode == 0
+    state, *_ = _write_control_files(channel)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 1
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+
+    assert (channel / ".gitignore").read_text(encoding="utf-8").endswith(template)
+    assert state.relative_to(channel).as_posix() in _git(channel, "diff", "--cached", "--name-only").stdout

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -13,6 +13,7 @@ from tests.helpers.paths import REPO_ROOT
 from youtube_automation.domains.skills.inventory import SkillInventory
 
 _FILE_ASSETS = {
+    Path(".gitignore"): Path("src/youtube_automation/infrastructure/resources/channel/gitignore.template"),
     Path(".claude/CLAUDE.md"): Path(".claude/CLAUDE.template.md"),
     Path("docs/workflow-cheatsheet.md"): Path("docs/workflow-cheatsheet.md"),
     Path("docs/features.md"): Path("docs/features.md"),
@@ -466,7 +467,7 @@ assert "wheel-identity-check" not in legacy._cache
 
     diffed = _run(yt_skills, "diff", cwd=downstream, env=clean_env)
     assert diffed.returncode == 0, diffed.stdout + diffed.stderr
-    assert diffed.stdout.count("差分なし") == 5
+    assert diffed.stdout.count("差分なし") == 6
     assert "hooks.PreToolUse" in diffed.stdout
 
 


### PR DESCRIPTION
## 概要

workflow-state、upload tracking、post-publish、pinned historyをGit管理対象へ移し、既存channelを安全に移行できる明示コマンドを追加します。

## 変更内容

- 新規channelとskill同期で正準 `.gitignore` を生成
- `yt-skills migrate-state-git` に check / dry-run / apply を追加
- secret、symlink、dirty/staged/untracked、誤repository走査をfail-closed化
- template、wheel、利用者導線とCHANGELOGを追従

## 検証

- focused: 214 passed
- full（rebase前）: 9432 passed, 3 skipped
- ruff check / format、yt-skills lint、build、wheel installed smoke: green

Closes #4049