### PR TITLE
issue 4050 state sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
 - `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。
 - `feat(hybrid)`: 工程境界専用の `MediaStore` port と checksum 検証付き Local / Cloudflare R2 adapterを追加し、bucket・prefix・path・symlink 境界と secret 解決を fail-closed に固定する（#4044）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -92,7 +92,7 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 ### クラウド移譲
 
-**workflow-state**: collection の制作・公開進捗を Git 管理の `workflow-state.json` に保持する制御面 document。schema の正本と読み書き owner は `domains.collections.workflow_state` であり、追従文書は `.claude/skills/wf-new/references/schema.md`。新規 consumer は owner の `read()` / `read_or_none()` / `update()` を使い、JSON の直パース・直接書き込みを追加しない。既存の直アクセスは段階移行対象で、未知キーを保持したまま移行する。ADR-0024 の single-writer 原則では `phase` が local / cloud 間の引き渡しトークンとなり、R2 のメディアデータとは分離する。
+**workflow-state**: collection の制作・公開進捗を Git 管理の `workflow-state.json` に保持する制御面 document。schema の正本と読み書き owner は `domains.collections.workflow_state` であり、追従文書は `.claude/skills/wf-new/references/schema.md`。新規 consumer は owner の `read()` / `read_or_none()` / `update()` を使い、JSON の直パース・直接書き込みを追加しない。既存の直アクセスは段階移行対象で、未知キーを保持したまま移行する。Git同期境界は `infrastructure.vcs.state_sync` が所有し、読む前のfast-forward pullと更新後のcommit + pushを強制する。non-fast-forwardは通知eventを発火して自動merge/rebaseなしで停止する。ADR-0024 の single-writer 原則では `phase` が local / cloud 間の引き渡しトークンとなり、R2 のメディアデータとは分離する。
 
 **制御面 / データ面**: ハイブリッド制作基盤の 2 面。制御面は Git（`workflow-state.json` と冪等性 tracking 群が正本）、データ面は R2（メディアの受け渡し）で、状態をデータ面に置かない（ADR-0024）。
 

--- a/docs/migration/state-git-control-plane.md
+++ b/docs/migration/state-git-control-plane.md
@@ -22,4 +22,8 @@ uv run yt-skills migrate-state-git --channel-dir /absolute/path/to/channel --che
 
 移行コマンドはリポジトリ全域を再帰走査せず、指定した channel root の既知の配置だけを検査します。対象 JSON の symlink、壊れた JSON、secret 候補、移行対象外の staged / dirty / untracked 変更を検出した場合は `.gitignore` や Git index を変更せず停止します。`upload_tracking.json` に resumable upload session URI が残っている場合は、外部 write の再開状態を解消してから再実行してください。
 
-`--check` はポリシーと対象 JSON が commit 済みで、未追跡・staged・dirty でないことを検査します。対象ファイルがまだ生成されていない新規チャンネルでは、ポリシーが commit 済みなら合格します。pull / commit / push の実行時強制と non-fast-forward 停止は後続の Git state owner が担当します。
+`--check` はポリシーと対象 JSON が commit 済みで、未追跡・staged・dirty でないことを検査します。対象ファイルがまだ生成されていない新規チャンネルでは、ポリシーが commit 済みなら合格します。
+
+実行時は `infrastructure.vcs.state_sync` が ADR-0024 の同期境界を所有します。reader は `pull_then_read()`、writer は `pull_update_commit_push()` を使い、後者には state owner の更新 callback と1行の commit messageを渡します。writer が変更できるのは既知の制御面 JSON だけです。開始時に worktree が clean でない場合、pull が fast-forward できない場合、または対象外ファイルが変更された場合は停止します。
+
+push が non-fast-forward で拒否された場合は自動 merge / rebase / retryを行いません。`StateSyncEventKind.NON_FAST_FORWARD` を `on_event` callbackへ1回渡して `StateSyncError` で停止するため、呼び出し側はこのeventをDiscord等の通知adapterへ接続できます。event payloadはrepository pathと固定診断だけを持ち、remote URLや認証情報を含みません。競合解消は工程所有者が明示的に行ってください。

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -133,6 +133,10 @@ class MediaHandoffNotFoundError(MediaStoreError):
     """完了マーカーが無く、受け渡し物が未完成または存在しない。"""
 
 
+class StateSyncError(AutomationError):
+    """Git制御面stateのpull / commit / push同期エラー。"""
+
+
 def _http_error_reason(error) -> str | None:
     content = getattr(error, "content", b"")
     if isinstance(content, bytes):

--- a/src/youtube_automation/infrastructure/vcs/state_sync.py
+++ b/src/youtube_automation/infrastructure/vcs/state_sync.py
@@ -1,0 +1,145 @@
+"""Git control-plane state synchronization boundary.
+
+ADR-0024 の single-writer 前提を保ったまま、state を読む前の fast-forward
+pull と、更新後の commit + push を一呼び出しに閉じ込める。分散ロックや競合の
+自動解消は行わない。
+"""
+
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TypeVar
+
+from youtube_automation.core.errors import StateSyncError
+from youtube_automation.infrastructure.vcs.state_git import StateGitContext, build_context
+
+T = TypeVar("T")
+
+
+class StateSyncEventKind(StrEnum):
+    """呼び出し側の通知adapterへ渡す同期イベント種別。"""
+
+    NON_FAST_FORWARD = "non_fast_forward"
+
+
+@dataclass(frozen=True, slots=True)
+class StateSyncEvent:
+    """secretやremote URLを含まない通知用event。"""
+
+    kind: StateSyncEventKind
+    repository: Path
+    message: str
+
+
+EventSink = Callable[[StateSyncEvent], None]
+
+
+def _run_git(repository: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repository,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _require_clean(repository: Path) -> None:
+    status = _run_git(repository, "status", "--porcelain=v1", "--untracked-files=all")
+    if status.returncode != 0:
+        raise StateSyncError("Git worktreeの状態を確認できません")
+    if status.stdout:
+        raise StateSyncError("state同期の開始前にGit worktreeをcleanにしてください")
+
+
+def _pull_fast_forward(repository: Path) -> None:
+    pulled = _run_git(repository, "pull", "--ff-only")
+    if pulled.returncode != 0:
+        raise StateSyncError("stateを読む前のgit pull --ff-onlyに失敗しました")
+
+
+def _paths(repository: Path, *args: str) -> set[str]:
+    result = _run_git(repository, *args)
+    if result.returncode != 0:
+        raise StateSyncError("Gitの変更pathを確認できません")
+    return set(result.stdout.splitlines())
+
+
+def _changed_paths(repository: Path) -> set[str]:
+    return (
+        _paths(repository, "diff", "--name-only", "--")
+        | _paths(repository, "diff", "--cached", "--name-only", "--")
+        | _paths(repository, "ls-files", "--others", "--exclude-standard")
+    )
+
+
+def _relative_control_paths(*contexts: StateGitContext) -> set[str]:
+    repository = contexts[0].repository
+    return {path.relative_to(repository).as_posix() for context in contexts for path in context.control_files}
+
+
+def _is_non_fast_forward(push: subprocess.CompletedProcess[str]) -> bool:
+    output = f"{push.stdout}\n{push.stderr}".lower()
+    return "non-fast-forward" in output or "(fetch first)" in output
+
+
+def pull_then_read(context: StateGitContext, reader: Callable[[], T]) -> T:
+    """cleanなrepositoryをfast-forward pullしてからstateを読む。"""
+
+    _require_clean(context.repository)
+    _pull_fast_forward(context.repository)
+    return reader()
+
+
+def pull_update_commit_push(
+    context: StateGitContext,
+    writer: Callable[[], T],
+    *,
+    commit_message: str,
+    on_event: EventSink | None = None,
+) -> T:
+    """pull → state更新 → commit → pushをfail-closedで実行する。
+
+    writer が変更できるのは ``StateGitContext`` が所有する既知の制御面JSONだけ。
+    push競合は自動merge/rebaseせず、通知eventを発火して停止する。
+    """
+
+    if not commit_message.strip() or "\n" in commit_message:
+        raise StateSyncError("state同期のcommit messageは空でない1行を指定してください")
+    _require_clean(context.repository)
+    _pull_fast_forward(context.repository)
+    before = build_context(context.channel_dir)
+    result = writer()
+    after = build_context(context.channel_dir)
+    changed = _changed_paths(context.repository)
+    allowed = _relative_control_paths(before, after)
+    unexpected = changed - allowed
+    if unexpected:
+        raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
+    if not changed:
+        return result
+
+    paths = sorted(changed)
+    added = _run_git(context.repository, "add", "--", *paths)
+    if added.returncode != 0:
+        raise StateSyncError("Git制御面stateをstageできません")
+    committed = _run_git(context.repository, "commit", "-m", commit_message, "--", *paths)
+    if committed.returncode != 0:
+        raise StateSyncError("Git制御面stateをcommitできません")
+    pushed = _run_git(context.repository, "push", "--porcelain")
+    if pushed.returncode == 0:
+        return result
+    if _is_non_fast_forward(pushed):
+        event = StateSyncEvent(
+            kind=StateSyncEventKind.NON_FAST_FORWARD,
+            repository=context.repository,
+            message="state pushがnon-fast-forwardで拒否されました。自動merge/rebaseは行いません。",
+        )
+        if on_event is not None:
+            on_event(event)
+        raise StateSyncError("state pushがnon-fast-forwardで拒否されました")
+    raise StateSyncError("Git制御面stateをpushできません")

--- a/tests/infrastructure/vcs/test_state_sync.py
+++ b/tests/infrastructure/vcs/test_state_sync.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.core.errors import StateSyncError
+from youtube_automation.infrastructure.vcs.state_git import build_context
+from youtube_automation.infrastructure.vcs.state_sync import (
+    StateSyncEvent,
+    StateSyncEventKind,
+    pull_then_read,
+    pull_update_commit_push,
+)
+
+
+def _git(directory: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=directory,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return completed.stdout.strip()
+
+
+def _write_state(repository: Path, phase: str) -> Path:
+    state = repository / "collections" / "planning" / "sample" / "workflow-state.json"
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text(json.dumps({"phase": phase}) + "\n", encoding="utf-8")
+    return state
+
+
+def _clone(remote: Path, destination: Path) -> Path:
+    subprocess.run(
+        ["git", "clone", str(remote), str(destination)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _git(destination, "config", "user.email", "test@example.com")
+    _git(destination, "config", "user.name", "Test User")
+    return destination
+
+
+@pytest.fixture
+def repositories(tmp_path: Path) -> tuple[Path, Path, Path]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init", "--initial-branch=main")
+    _git(seed, "config", "user.email", "test@example.com")
+    _git(seed, "config", "user.name", "Test User")
+    (seed / ".gitignore").write_text("\n", encoding="utf-8")
+    _write_state(seed, "planned")
+    _git(seed, "add", ".gitignore", "collections")
+    _git(seed, "commit", "-m", "initial")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    return remote, _clone(remote, tmp_path / "local-a"), _clone(remote, tmp_path / "local-b")
+
+
+def test_pull_then_read_observes_remote_state(repositories: tuple[Path, Path, Path]) -> None:
+    _, local_a, local_b = repositories
+    _write_state(local_b, "generated")
+    _git(local_b, "add", "collections")
+    _git(local_b, "commit", "-m", "remote update")
+    _git(local_b, "push")
+
+    value = pull_then_read(
+        build_context(local_a),
+        lambda: json.loads(_write_target(local_a).read_text(encoding="utf-8")),
+    )
+
+    assert value["phase"] == "generated"
+
+
+def test_update_commits_and_pushes_control_state(repositories: tuple[Path, Path, Path]) -> None:
+    remote, local_a, _ = repositories
+    state = _write_target(local_a)
+
+    result = pull_update_commit_push(
+        build_context(local_a),
+        lambda: (_write_state(local_a, "mastered"), "updated")[1],
+        commit_message="chore: stateを更新する",
+    )
+
+    verifier = _clone(remote, local_a.parent / "verifier")
+    assert result == "updated"
+    assert json.loads(_write_target(verifier).read_text(encoding="utf-8"))["phase"] == "mastered"
+    assert _git(local_a, "status", "--porcelain") == ""
+    assert state.is_file()
+
+
+def test_concurrent_push_rejection_stops_and_emits_event(
+    repositories: tuple[Path, Path, Path],
+) -> None:
+    remote, local_a, local_b = repositories
+    events: list[StateSyncEvent] = []
+
+    def racing_update() -> None:
+        _write_state(local_a, "local-a")
+        pull_update_commit_push(
+            build_context(local_b),
+            lambda: _write_state(local_b, "local-b"),
+            commit_message="chore: competing state",
+        )
+
+    with pytest.raises(StateSyncError, match="non-fast-forward"):
+        pull_update_commit_push(
+            build_context(local_a),
+            racing_update,
+            commit_message="chore: losing state",
+            on_event=events.append,
+        )
+
+    verifier = _clone(remote, local_a.parent / "race-verifier")
+    assert json.loads(_write_target(verifier).read_text(encoding="utf-8"))["phase"] == "local-b"
+    assert [event.kind for event in events] == [StateSyncEventKind.NON_FAST_FORWARD]
+    assert events[0].repository == local_a.resolve()
+    assert len(_git(local_a, "rev-list", "--parents", "-n", "1", "HEAD").split()) == 2
+    assert _git(local_a, "status", "--porcelain") == ""
+
+
+def test_update_rejects_unrelated_dirty_file_before_writer(
+    repositories: tuple[Path, Path, Path],
+) -> None:
+    _, local_a, _ = repositories
+    unrelated = local_a / "notes.txt"
+    unrelated.write_text("dirty\n", encoding="utf-8")
+    called = False
+
+    def writer() -> None:
+        nonlocal called
+        called = True
+
+    with pytest.raises(StateSyncError, match="clean"):
+        pull_update_commit_push(
+            build_context(local_a),
+            writer,
+            commit_message="chore: stateを更新する",
+        )
+
+    assert called is False
+
+
+def test_update_rejects_changes_outside_control_files(
+    repositories: tuple[Path, Path, Path],
+) -> None:
+    _, local_a, _ = repositories
+    readme = local_a / "README.md"
+
+    with pytest.raises(StateSyncError, match="制御面"):
+        pull_update_commit_push(
+            build_context(local_a),
+            lambda: readme.write_text("unexpected\n", encoding="utf-8"),
+            commit_message="chore: stateを更新する",
+        )
+
+    assert not readme.is_file() or _git(local_a, "status", "--porcelain") == "?? README.md"
+
+
+def test_update_without_changes_does_not_create_commit(repositories: tuple[Path, Path, Path]) -> None:
+    _, local_a, _ = repositories
+    before = _git(local_a, "rev-parse", "HEAD")
+
+    result = pull_update_commit_push(
+        build_context(local_a),
+        lambda: "unchanged",
+        commit_message="chore: stateを更新する",
+    )
+
+    assert result == "unchanged"
+    assert _git(local_a, "rev-parse", "HEAD") == before
+
+
+def _write_target(repository: Path) -> Path:
+    return repository / "collections" / "planning" / "sample" / "workflow-state.json"


### PR DESCRIPTION
## 概要

Git管理された制御面stateを、読む前にfast-forward pullし、更新後は既知JSONだけをcommit+pushする単一境界へ集約します。

## 変更内容

- `pull_then_read` と `pull_update_commit_push` を追加
- clean確認と `pull --ff-only` を必須化
- 既知の制御面JSONだけを更新・commit・push
- non-fast-forwardは自動merge/rebase/retryせず、eventを1回発火して `StateSyncError` で停止
- single-writer境界を維持し、分散lockや通知adapterは追加しない

## 検証

- focused: 404 passed
- full（rebase前）: 9499 passed, 3 skipped
- ruff / format / yt-skills / build / wheel smoke: green

Closes #4050