### PR TITLE
feat(hybrid): R2 multipart転送を中断再開可能にする (#4046)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
+- `feat(hybrid)`: R2 の大容量 push を固定 part の multipart 転送へ切り替え、atomic checkpoint と remote `ListParts` を正本にプロセス中断後の再開・完了済み part のskip・再実行冪等性を追加する（#4046）。
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
 - `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。
 - `feat(hybrid)`: 工程境界専用の `MediaStore` port と checksum 検証付き Local / Cloudflare R2 adapterを追加し、bucket・prefix・path・symlink 境界と secret 解決を fail-closed に固定する（#4044）。

--- a/src/youtube_automation/infrastructure/media_store/r2.py
+++ b/src/youtube_automation/infrastructure/media_store/r2.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import re
+import tempfile
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, Protocol, cast
@@ -12,7 +15,13 @@ from typing import BinaryIO, Protocol, cast
 from youtube_automation.core.errors import ConfigError, MediaStoreError
 from youtube_automation.domains.media_store import MediaKey, MediaObjectMetadata
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
-from youtube_automation.infrastructure.media_store._files import atomic_destination, require_regular_source, sha256_file
+from youtube_automation.infrastructure.file_lock import file_lock
+from youtube_automation.infrastructure.media_store._files import (
+    atomic_destination,
+    reject_symlink_components,
+    require_regular_source,
+    sha256_file,
+)
 from youtube_automation.infrastructure.secrets import get_secret
 
 _BUCKET_RE = re.compile(r"[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]\Z")
@@ -20,6 +29,10 @@ _IDENTIFIER_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9_-]*\Z")
 _PREFIX_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
 _SHA256_RE = re.compile(r"[0-9a-f]{64}\Z")
 _DEFAULT_MULTIPART_CHUNK_SIZE = 100 * 1024 * 1024
+_MINIMUM_MULTIPART_PART_SIZE = 5 * 1024 * 1024
+_MAXIMUM_MULTIPART_PARTS = 10_000
+_MULTIPART_STATE_DIRECTORY = ".yt-r2-multipart"
+_MULTIPART_CHECKPOINT_VERSION = 1
 
 
 class _S3Client(Protocol):
@@ -43,6 +56,71 @@ class _S3Client(Protocol):
     ) -> None: ...
 
     def head_object(self, *, Bucket: str, Key: str) -> dict[str, object]: ...
+
+    def create_multipart_upload(self, *, Bucket: str, Key: str, Metadata: dict[str, str]) -> dict[str, object]: ...
+
+    def upload_part(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        PartNumber: int,
+        UploadId: str,
+        Body: bytes,
+    ) -> dict[str, object]: ...
+
+    def list_parts(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        PartNumberMarker: int | None = None,
+    ) -> dict[str, object]: ...
+
+    def complete_multipart_upload(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        MultipartUpload: dict[str, object],
+    ) -> dict[str, object]: ...
+
+    def abort_multipart_upload(self, *, Bucket: str, Key: str, UploadId: str) -> None: ...
+
+
+@dataclass(frozen=True)
+class MultipartTransferConfig:
+    """R2 multipart の固定境界。test は R2 最小 part size まで縮小できる。"""
+
+    threshold: int = _DEFAULT_MULTIPART_CHUNK_SIZE
+    part_size: int = _DEFAULT_MULTIPART_CHUNK_SIZE
+
+    def __post_init__(self) -> None:
+        if self.threshold < _MINIMUM_MULTIPART_PART_SIZE:
+            raise ConfigError("R2 multipart threshold は 5 MiB 以上にしてください")
+        if self.part_size < _MINIMUM_MULTIPART_PART_SIZE:
+            raise ConfigError("R2 multipart part_size は 5 MiB 以上にしてください")
+
+
+@dataclass(frozen=True)
+class _MultipartCheckpoint:
+    bucket: str
+    object_key: str
+    source_size: int
+    source_sha256: str
+    part_size: int
+    upload_id: str
+
+    def matches(self, *, bucket: str, object_key: str, source_size: int, source_sha256: str, part_size: int) -> bool:
+        return (
+            self.bucket == bucket
+            and self.object_key == object_key
+            and self.source_size == source_size
+            and self.source_sha256 == source_sha256
+            and self.part_size == part_size
+        )
 
 
 def _required_environment(name: str) -> str:
@@ -144,8 +222,10 @@ class R2MediaStore:
         *,
         client: _S3Client | None = None,
         transfer_config: object | None = None,
+        multipart_transfer_config: MultipartTransferConfig | None = None,
     ) -> None:
         self._config = config
+        self._multipart_transfer_config = multipart_transfer_config or MultipartTransferConfig()
         if client is None or transfer_config is None:
             built_client, built_transfer = _build_client(config)
             self._client = client or built_client
@@ -169,20 +249,270 @@ class R2MediaStore:
         size, checksum = sha256_file(source)
         object_key = self._object_key(key)
         try:
-            with source.open("rb") as file_object:
-                self._client.upload_fileobj(
-                    file_object,
-                    self._config.bucket,
-                    object_key,
-                    ExtraArgs={"Metadata": {"sha256": checksum}},
-                    Config=self._transfer_config,
-                )
+            existing = self.metadata(key)
+            if existing is not None and existing.size == size and existing.sha256 == checksum:
+                if size >= self._multipart_transfer_config.threshold:
+                    checkpoint_path = self._checkpoint_path(source, object_key)
+                    with file_lock(checkpoint_path):
+                        checkpoint_path.unlink(missing_ok=True)
+                return existing
+            if size >= self._multipart_transfer_config.threshold:
+                self._push_multipart(source, object_key, size=size, checksum=checksum)
+            else:
+                with source.open("rb") as file_object:
+                    self._client.upload_fileobj(
+                        file_object,
+                        self._config.bucket,
+                        object_key,
+                        ExtraArgs={"Metadata": {"sha256": checksum}},
+                        Config=self._transfer_config,
+                    )
             remote = self.metadata(key)
         except Exception as exc:
             raise self._error("push", exc) from exc
         if remote is None or remote.size != size or remote.sha256 != checksum:
             raise MediaStoreError(f"R2 MediaStore push 後の完全性検証に失敗しました: {key.as_posix()}")
         return remote
+
+    def _push_multipart(self, source: Path, object_key: str, *, size: int, checksum: str) -> None:
+        part_size = self._multipart_transfer_config.part_size
+        part_count = (size + part_size - 1) // part_size
+        if part_count > _MAXIMUM_MULTIPART_PARTS:
+            raise MediaStoreError(f"R2 multipart part 数が上限 {_MAXIMUM_MULTIPART_PARTS} を超えます")
+        checkpoint_path = self._checkpoint_path(source, object_key)
+        with file_lock(checkpoint_path):
+            if self._remote_object_matches(object_key, size=size, checksum=checksum):
+                checkpoint_path.unlink(missing_ok=True)
+                return
+            checkpoint = self._load_checkpoint(checkpoint_path)
+            if checkpoint is not None and (
+                checkpoint.bucket != self._config.bucket or checkpoint.object_key != object_key
+            ):
+                raise MediaStoreError("R2 multipart checkpoint の bucket / key 境界が不正です")
+            if checkpoint is not None and not checkpoint.matches(
+                bucket=self._config.bucket,
+                object_key=object_key,
+                source_size=size,
+                source_sha256=checksum,
+                part_size=part_size,
+            ):
+                self._client.abort_multipart_upload(
+                    Bucket=checkpoint.bucket,
+                    Key=checkpoint.object_key,
+                    UploadId=checkpoint.upload_id,
+                )
+                checkpoint_path.unlink(missing_ok=True)
+                checkpoint = None
+            if checkpoint is None:
+                checkpoint = self._create_multipart_checkpoint(
+                    checkpoint_path,
+                    object_key=object_key,
+                    size=size,
+                    checksum=checksum,
+                    part_size=part_size,
+                )
+            try:
+                completed = self._list_completed_parts(checkpoint, size=size)
+            except Exception as exc:
+                if _status_code(exc) != 404:
+                    raise
+                checkpoint_path.unlink(missing_ok=True)
+                checkpoint = self._create_multipart_checkpoint(
+                    checkpoint_path,
+                    object_key=object_key,
+                    size=size,
+                    checksum=checksum,
+                    part_size=part_size,
+                )
+                completed = {}
+            parts = self._upload_missing_parts(source, checkpoint, completed, part_count=part_count)
+            self._client.complete_multipart_upload(
+                Bucket=self._config.bucket,
+                Key=object_key,
+                UploadId=checkpoint.upload_id,
+                MultipartUpload={"Parts": parts},
+            )
+            checkpoint_path.unlink(missing_ok=True)
+
+    def _remote_object_matches(self, object_key: str, *, size: int, checksum: str) -> bool:
+        try:
+            response = self._client.head_object(Bucket=self._config.bucket, Key=object_key)
+        except Exception as exc:
+            if _status_code(exc) == 404:
+                return False
+            raise
+        metadata = response.get("Metadata")
+        return (
+            response.get("ContentLength") == size and isinstance(metadata, dict) and metadata.get("sha256") == checksum
+        )
+
+    def _checkpoint_path(self, source: Path, object_key: str) -> Path:
+        state_directory = source.parent / _MULTIPART_STATE_DIRECTORY
+        reject_symlink_components(state_directory)
+        state_directory.mkdir(mode=0o700, exist_ok=True)
+        reject_symlink_components(state_directory)
+        identifier = hashlib.sha256(f"{self._config.bucket}\0{object_key}".encode()).hexdigest()
+        return state_directory / f"{identifier}.json"
+
+    def _load_checkpoint(self, path: Path) -> _MultipartCheckpoint | None:
+        if not path.exists():
+            return None
+        if path.is_symlink() or not path.is_file():
+            raise MediaStoreError("R2 multipart checkpoint が通常ファイルではありません")
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict) or payload.get("version") != _MULTIPART_CHECKPOINT_VERSION:
+                raise ValueError("unsupported version")
+            checkpoint = _MultipartCheckpoint(
+                bucket=payload["bucket"],
+                object_key=payload["object_key"],
+                source_size=payload["source_size"],
+                source_sha256=payload["source_sha256"],
+                part_size=payload["part_size"],
+                upload_id=payload["upload_id"],
+            )
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+            raise MediaStoreError("R2 multipart checkpoint が不正です") from exc
+        if (
+            not isinstance(checkpoint.bucket, str)
+            or not isinstance(checkpoint.object_key, str)
+            or not isinstance(checkpoint.source_size, int)
+            or checkpoint.source_size < 0
+            or not isinstance(checkpoint.source_sha256, str)
+            or not _SHA256_RE.fullmatch(checkpoint.source_sha256)
+            or not isinstance(checkpoint.part_size, int)
+            or checkpoint.part_size < _MINIMUM_MULTIPART_PART_SIZE
+            or not isinstance(checkpoint.upload_id, str)
+            or not checkpoint.upload_id
+        ):
+            raise MediaStoreError("R2 multipart checkpoint が不正です")
+        return checkpoint
+
+    def _create_multipart_checkpoint(
+        self,
+        path: Path,
+        *,
+        object_key: str,
+        size: int,
+        checksum: str,
+        part_size: int,
+    ) -> _MultipartCheckpoint:
+        response = self._client.create_multipart_upload(
+            Bucket=self._config.bucket,
+            Key=object_key,
+            Metadata={"sha256": checksum},
+        )
+        upload_id = response.get("UploadId")
+        if not isinstance(upload_id, str) or not upload_id:
+            raise MediaStoreError("R2 multipart upload ID が不正です")
+        checkpoint = _MultipartCheckpoint(
+            bucket=self._config.bucket,
+            object_key=object_key,
+            source_size=size,
+            source_sha256=checksum,
+            part_size=part_size,
+            upload_id=upload_id,
+        )
+        try:
+            self._write_checkpoint(path, checkpoint)
+        except Exception:
+            self._client.abort_multipart_upload(Bucket=self._config.bucket, Key=object_key, UploadId=upload_id)
+            raise
+        return checkpoint
+
+    @staticmethod
+    def _write_checkpoint(path: Path, checkpoint: _MultipartCheckpoint) -> None:
+        payload = {
+            "version": _MULTIPART_CHECKPOINT_VERSION,
+            "bucket": checkpoint.bucket,
+            "object_key": checkpoint.object_key,
+            "source_size": checkpoint.source_size,
+            "source_sha256": checkpoint.source_sha256,
+            "part_size": checkpoint.part_size,
+            "upload_id": checkpoint.upload_id,
+        }
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        temporary = Path(temporary_name)
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as file_object:
+                json.dump(payload, file_object, sort_keys=True)
+                file_object.flush()
+                os.fsync(file_object.fileno())
+            reject_symlink_components(path)
+            os.replace(temporary, path)
+        except Exception:
+            with suppress(OSError):
+                os.close(descriptor)
+            temporary.unlink(missing_ok=True)
+            raise
+
+    def _list_completed_parts(self, checkpoint: _MultipartCheckpoint, *, size: int) -> dict[int, str]:
+        completed: dict[int, str] = {}
+        marker: int | None = None
+        while True:
+            if marker is None:
+                response = self._client.list_parts(
+                    Bucket=checkpoint.bucket,
+                    Key=checkpoint.object_key,
+                    UploadId=checkpoint.upload_id,
+                )
+            else:
+                response = self._client.list_parts(
+                    Bucket=checkpoint.bucket,
+                    Key=checkpoint.object_key,
+                    UploadId=checkpoint.upload_id,
+                    PartNumberMarker=marker,
+                )
+            raw_parts = response.get("Parts", [])
+            if not isinstance(raw_parts, list):
+                raise MediaStoreError("R2 multipart parts 応答が不正です")
+            for raw_part in raw_parts:
+                if not isinstance(raw_part, dict):
+                    raise MediaStoreError("R2 multipart part 応答が不正です")
+                number = raw_part.get("PartNumber")
+                etag = raw_part.get("ETag")
+                part_bytes = raw_part.get("Size")
+                if not isinstance(number, int) or not isinstance(etag, str) or not isinstance(part_bytes, int):
+                    raise MediaStoreError("R2 multipart part 応答が不正です")
+                expected_size = min(checkpoint.part_size, size - (number - 1) * checkpoint.part_size)
+                if number < 1 or expected_size <= 0:
+                    raise MediaStoreError("R2 multipart part 番号が不正です")
+                if part_bytes == expected_size:
+                    completed[number] = etag
+            if response.get("IsTruncated") is not True:
+                return completed
+            next_marker = response.get("NextPartNumberMarker")
+            if not isinstance(next_marker, int) or next_marker <= (marker or 0):
+                raise MediaStoreError("R2 multipart pagination が不正です")
+            marker = next_marker
+
+    def _upload_missing_parts(
+        self,
+        source: Path,
+        checkpoint: _MultipartCheckpoint,
+        completed: dict[int, str],
+        *,
+        part_count: int,
+    ) -> list[dict[str, object]]:
+        parts: list[dict[str, object]] = []
+        with source.open("rb") as file_object:
+            for number in range(1, part_count + 1):
+                body = file_object.read(checkpoint.part_size)
+                etag = completed.get(number)
+                if etag is None:
+                    response = self._client.upload_part(
+                        Bucket=checkpoint.bucket,
+                        Key=checkpoint.object_key,
+                        PartNumber=number,
+                        UploadId=checkpoint.upload_id,
+                        Body=body,
+                    )
+                    etag = response.get("ETag")
+                    if not isinstance(etag, str) or not etag:
+                        raise MediaStoreError("R2 multipart ETag が不正です")
+                parts.append({"PartNumber": number, "ETag": etag})
+        return parts
 
     def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
         remote = self.metadata(key)

--- a/tests/infrastructure/media_store/test_r2.py
+++ b/tests/infrastructure/media_store/test_r2.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import io
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -9,12 +10,16 @@ import pytest
 
 from youtube_automation.core.errors import ConfigError, MediaStoreError
 from youtube_automation.domains.media_store import MediaKey
-from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
+from youtube_automation.infrastructure.media_store.r2 import MultipartTransferConfig, R2MediaStore, R2MediaStoreConfig
 
 
 class FakeS3Client:
     def __init__(self) -> None:
         self.objects: dict[tuple[str, str], tuple[bytes, dict[str, str]]] = {}
+        self.multipart_uploads: dict[str, dict[str, object]] = {}
+        self.create_calls = 0
+        self.uploaded_parts: list[int] = []
+        self.interrupt_part: int | None = None
 
     def upload_fileobj(
         self,
@@ -47,6 +52,88 @@ class FakeS3Client:
         except KeyError as exc:
             raise FakeClientError(404, "missing") from exc
         return {"ContentLength": len(payload), "Metadata": metadata, "ETag": '"fixture-etag"'}
+
+    def create_multipart_upload(self, *, Bucket: str, Key: str, Metadata: dict[str, str]) -> dict[str, object]:
+        self.create_calls += 1
+        upload_id = f"upload-{self.create_calls}"
+        self.multipart_uploads[upload_id] = {
+            "bucket": Bucket,
+            "key": Key,
+            "metadata": Metadata,
+            "parts": {},
+        }
+        return {"UploadId": upload_id}
+
+    def upload_part(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        PartNumber: int,
+        UploadId: str,
+        Body: bytes,
+    ) -> dict[str, object]:
+        upload = self.multipart_uploads[UploadId]
+        assert upload["bucket"] == Bucket
+        assert upload["key"] == Key
+        if self.interrupt_part == PartNumber:
+            self.interrupt_part = None
+            raise RuntimeError("connection interrupted")
+        parts = upload["parts"]
+        assert isinstance(parts, dict)
+        parts[PartNumber] = Body
+        self.uploaded_parts.append(PartNumber)
+        return {"ETag": f'"etag-{PartNumber}"'}
+
+    def list_parts(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        PartNumberMarker: int | None = None,
+    ) -> dict[str, object]:
+        del PartNumberMarker
+        try:
+            upload = self.multipart_uploads[UploadId]
+        except KeyError as exc:
+            raise FakeClientError(404, "NoSuchUpload") from exc
+        assert upload["bucket"] == Bucket
+        assert upload["key"] == Key
+        parts = upload["parts"]
+        assert isinstance(parts, dict)
+        return {
+            "Parts": [
+                {"PartNumber": part_number, "ETag": f'"etag-{part_number}"', "Size": len(payload)}
+                for part_number, payload in sorted(parts.items())
+            ],
+            "IsTruncated": False,
+        }
+
+    def complete_multipart_upload(
+        self,
+        *,
+        Bucket: str,
+        Key: str,
+        UploadId: str,
+        MultipartUpload: dict[str, object],
+    ) -> dict[str, object]:
+        upload = self.multipart_uploads.pop(UploadId)
+        assert upload["bucket"] == Bucket
+        assert upload["key"] == Key
+        parts = upload["parts"]
+        metadata = upload["metadata"]
+        assert isinstance(parts, dict)
+        assert isinstance(metadata, dict)
+        requested = MultipartUpload["Parts"]
+        assert isinstance(requested, list)
+        payload = b"".join(parts[part["PartNumber"]] for part in requested)
+        self.objects[(Bucket, Key)] = (payload, metadata)
+        return {"ETag": '"completed-etag"'}
+
+    def abort_multipart_upload(self, *, Bucket: str, Key: str, UploadId: str) -> None:
+        del Bucket, Key
+        self.multipart_uploads.pop(UploadId, None)
 
 
 class FakeClientError(Exception):
@@ -207,3 +294,69 @@ def test_r2_metadata_without_checksum_is_rejected(tmp_path: Path) -> None:
 
     with pytest.raises(MediaStoreError, match="metadata が不正"):
         store.metadata(_key())
+
+
+def test_r2_multipart_resumes_remote_parts_after_process_interruption(tmp_path: Path) -> None:
+    part_size = 5 * 1024 * 1024
+    payload = b"a" * part_size + b"b" * part_size + b"tail"
+    source = tmp_path / "Master.mp4"
+    source.write_bytes(payload)
+    client = FakeS3Client()
+    client.interrupt_part = 2
+    transfer = MultipartTransferConfig(threshold=part_size, part_size=part_size)
+    first_store = R2MediaStore(_config(), client=client, transfer_config=object(), multipart_transfer_config=transfer)
+
+    with pytest.raises(MediaStoreError, match="connection interrupted"):
+        first_store.push(source, _key())
+
+    checkpoint = next((tmp_path / ".yt-r2-multipart").glob("*.json"))
+    assert stat.S_IMODE(checkpoint.stat().st_mode) == 0o600
+    assert client.uploaded_parts == [1]
+
+    resumed_store = R2MediaStore(_config(), client=client, transfer_config=object(), multipart_transfer_config=transfer)
+    remote = resumed_store.push(source, _key())
+
+    assert client.create_calls == 1
+    assert client.uploaded_parts == [1, 2, 3]
+    object_key = "automation/v1/ambient-lab/rain-night/video-upload/Master.mp4"
+    assert client.objects[("media-handoffs", object_key)][0] == payload
+    assert remote.sha256 == hashlib.sha256(payload).hexdigest()
+    assert not checkpoint.exists()
+
+
+def test_r2_multipart_push_is_idempotent_after_completion(tmp_path: Path) -> None:
+    part_size = 5 * 1024 * 1024
+    source = tmp_path / "Master.mp4"
+    source.write_bytes(b"x" * (part_size + 1))
+    client = FakeS3Client()
+    store = R2MediaStore(
+        _config(),
+        client=client,
+        transfer_config=object(),
+        multipart_transfer_config=MultipartTransferConfig(threshold=part_size, part_size=part_size),
+    )
+
+    first = store.push(source, _key())
+    uploads_after_first_push = list(client.uploaded_parts)
+    second = store.push(source, _key())
+
+    assert second == first
+    assert client.create_calls == 1
+    assert client.uploaded_parts == uploads_after_first_push
+
+
+def test_r2_small_push_keeps_the_managed_transfer_path(tmp_path: Path) -> None:
+    source = tmp_path / "small.bin"
+    source.write_bytes(b"small")
+    client = FakeS3Client()
+    store = R2MediaStore(
+        _config(),
+        client=client,
+        transfer_config=object(),
+        multipart_transfer_config=MultipartTransferConfig(threshold=5 * 1024 * 1024, part_size=5 * 1024 * 1024),
+    )
+
+    store.push(source, _key())
+
+    assert client.create_calls == 0
+    assert client.uploaded_parts == []


### PR DESCRIPTION
## 概要

R2の大容量media転送をmultipart uploadへ切り替え、中断後にremote stateを正本として安全に再開できるようにします。

## 変更内容

- 100MiB超を低レベルR2 multipartへ切替
- upload IDを0o600 atomic checkpointへ保存
- remote ListPartsを正本に完了partをskip
- part数上限、stale upload再作成、source fingerprint不一致abort、process lockを追加
- 完了objectの冪等skipと最終metadata完全性検証
- small fileは既存managed transferを維持

## 検証

- focused: 34 passed
- architecture/domain: 229 passed
- full: 9527 passed, 3 skipped
- ruff / format / Any / build / wheel smoke: green

Closes #4046