### PR TITLE
issue 4047 r2 terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
+- `feat(hybrid)`: MediaStore の R2 bucket・bucket-scoped runtime token・object / multipart lifecycle を Cloudflare provider v5 の独立 Terraform stack で管理し、GCS backend・secret 非永続化・無料枠 retention guardrail・offline mock plan 契約を追加する（#4047）。
 - `feat(hybrid)`: R2 の大容量 push を固定 part の multipart 転送へ切り替え、atomic checkpoint と remote `ListParts` を正本にプロセス中断後の再開・完了済み part のskip・再実行冪等性を追加する（#4046）。
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
 - `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。

--- a/infra/terraform/r2/.terraform.lock.hcl
+++ b/infra/terraform/r2/.terraform.lock.hcl
@@ -1,0 +1,19 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.22.0"
+  constraints = "~> 5.22.0"
+  hashes = [
+    "h1:H3XmcpcMLeDyuGU6QsBXeVOB2CQGnIVRt6PJf7hfrtE=",
+    "zh:45f3b7c50254b1da1dc21e77e03cd1e931cab40fb75c7cba822a53ed54cd232e",
+    "zh:8437138c0af1a1a557b516ca42dae54499933cc81072396abe7eefd267218f79",
+    "zh:9140044a3c909e1a2767c8b2dd95370b8152bcbc7cb26c47e376e81f75512d32",
+    "zh:b69a80d2bb33059e93dec94490065fe210c621d8bdf32d745b1d1972aa85abbf",
+    "zh:ca4bf16742a7e59319a482f003d32f6f6abbc5fbf862916ce1a136278e6d420d",
+    "zh:cd767016ea7382e384e560f6ddb302637ecb1b53ece15c9326032010effe6c33",
+    "zh:d952f92ae1a688ed376757127ae1aa3b625571bf1fc606214a5822eae98213e0",
+    "zh:f5213814c8ca0d736623438b283143b9a7f98e72ca4992eb906966e7f8cc383b",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}

--- a/infra/terraform/r2/README.md
+++ b/infra/terraform/r2/README.md
@@ -1,0 +1,62 @@
+# infra/terraform/r2
+
+ハイブリッド制作の境界受け渡し専用 R2 bucket、bucket-scoped runtime token、object / 未完了 multipart upload の lifecycle 削除を管理する Terraform stack。
+
+## 管理するリソース
+
+- `cloudflare_r2_bucket`: `${name_prefix}-${environment}-handoffs`
+- `cloudflare_r2_bucket_lifecycle`: `object_prefix` 配下の object と未完了 multipart upload を `retention_days` 後に削除
+- `cloudflare_account_token`: 作成した bucket だけに `Workers R2 Storage Bucket Item Write` を許可
+
+`retention_days * expected_monthly_collections <= 30` を変数 validation で強制し、ADR-0024 の R2 無料枠 guardrail を超える plan を拒否する。bucket 自体は `prevent_destroy` で保護する。
+
+## 前提
+
+- Terraform 1.15.x
+- `infra/terraform/bootstrap` で作成した GCS tfstate bucket
+- Terraform bootstrap token に `Workers R2 Storage Write` と `Account API Tokens Write` があること
+- 1Password CLI で bootstrap token を取得できること
+
+## plan / apply
+
+```bash
+cd infra/terraform/r2
+cp terraform.tfvars.example terraform.tfvars
+# terraform.tfvars は non-secret 値だけを編集する
+
+export TF_VAR_cloudflare_api_token="$(op read 'op://Personal/Cloudflare Terraform API Token/credential')"
+terraform init -backend-config="bucket=<tfstate-bucket-name>"
+terraform plan
+terraform apply
+```
+
+`terraform.tfvars` や保存済み plan file に token を書き出さない。`sensitive = true` は CLI 表示を隠すだけで、token value は tfstate に平文で保持される。state は GCS backend の暗号化・IAM・versioning で保護する。
+
+実行前に plan が R2 stack の bucket / lifecycle / token だけを作成・変更し、別 resource の削除や置換を含まないことを確認する。想定外の差分があれば apply しない。
+
+## MediaStore secret への受け渡し
+
+apply 後、`r2_access_key_id` と `r2_api_token` の sensitive output はファイルや shell 履歴へ保存せず、既存の 1Password item へ直接登録する。
+
+非 secret は次で確認できる。
+
+```bash
+terraform output r2_account_id
+terraform output r2_bucket
+terraform output r2_prefix
+```
+
+下流 runtime はそれぞれ `R2_ACCOUNT_ID` / `R2_BUCKET` / `R2_PREFIX` として渡す。1Password の `access_key_id` / `api_token` は `R2_ACCESS_KEY_ID` / `R2_API_TOKEN` の既存 secret owner へ接続する。API token の ID が S3 Access Key ID、token value の SHA-256 が S3 Secret Access Key になる。
+
+## 非破壊検証
+
+Cloudflare account へ接続しない static / mock plan gate:
+
+```bash
+terraform fmt -check -recursive
+terraform init -backend=false
+terraform validate
+terraform test
+```
+
+`terraform test` は mock provider の plan だけを使い、実 resource は作成しない。

--- a/infra/terraform/r2/bucket.tf
+++ b/infra/terraform/r2/bucket.tf
@@ -1,0 +1,45 @@
+locals {
+  resource_name     = "${var.name_prefix}-${var.environment}"
+  bucket_name       = "${local.resource_name}-handoffs"
+  lifecycle_prefix  = "${var.object_prefix}/"
+  retention_seconds = var.retention_days * 24 * 60 * 60
+  bucket_resource   = "com.cloudflare.edge.r2.bucket.${var.cloudflare_account_id}_default_${local.bucket_name}"
+}
+
+resource "cloudflare_r2_bucket" "handoffs" {
+  account_id    = var.cloudflare_account_id
+  name          = local.bucket_name
+  jurisdiction  = "default"
+  location      = var.location
+  storage_class = "Standard"
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "cloudflare_r2_bucket_lifecycle" "handoffs" {
+  account_id   = var.cloudflare_account_id
+  bucket_name  = cloudflare_r2_bucket.handoffs.name
+  jurisdiction = "default"
+
+  rules = [{
+    id      = "expire-media-handoffs"
+    enabled = true
+    conditions = {
+      prefix = local.lifecycle_prefix
+    }
+    delete_objects_transition = {
+      condition = {
+        type    = "Age"
+        max_age = local.retention_seconds
+      }
+    }
+    abort_multipart_uploads_transition = {
+      condition = {
+        type    = "Age"
+        max_age = local.retention_seconds
+      }
+    }
+  }]
+}

--- a/infra/terraform/r2/outputs.tf
+++ b/infra/terraform/r2/outputs.tf
@@ -1,0 +1,26 @@
+output "r2_account_id" {
+  description = "R2_ACCOUNT_ID for MediaStore configuration."
+  value       = var.cloudflare_account_id
+}
+
+output "r2_bucket" {
+  description = "R2_BUCKET for MediaStore configuration."
+  value       = cloudflare_r2_bucket.handoffs.name
+}
+
+output "r2_prefix" {
+  description = "R2_PREFIX for MediaStore configuration."
+  value       = var.object_prefix
+}
+
+output "r2_access_key_id" {
+  description = "R2_ACCESS_KEY_ID generated for the bucket-scoped MediaStore token."
+  value       = cloudflare_account_token.media_store.id
+  sensitive   = true
+}
+
+output "r2_api_token" {
+  description = "R2_API_TOKEN whose SHA-256 digest is the S3 Secret Access Key."
+  value       = cloudflare_account_token.media_store.value
+  sensitive   = true
+}

--- a/infra/terraform/r2/terraform.tfvars.example
+++ b/infra/terraform/r2/terraform.tfvars.example
@@ -1,0 +1,8 @@
+# Non-secret values only. Keep cloudflare_api_token in TF_VAR_cloudflare_api_token.
+cloudflare_account_id        = "0123456789abcdef0123456789abcdef"
+name_prefix                  = "youtube-automation"
+environment                  = "production"
+location                     = "apac"
+object_prefix                = "automation/v1"
+retention_days               = 7
+expected_monthly_collections = 4

--- a/infra/terraform/r2/tests/r2.tftest.hcl
+++ b/infra/terraform/r2/tests/r2.tftest.hcl
@@ -1,0 +1,59 @@
+mock_provider "cloudflare" {}
+
+variables {
+  cloudflare_api_token         = "fixture-admin-token"
+  cloudflare_account_id        = "0123456789abcdef0123456789abcdef"
+  name_prefix                  = "youtube-automation"
+  environment                  = "production"
+  location                     = "apac"
+  object_prefix                = "automation/v1"
+  retention_days               = 7
+  expected_monthly_collections = 4
+}
+
+run "plans_bucket_scoped_credentials_and_expiration" {
+  command = plan
+
+  assert {
+    condition     = cloudflare_r2_bucket.handoffs.name == "youtube-automation-production-handoffs"
+    error_message = "R2 bucket name must follow the shared environment naming contract."
+  }
+
+  assert {
+    condition     = cloudflare_r2_bucket_lifecycle.handoffs.rules[0].conditions.prefix == "automation/v1/"
+    error_message = "Lifecycle must be scoped to the MediaStore object prefix."
+  }
+
+  assert {
+    condition     = cloudflare_r2_bucket_lifecycle.handoffs.rules[0].delete_objects_transition.condition.max_age == 604800
+    error_message = "Completed handoffs must expire after retention_days."
+  }
+
+  assert {
+    condition     = cloudflare_r2_bucket_lifecycle.handoffs.rules[0].abort_multipart_uploads_transition.condition.max_age == 604800
+    error_message = "Incomplete multipart uploads must not outlive completed handoffs."
+  }
+
+  assert {
+    condition     = cloudflare_account_token.media_store.policies[0].permission_groups[0].id == "2efd5506f9c8494dacb1fa10a3e7d5b6"
+    error_message = "Runtime credentials must use the R2 bucket item write permission only."
+  }
+
+  assert {
+    condition = jsondecode(cloudflare_account_token.media_store.policies[0].resources)[
+      "com.cloudflare.edge.r2.bucket.0123456789abcdef0123456789abcdef_default_youtube-automation-production-handoffs"
+    ] == "*"
+    error_message = "Runtime credentials must be scoped to the provisioned bucket only."
+  }
+}
+
+run "rejects_a_retention_budget_above_the_free_tier_guardrail" {
+  command = plan
+
+  variables {
+    retention_days               = 8
+    expected_monthly_collections = 4
+  }
+
+  expect_failures = [var.retention_days]
+}

--- a/infra/terraform/r2/token.tf
+++ b/infra/terraform/r2/token.tf
@@ -1,0 +1,15 @@
+resource "cloudflare_account_token" "media_store" {
+  account_id = var.cloudflare_account_id
+  name       = "${local.resource_name}-media-store"
+  status     = "active"
+
+  policies = [{
+    effect = "allow"
+    permission_groups = [{
+      id = var.r2_bucket_item_write_permission_group_id
+    }]
+    resources = jsonencode({
+      (local.bucket_resource) = "*"
+    })
+  }]
+}

--- a/infra/terraform/r2/variables.tf
+++ b/infra/terraform/r2/variables.tf
@@ -1,0 +1,93 @@
+variable "cloudflare_api_token" {
+  type        = string
+  description = "Terraform bootstrap token. Inject through TF_VAR_cloudflare_api_token from 1Password."
+  sensitive   = true
+}
+
+variable "cloudflare_account_id" {
+  type        = string
+  description = "Cloudflare account ID that owns the R2 bucket."
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.cloudflare_account_id))
+    error_message = "cloudflare_account_id must be a 32-character lowercase hexadecimal account ID."
+  }
+}
+
+variable "r2_bucket_item_write_permission_group_id" {
+  type        = string
+  description = "Public Cloudflare permission group ID for Workers R2 Storage Bucket Item Write."
+  default     = "2efd5506f9c8494dacb1fa10a3e7d5b6"
+
+  validation {
+    condition     = can(regex("^[0-9a-f]{32}$", var.r2_bucket_item_write_permission_group_id))
+    error_message = "r2_bucket_item_write_permission_group_id must be a 32-character lowercase hexadecimal permission group ID."
+  }
+}
+
+variable "name_prefix" {
+  type        = string
+  description = "Shared lowercase prefix used for every R2 resource name."
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.name_prefix))
+    error_message = "name_prefix must contain lowercase letters, digits, and internal hyphens only."
+  }
+}
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment included in every R2 resource name."
+
+  validation {
+    condition = (
+      can(regex("^[a-z0-9][a-z0-9-]*[a-z0-9]$", var.environment))
+      && length("${var.name_prefix}-${var.environment}-handoffs") <= 63
+    )
+    error_message = "environment must be lowercase kebab-case and keep the generated bucket name within 63 characters."
+  }
+}
+
+variable "location" {
+  type        = string
+  description = "R2 location hint used only when the bucket is first created."
+
+  validation {
+    condition     = contains(["apac", "eeur", "enam", "weur", "wnam", "oc"], var.location)
+    error_message = "location must be one of apac, eeur, enam, weur, wnam, or oc."
+  }
+}
+
+variable "object_prefix" {
+  type        = string
+  description = "R2 key prefix shared by MediaStore and the lifecycle rule, without leading or trailing slash."
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9][A-Za-z0-9._/-]*[A-Za-z0-9]$", var.object_prefix)) && !strcontains(var.object_prefix, "//") && !strcontains(var.object_prefix, "..")
+    error_message = "object_prefix must be a relative key prefix without empty or parent segments."
+  }
+}
+
+variable "retention_days" {
+  type        = number
+  description = "Whole days before handoff objects and incomplete multipart uploads are deleted."
+
+  validation {
+    condition = (
+      var.retention_days >= 1
+      && floor(var.retention_days) == var.retention_days
+      && var.retention_days * var.expected_monthly_collections <= 30
+    )
+    error_message = "retention_days must be a positive integer and retention_days * expected_monthly_collections must not exceed 30."
+  }
+}
+
+variable "expected_monthly_collections" {
+  type        = number
+  description = "Upper bound of monthly collections used to enforce the R2 free-tier retention guardrail."
+
+  validation {
+    condition     = var.expected_monthly_collections >= 1 && floor(var.expected_monthly_collections) == var.expected_monthly_collections
+    error_message = "expected_monthly_collections must be a positive integer."
+  }
+}

--- a/infra/terraform/r2/versions.tf
+++ b/infra/terraform/r2/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = "~> 1.15.0"
+
+  backend "gcs" {
+    prefix = "r2"
+  }
+
+  required_providers {
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.22.0"
+    }
+  }
+}
+
+provider "cloudflare" {
+  api_token = var.cloudflare_api_token
+}


### PR DESCRIPTION
## 概要

R2 bucket、bucket-scoped runtime token、lifecycleをTerraformで再現可能に管理します。

## 変更内容

- Cloudflare provider v5.22でR2 bucket/token/lifecycleを定義
- GCS backendとsecret非tfvars境界を追加
- `prevent_destroy` と無料枠retention guardrailを追加
- object/multipart cleanupを明示
- 実Cloudflare操作なしのmock plan契約を追加

## 検証

- Terraform mock plan: 2 passed
- fmt/init/validate: green
- focused: 15 passed
- full: 9562 passed, 3 skipped
- ruff / format / Any / build: green

Closes #4047