### PR TITLE
feat(hybrid): stateで工程引き渡しを表現する (#4051)

### DIFF
--- a/.claude/skills/wf-new/references/auto.md
+++ b/.claude/skills/wf-new/references/auto.md
@@ -41,7 +41,8 @@ STATE_SCRIPT=.claude/skills/wf-new/references/wf-auto-state.py
 
 uv run python "$STATE_SCRIPT" acquire --channel-dir .
 uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
-uv run python "$STATE_SCRIPT" plan --channel-dir . [--collection <fixed-name>]
+uv run python "$STATE_SCRIPT" plan --channel-dir . --executor local [--collection <fixed-name>]
+# cloud runner は同じresolverを --executor cloud で実行する
 uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> \
   --collection <fixed-name> --action <action> --status success|blocked|failed \
   --reason <reason> [--resume-action <action>] \
@@ -73,6 +74,7 @@ uv run python "$STATE_SCRIPT" release --channel-dir . --token <token>
 | `wf-next` | `/wf-next`。config が許可した場合だけ upload を含める |
 | `publish` | `/publish`。各成果物の状態判定により完了 step を skip |
 | `blocked` | reason / resume_action を記録して停止 |
+| `no-op` | stateの `handoff.owner` が現在executorと一致しないため、state・成果物を変更せず停止 |
 | `complete` | 完了を記録して停止 |
 
 ### canonical action の AI timing 契約

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -14,6 +14,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 |-------|------|--------------|
 | `planning` | 企画提案前 | /wf-new で企画選択 |
 | `prepared` | サムネ承認済み+音楽素材準備完了 | Suno 作成 or Lyria 生成 → ミキシング+マスタリング |
+| `cloud_owned` | Suno DL成果物のmanifest参照を記録し、工程所有権をcloudへ引き渡し済み | cloud executorがmanifest検証済み成果物からミキシング+マスタリングを再開 |
 | `mastered` | 最終マスター音源配置済み | /wf-next で全自動公開 |
 | `publishing` | 公開フロー実行中 | 自動完了待ち（エラー時は /wf-next で再実行） |
 | `complete` | 全工程完了 | /analytics --analyze で初週パフォーマンス確認 |
@@ -29,7 +30,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
   "created_at": "ISO 8601",
   "updated_at": "ISO 8601",
   "stage": "planning | live",
-  "phase": "planning | prepared | mastered | publishing | complete",
+  "phase": "planning | prepared | cloud_owned | mastered | publishing | complete",
   "selected_plan": "A | B | C | D | E",
   "track_count": 12,
   "planning": {
@@ -63,6 +64,12 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
     "master_audio": null,
     "master_video": null,
     "description": false
+  },
+  "handoff": {
+    "point": "suno_download",
+    "owner": "cloud",
+    "manifest_key": "002ch/sample/suno-download/manifest.json",
+    "root_sha256": "64 lowercase hex characters"
   },
   "music_pair_selection": {
     "updated_at": "ISO 8601",
@@ -144,6 +151,19 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 | `description` | boolean | YouTube 概要欄の検証済み JSON+HTML pair 生成済み（`20-documentation/descriptions.{json,html}`） |
 
 `music_downloaded: true` かつ `raw_master: null` は、Suno 楽曲が DL 済みで raw master（クロスフェード結合出力）が未生成の中間状態を表す。
+
+### handoff フィールド詳細
+
+`yt-workflow-state record-handoff` は `phase: prepared`、`planning.music.engine: suno`、`assets.music_downloaded: true` を検証してから、`phase` を `cloud_owned` へ一方向遷移する。同じmanifest参照での再実行は冪等で、別manifestへの上書きや逆遷移は拒否する。
+
+| フィールド | 型 | 説明 |
+|---|---|---|
+| `handoff.point` | `"suno_download"` | local → cloud の引き渡し点 |
+| `handoff.owner` | `"cloud"` | 現在の工程所有者。分散lockの代わりにresolverが参照する |
+| `handoff.manifest_key` | string | R2上の完了marker `manifest.json` の相対key |
+| `handoff.root_sha256` | string | manifest正準file一覧のroot SHA-256（lowercase 64 hex） |
+
+stateにはmanifest全文やfile一覧を複製しない。正本はMediaStore上のmanifestであり、Git制御面はkeyとroot checksumだけを保持する。
 
 ### stage フィールド詳細
 

--- a/.claude/skills/wf-new/references/wf-auto-state.py
+++ b/.claude/skills/wf-new/references/wf-auto-state.py
@@ -31,7 +31,7 @@ LEASE_FILE_NAME = "lease.json"
 LEASE_MUTEX_NAME = "lease.mutex"
 HISTORY_FILE_NAME = "history.json"
 AUDIO_SUFFIXES = {".mp3", ".m4a", ".wav", ".flac", ".aac"}
-PHASES = {"planning", "prepared", "mastered", "publishing", "complete"}
+PHASES = {"planning", "prepared", "cloud_owned", "mastered", "publishing", "complete"}
 ENGINES = {"suno", "lyria", "minimax"}
 ACTIONS = {
     "wf-new",
@@ -44,6 +44,7 @@ ACTIONS = {
     "publish",
     "blocked",
     "complete",
+    "no-op",
 }
 
 
@@ -604,7 +605,13 @@ def _publish_followup_complete(root: Path, collection: Path, video_id: str) -> b
     return history.get("schema_version") == 1 and isinstance(posted, dict) and video_id in posted
 
 
-def evaluate_collection(root: Path, collection: Path, config: RunnerConfig) -> Decision:
+def evaluate_collection(
+    root: Path,
+    collection: Path,
+    config: RunnerConfig,
+    *,
+    executor: Literal["local", "cloud"] | None = None,
+) -> Decision:
     root = root.resolve()
     collection = _inside(root, collection, "collection")
     state = _state(collection)
@@ -615,6 +622,32 @@ def evaluate_collection(root: Path, collection: Path, config: RunnerConfig) -> D
     if not isinstance(assets, dict) or not isinstance(upload, dict):
         raise ValueError("workflow-state.json::assets / upload は object でなければなりません")
     video_id = upload.get("video_id")
+
+    handoff = state.handoff
+    owner = "local"
+    if handoff is not None and handoff.owner is not None:
+        owner = handoff.owner
+    if phase == "cloud_owned":
+        if (
+            handoff is None
+            or handoff.point != "suno_download"
+            or handoff.owner != "cloud"
+            or handoff.manifest_key is None
+            or handoff.root_sha256 is None
+        ):
+            raise ValueError("cloud_owned phase requires a complete cloud handoff reference")
+    elif owner == "cloud" and phase not in {"mastered", "publishing", "complete"}:
+        raise ValueError("cloud handoff owner is inconsistent with workflow phase")
+    if executor is not None and executor != owner:
+        return _decision(
+            collection=collection,
+            phase=phase,
+            engine=engine,
+            action="no-op",
+            reason=f"{owner}_ownership",
+            config=config,
+        )
+    routing_phase = "prepared" if phase == "cloud_owned" else phase
 
     stage = state.get("stage")
     if isinstance(video_id, str) and video_id and (phase != "complete" or stage != "live"):
@@ -637,7 +670,7 @@ def evaluate_collection(root: Path, collection: Path, config: RunnerConfig) -> D
             resume_action="wf-next",
             config=config,
         )
-    if phase == "planning":
+    if routing_phase == "planning":
         return _decision(
             collection=collection,
             phase=phase,
@@ -647,7 +680,7 @@ def evaluate_collection(root: Path, collection: Path, config: RunnerConfig) -> D
             resume_action="wf-new",
             config=config,
         )
-    if phase == "prepared":
+    if routing_phase == "prepared":
         raw_master = assets.get("raw_master")
         if raw_master is not None:
             if not _artifact_file(collection, "01-master", raw_master):
@@ -1038,6 +1071,7 @@ def resolve_action(
     requested: str | None = None,
     *,
     config: RunnerConfig | None = None,
+    executor: Literal["local", "cloud"] | None = None,
 ) -> Decision:
     """Return the next delegated action without mutating workflow state."""
     resolved_config = config or _load_runner_config(root)
@@ -1055,7 +1089,7 @@ def resolve_action(
             "resume_action": "wf-new",
             "allow_external_publish": resolved_config.allow_external_publish,
         }
-    return evaluate_collection(root, collection, resolved_config)
+    return evaluate_collection(root, collection, resolved_config, executor=executor)
 
 
 def record_bootstrap_attempt(
@@ -1101,6 +1135,7 @@ def _parser() -> argparse.ArgumentParser:
     plan = sub.add_parser("plan")
     plan.add_argument("--channel-dir", type=Path, default=Path.cwd())
     plan.add_argument("--collection")
+    plan.add_argument("--executor", choices=("local", "cloud"))
     record = sub.add_parser("record")
     record.add_argument("--channel-dir", type=Path, default=Path.cwd())
     record.add_argument("--token", required=True)
@@ -1139,7 +1174,7 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "release":
             result = {"status": "released" if release_lease(root, args.token) else "not-owner"}
         elif args.command == "plan":
-            result = resolve_action(root, args.collection)
+            result = resolve_action(root, args.collection, executor=args.executor)
         elif args.command == "record-bootstrap":
             recorded_at = datetime.now(UTC).isoformat()
             record_bootstrap_attempt(

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: Suno DL後のmanifest key + root SHA-256をworkflow-stateへ記録して`cloud_owned`へ一方向遷移し、resolverが引き渡し前のcloud／引き渡し後のlocalを`no-op`にする工程所有権契約を追加する（#4051）。
 - `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
 - `feat(thumbnail)`: 候補画像と固定QAを原寸/320pxで比較する安全なWeb reviewを追加し、検証済みcandidate IDだけをthumbnail/main/ABの既存確定ownerへ渡す（#4017）。
 - `feat(hybrid)`: versioned 受け渡し manifest を completion marker として追加し、正準 file list・root checksum・manifest-last push・listing 非依存 pull・既存local成果物のrollbackをfail-closedに固定する（#4045）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -96,7 +96,7 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 **制御面 / データ面**: ハイブリッド制作基盤の 2 面。制御面は Git（`workflow-state.json` と冪等性 tracking 群が正本）、データ面は R2（メディアの受け渡し）で、状態をデータ面に置かない（ADR-0024）。
 
-**工程所有権**: 各工程の実行者（local / cloud）が境界規則により常に一意である性質。「いま誰の番か」は Git 上の state の phase が表し、single-writer 原則により state 自体が引き渡しトークンになる。ネットワーク越しの分散ロックを作らない根拠（ADR-0024）。
+**工程所有権**: 各工程の実行者（local / cloud）が境界規則により常に一意である性質。「いま誰の番か」は Git 上の state の phase が表し、single-writer 原則により state 自体が引き渡しトークンになる。Suno DL後はowner APIがmanifest key + root SHA-256だけを `handoff` に記録して `phase: cloud_owned` へ一方向遷移する。resolverは明示executorとownerが一致しなければ`no-op`にし、ネットワーク越しの分散ロックを作らない（ADR-0024）。
 
 **サンドイッチ実行モデル**: クラウドジョブが Git clone + マニフェスト検証つき R2 pull でローカル FS を再構成し、既存のローカル前提コードを無改造で動かし、終了時に成果物 push + state commit する実行方式。MediaStore 抽象は pull / push を行う転送層としてのみ導入する（ADR-0024）。
 

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -11,7 +11,14 @@ from typing import cast
 
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import WorkflowStateError
-from youtube_automation.domains.collections.workflow_state import AssetKey, Phase, PlanningKey, Stage, WorkflowState
+from youtube_automation.domains.collections.workflow_state import (
+    AssetKey,
+    HandoffPoint,
+    Phase,
+    PlanningKey,
+    Stage,
+    WorkflowState,
+)
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.filesystem import JSONValue
@@ -65,6 +72,10 @@ def build_parser() -> argparse.ArgumentParser:
     planning_parser = subparsers.add_parser("set-planning", help="planning の JSON 値を更新")
     planning_parser.add_argument("key", choices=_PLANNING_CHOICES)
     planning_parser.add_argument("value", help="JSON 値（文字列は JSON の二重引用符を含める）")
+    handoff_parser = subparsers.add_parser("record-handoff", help="検証済みmanifest参照を記録してcloudへ引き渡す")
+    handoff_parser.add_argument("--point", choices=("suno_download",), required=True)
+    handoff_parser.add_argument("--manifest-key", required=True, help="R2上のmanifest.json相対key")
+    handoff_parser.add_argument("--root-sha256", required=True, help="manifestのroot SHA-256")
     for command, help_text in (
         ("set-thumbnail-approved", "thumbnail 承認状態を更新"),
         ("set-description-generated", "概要欄生成状態を更新"),
@@ -149,6 +160,17 @@ def _set_post_upload_shorts(state: WorkflowState, value: JSONValue) -> None:
     _touch(state)
 
 
+def _record_handoff(state: WorkflowState, args: argparse.Namespace) -> None:
+    before = state.to_dict()
+    state.record_cloud_handoff(
+        point=cast(HandoffPoint, args.point),
+        manifest_key=args.manifest_key,
+        root_sha256=args.root_sha256,
+    )
+    if state.to_dict() != before:
+        _touch(state)
+
+
 def _set_completion_flag(
     state: WorkflowState,
     *,
@@ -187,6 +209,8 @@ def run(args: argparse.Namespace) -> int:
         update_workflow_state(state_path, lambda state: _set_completion_flag(state, description=args.value == "true"))
     elif args.command == "set-post-upload-shorts":
         update_workflow_state(state_path, lambda state: _set_post_upload_shorts(state, _json_value(args.value)))
+    elif args.command == "record-handoff":
+        update_workflow_state(state_path, lambda state: _record_handoff(state, args))
     elif args.command == "touch":
         update_workflow_state(state_path, _touch)
     return 0

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -18,7 +18,7 @@ from youtube_automation.infrastructure.documents.publishing import read_publishe
 STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
 
 # /wf-status が定義する v2 phase 語彙を正規の段判定にも使う。
-WF_STATUS_PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
+WF_STATUS_PHASES = frozenset({"planning", "prepared", "cloud_owned", "mastered", "publishing", "complete"})
 _ANALYSIS_REPORT = re.compile(r"analysis_(\d{8})\.json\Z")
 
 

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -7,15 +7,18 @@ import os
 import tempfile
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from copy import deepcopy
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Literal, TypedDict, cast
 
-from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.domains.media_store import MediaKey
 from youtube_automation.infrastructure.filesystem import JSONValue, file_lock
 
-Phase = Literal["planning", "prepared", "mastered", "publishing", "complete"]
+Phase = Literal["planning", "prepared", "cloud_owned", "mastered", "publishing", "complete"]
 Stage = Literal["planning", "live"]
 MusicEngine = Literal["suno", "lyria", "minimax"]
+HandoffPoint = Literal["suno_download"]
+ExecutionOwner = Literal["local", "cloud"]
 WorkflowStateUpdater = Callable[["WorkflowState"], "WorkflowState | None"]
 AssetKey = Literal[
     "thumbnail",
@@ -57,6 +60,13 @@ class AssetsDocument(TypedDict, total=False):
     master_audio: str | None
     master_video: str | None
     description: bool
+
+
+class HandoffDocument(TypedDict, total=False):
+    point: HandoffPoint
+    owner: ExecutionOwner
+    manifest_key: str
+    root_sha256: str
 
 
 class MusicPairSelectionExceptionDocument(TypedDict, total=False):
@@ -143,6 +153,7 @@ class WorkflowStateDocument(TypedDict, total=False):
     scene_phrases: dict[str, str]
     title_template_check: TitleTemplateCheckDocument
     assets: AssetsDocument
+    handoff: HandoffDocument
     music_pair_selection: MusicPairSelectionDocument
     upload: UploadDocument
     post_upload: PostUploadDocument
@@ -151,7 +162,7 @@ class WorkflowStateDocument(TypedDict, total=False):
     thumbnail_auto_selection: ThumbnailAutoSelectionDocument
 
 
-_PHASES = frozenset({"planning", "prepared", "mastered", "publishing", "complete"})
+_PHASES = frozenset({"planning", "prepared", "cloud_owned", "mastered", "publishing", "complete"})
 _STAGES = frozenset({"planning", "live"})
 _MUSIC_ENGINES = frozenset({"suno", "lyria", "minimax"})
 _MUSIC_TEMPOS = frozenset({"very slow", "slow", "gentle", "moderate", "lively"})
@@ -159,6 +170,7 @@ _KNOWN_OBJECT_SECTIONS = frozenset(
     {
         "assets",
         "description",
+        "handoff",
         "music_pair_selection",
         "planning",
         "post_upload",
@@ -234,6 +246,10 @@ class AssetsState(_ObjectSection):
     @description.setter
     def description(self, value: bool) -> None:
         self._data["description"] = value
+
+    @property
+    def music_downloaded(self) -> bool | None:
+        return _optional_bool(self._data, "music_downloaded", "workflow-state.json::assets.music_downloaded")
 
     @property
     def raw_master(self) -> str | None:
@@ -416,6 +432,42 @@ class UploadState(_ObjectSection):
         self._data["publish_at"] = value
 
 
+class HandoffState(_ObjectSection):
+    """境界引き渡しの完了marker参照と現在owner。"""
+
+    @property
+    def point(self) -> HandoffPoint | None:
+        value = _optional_string(self._data, "point", "workflow-state.json::handoff.point")
+        if value is None:
+            return None
+        if value != "suno_download":
+            raise WorkflowStateError(f"unsupported workflow-state handoff point: {value}")
+        return "suno_download"
+
+    @property
+    def owner(self) -> ExecutionOwner | None:
+        value = _optional_string(self._data, "owner", "workflow-state.json::handoff.owner")
+        if value is None:
+            return None
+        if value not in {"local", "cloud"}:
+            raise WorkflowStateError(f"unsupported workflow-state handoff owner: {value}")
+        return cast(ExecutionOwner, value)
+
+    @property
+    def manifest_key(self) -> str | None:
+        value = _optional_string(self._data, "manifest_key", "workflow-state.json::handoff.manifest_key")
+        if value is not None:
+            _validate_manifest_key(value)
+        return value
+
+    @property
+    def root_sha256(self) -> str | None:
+        value = _optional_string(self._data, "root_sha256", "workflow-state.json::handoff.root_sha256")
+        if value is not None:
+            _validate_root_sha256(value)
+        return value
+
+
 class WorkflowState(MutableMapping[str, JSONValue]):
     """既知 section を型付きで扱い、未知キーも保持する document object。"""
 
@@ -447,6 +499,12 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         planning = self.planning
         if planning is not None:
             _music = planning.music
+        handoff = self.handoff
+        if handoff is not None:
+            _point = handoff.point
+            _owner = handoff.owner
+            _manifest_key = handoff.manifest_key
+            _root_sha256 = handoff.root_sha256
 
     @property
     def phase(self) -> Phase | None:
@@ -497,6 +555,56 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def post_upload(self) -> PostUploadState | None:
         value = self._data.get("post_upload")
         return PostUploadState(value) if isinstance(value, dict) else None
+
+    @property
+    def handoff(self) -> HandoffState | None:
+        value = self._data.get("handoff")
+        return HandoffState(value) if isinstance(value, dict) else None
+
+    def record_cloud_handoff(
+        self,
+        *,
+        point: HandoffPoint,
+        manifest_key: str,
+        root_sha256: str,
+    ) -> None:
+        """Suno DL完了markerを記録し、工程所有権をcloudへ一方向遷移する。"""
+
+        _validate_handoff_reference(point, manifest_key, root_sha256)
+        existing = self.handoff
+        if self.phase == "cloud_owned":
+            if (
+                existing is not None
+                and existing.point == point
+                and existing.owner == "cloud"
+                and existing.manifest_key == manifest_key
+                and existing.root_sha256 == root_sha256
+            ):
+                return
+            raise WorkflowStateError("workflow-state handoff already records a different manifest")
+        if self.phase != "prepared":
+            raise WorkflowStateError("workflow-state handoff requires phase prepared")
+        if self.music_engine != "suno":
+            raise WorkflowStateError("workflow-state suno_download handoff requires music engine suno")
+        assets = self.assets
+        if assets is None or assets.music_downloaded is not True:
+            raise WorkflowStateError("workflow-state handoff requires assets.music_downloaded true")
+        if existing is not None:
+            known = (existing.point, existing.owner, existing.manifest_key, existing.root_sha256)
+            if any(value is not None for value in known):
+                raise WorkflowStateError("workflow-state handoff already records a different manifest")
+
+        handoff = self._data.setdefault("handoff", {})
+        assert isinstance(handoff, dict)
+        handoff.update(
+            {
+                "point": point,
+                "owner": "cloud",
+                "manifest_key": manifest_key,
+                "root_sha256": root_sha256,
+            }
+        )
+        self.phase = "cloud_owned"
 
     def set_thumbnail_approved(self, approved: bool) -> None:
         if not isinstance(approved, bool):
@@ -611,6 +719,37 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def to_dict(self) -> dict[str, JSONValue]:
         """永続化用に document の独立したコピーを返す。"""
         return deepcopy(self._data)
+
+
+def _validate_handoff_reference(point: str, manifest_key: str, root_sha256: str) -> None:
+    if point != "suno_download":
+        raise WorkflowStateError(f"unsupported workflow-state handoff point: {point}")
+    _validate_manifest_key(manifest_key)
+    _validate_root_sha256(root_sha256)
+
+
+def _validate_manifest_key(manifest_key: str) -> None:
+    key = PurePosixPath(manifest_key)
+    if (
+        not manifest_key
+        or manifest_key.startswith("/")
+        or "\\" in manifest_key
+        or any(part in {"", ".", ".."} for part in key.parts)
+        or len(key.parts) != 4
+        or key.name != "manifest.json"
+    ):
+        raise WorkflowStateError("workflow-state handoff.manifest_key must be a relative manifest.json key")
+    try:
+        normalized = MediaKey(key.parts[0], key.parts[1], key.parts[2], key.parts[3]).as_posix()
+    except ValidationError as exc:
+        raise WorkflowStateError("workflow-state handoff.manifest_key must use safe MediaKey segments") from exc
+    if normalized != manifest_key:
+        raise WorkflowStateError("workflow-state handoff.manifest_key must be a canonical MediaKey")
+
+
+def _validate_root_sha256(root_sha256: str) -> None:
+    if len(root_sha256) != 64 or any(character not in "0123456789abcdef" for character in root_sha256):
+        raise WorkflowStateError("workflow-state handoff.root_sha256 must be 64 lowercase hex characters")
 
 
 def _read_payload(path: Path) -> dict[str, JSONValue]:

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -71,6 +71,64 @@ def test_set_stage_supports_current_control_plane_vocabulary(tmp_path: Path) -> 
     assert _read_state(collection)["stage"] == "live"
 
 
+def test_record_handoff_uses_typed_owner_transition(tmp_path: Path) -> None:
+    collection = _collection(
+        tmp_path,
+        {
+            "phase": "prepared",
+            "planning": {"music": {"engine": "suno"}},
+            "assets": {"music_downloaded": True},
+            "unknown": {"keep": True},
+        },
+    )
+
+    assert (
+        workflow_state_cli.main(
+            [
+                "--collection",
+                str(collection),
+                "record-handoff",
+                "--point",
+                "suno_download",
+                "--manifest-key",
+                "002ch/sample/suno-download/manifest.json",
+                "--root-sha256",
+                "d" * 64,
+            ]
+        )
+        == 0
+    )
+
+    state = _read_state(collection)
+    assert state["phase"] == "cloud_owned"
+    assert state["handoff"] == {
+        "point": "suno_download",
+        "owner": "cloud",
+        "manifest_key": "002ch/sample/suno-download/manifest.json",
+        "root_sha256": "d" * 64,
+    }
+    assert state["unknown"] == {"keep": True}
+    assert isinstance(state["updated_at"], str)
+    before_retry = (collection / "workflow-state.json").read_bytes()
+    assert (
+        workflow_state_cli.main(
+            [
+                "--collection",
+                str(collection),
+                "record-handoff",
+                "--point",
+                "suno_download",
+                "--manifest-key",
+                "002ch/sample/suno-download/manifest.json",
+                "--root-sha256",
+                "d" * 64,
+            ]
+        )
+        == 0
+    )
+    assert (collection / "workflow-state.json").read_bytes() == before_retry
+
+
 def test_set_upload_creates_section_and_only_overwrites_supplied_fields(tmp_path: Path) -> None:
     collection = _collection(
         tmp_path,

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -296,6 +296,33 @@ def test_should_use_latest_workflow_state_when_command_does_not_name_collection(
     assert "  ▸  マスター化" in message
 
 
+def test_should_render_cloud_owned_handoff_phase_without_fallback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "cloud-owned",
+        {
+            "phase": "cloud_owned",
+            "planning": {"music": {"engine": "suno"}},
+            "assets": {"music_downloaded": True, "raw_master": None},
+            "handoff": {
+                "point": "suno_download",
+                "owner": "cloud",
+                "manifest_key": "002ch/cloud-owned/suno-download/manifest.json",
+                "root_sha256": "a" * 64,
+            },
+        },
+    )
+
+    message = _progress_message(tmp_path, capsys, command="uv run yt-generate-master")
+
+    assert "  ✓  企画" in message
+    assert "  ▸  マスター化" in message
+
+
 def test_should_mark_post_publish_and_analysis_from_channel_artifacts(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -148,6 +148,127 @@ def test_update_preserves_unknown_keys_during_round_trip(tmp_path: Path) -> None
     assert persisted["future_section"] == unknown
 
 
+def test_record_cloud_handoff_changes_phase_and_keeps_only_manifest_reference(tmp_path: Path) -> None:
+    state_path = tmp_path / "workflow-state.json"
+    _write(
+        state_path,
+        {
+            "phase": "prepared",
+            "planning": {"music": {"engine": "suno"}},
+            "assets": {"music_downloaded": True},
+            "handoff": {"future": "keep"},
+            "future_section": {"keep": True},
+        },
+    )
+
+    updated = update(
+        state_path,
+        lambda state: state.record_cloud_handoff(
+            point="suno_download",
+            manifest_key="002ch/sample/suno-download/manifest.json",
+            root_sha256="a" * 64,
+        ),
+    )
+
+    assert updated.phase == "cloud_owned"
+    assert updated.handoff is not None
+    assert updated.handoff.owner == "cloud"
+    assert updated.handoff.manifest_key == "002ch/sample/suno-download/manifest.json"
+    assert updated.handoff.root_sha256 == "a" * 64
+    persisted = json.loads(state_path.read_text(encoding="utf-8"))
+    assert persisted["handoff"] == {
+        "future": "keep",
+        "point": "suno_download",
+        "owner": "cloud",
+        "manifest_key": "002ch/sample/suno-download/manifest.json",
+        "root_sha256": "a" * 64,
+    }
+    assert "files" not in persisted["handoff"]
+    assert persisted["future_section"] == {"keep": True}
+
+
+def test_record_cloud_handoff_is_idempotent_but_rejects_conflicting_reference() -> None:
+    state = WorkflowState(
+        {
+            "phase": "prepared",
+            "planning": {"music": {"engine": "suno"}},
+            "assets": {"music_downloaded": True},
+        }
+    )
+
+    state.record_cloud_handoff(
+        point="suno_download",
+        manifest_key="002ch/sample/suno-download/manifest.json",
+        root_sha256="b" * 64,
+    )
+    state.record_cloud_handoff(
+        point="suno_download",
+        manifest_key="002ch/sample/suno-download/manifest.json",
+        root_sha256="b" * 64,
+    )
+
+    with pytest.raises(WorkflowStateError, match="different manifest"):
+        state.record_cloud_handoff(
+            point="suno_download",
+            manifest_key="002ch/sample/suno-download/manifest.json",
+            root_sha256="c" * 64,
+        )
+
+
+@pytest.mark.parametrize(
+    ("payload", "manifest_key", "root_sha256", "message"),
+    [
+        (
+            {"phase": "planning", "planning": {"music": {"engine": "suno"}}, "assets": {"music_downloaded": True}},
+            "002ch/sample/suno-download/manifest.json",
+            "a" * 64,
+            "prepared",
+        ),
+        (
+            {"phase": "prepared", "planning": {"music": {"engine": "suno"}}, "assets": {"music_downloaded": False}},
+            "002ch/sample/suno-download/manifest.json",
+            "a" * 64,
+            "music_downloaded",
+        ),
+        (
+            {"phase": "prepared", "planning": {"music": {"engine": "suno"}}, "assets": {"music_downloaded": True}},
+            "../manifest.json",
+            "a" * 64,
+            "manifest_key",
+        ),
+        (
+            {"phase": "prepared", "planning": {"music": {"engine": "suno"}}, "assets": {"music_downloaded": True}},
+            "manifest.json",
+            "a" * 64,
+            "manifest_key",
+        ),
+        (
+            {"phase": "prepared", "planning": {"music": {"engine": "suno"}}, "assets": {"music_downloaded": True}},
+            "002ch/sample/suno-download/manifest.json",
+            "not-a-sha",
+            "root_sha256",
+        ),
+    ],
+)
+def test_record_cloud_handoff_fails_closed_before_mutation(
+    payload: dict[str, JSONValue],
+    manifest_key: str,
+    root_sha256: str,
+    message: str,
+) -> None:
+    state = WorkflowState(payload)
+    before = state.to_dict()
+
+    with pytest.raises(WorkflowStateError, match=message):
+        state.record_cloud_handoff(
+            point="suno_download",
+            manifest_key=manifest_key,
+            root_sha256=root_sha256,
+        )
+
+    assert state.to_dict() == before
+
+
 def test_update_creates_missing_document_under_the_same_contract(tmp_path: Path) -> None:
     state_path = tmp_path / "workflow-state.json"
 

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -111,6 +111,74 @@ def test_minimax_collection_routes_to_music_generate_without_suno_fallback(tmp_p
     assert decision["resume_action"] == "minimax"
 
 
+def test_cloud_executor_is_noop_before_handoff_without_mutating_state(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(tmp_path, "20260721-local-owned", engine="suno")
+    state_path = collection / "workflow-state.json"
+    before = state_path.read_bytes()
+
+    decision = runner.resolve_action(
+        tmp_path,
+        collection.name,
+        config=_config(runner),
+        executor="cloud",
+    )
+
+    assert decision["action"] == "no-op"
+    assert decision["reason"] == "local_ownership"
+    assert decision["resume_action"] is None
+    assert state_path.read_bytes() == before
+
+
+def test_cloud_executor_resumes_suno_after_manifest_handoff(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(
+        tmp_path,
+        "20260721-cloud-owned",
+        phase="cloud_owned",
+        engine="suno",
+        assets={"music_downloaded": True},
+    )
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["planning"]["music"].update(
+        {
+            "expected_file_count": 2,
+            "suno_playlist_url": "https://suno.com/playlist/example",
+        }
+    )
+    state["handoff"] = {
+        "point": "suno_download",
+        "owner": "cloud",
+        "manifest_key": "002ch/sample/suno-download/manifest.json",
+        "root_sha256": "e" * 64,
+    }
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    (collection / "20-documentation" / "suno-prompts.json").write_text(
+        json.dumps({"entries": [{"prompt": "one"}]}),
+        encoding="utf-8",
+    )
+    (collection / "02-Individual-music" / "one.mp3").write_bytes(b"one")
+    (collection / "02-Individual-music" / "two.mp3").write_bytes(b"two")
+
+    cloud = runner.resolve_action(
+        tmp_path,
+        collection.name,
+        config=_config(runner),
+        executor="cloud",
+    )
+    local = runner.resolve_action(
+        tmp_path,
+        collection.name,
+        config=_config(runner),
+        executor="local",
+    )
+
+    assert cloud["phase"] == "cloud_owned"
+    assert cloud["action"] == "masterup"
+    assert cloud["reason"] == "suno_download_complete"
+    assert local["action"] == "no-op"
+    assert local["reason"] == "cloud_ownership"
+
+
 def test_legacy_music_engine_only_state_remains_routable(tmp_path: Path, runner: ModuleType) -> None:
     collection = _collection(tmp_path, "20260721-legacy", engine="lyria")
     state_path = collection / "workflow-state.json"


### PR DESCRIPTION
## 概要

境界引き渡しをworkflow-stateの一方向phase遷移と、manifest参照で決定的に表現します。

## 変更内容

- `prepared`＋Suno download完了から`cloud_owned`へのowner/CLI遷移を追加
- stateにはmanifest keyとroot SHA-256だけを記録
- 同一参照のみ冪等、逆行や不一致をfail-closed化
- executor owner不一致はstate不変のno-op
- cloud executorは引き渡し完了後だけ既存masterupへ進行

## 検証

- focused: 431 passed
- full（rebase前）: 9590 passed, 3 skipped
- Any / ruff / format / yt-skills / build / wheel smoke / CLI help: green

Closes #4051