### PR TITLE
refactor(hybrid): 定期実行境界を能力ベースにする (#4052)

### DIFF
--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -29,6 +29,8 @@ description: "Use when 新規コレクション制作を立ち上げるとき、
 | `--batch` | `references/batch.md` |
 | `--schedule` | `references/schedule.md` |
 
+`--schedule` の実行場所は能力ベースで判定する。local の本来条件は**人間のブラウザ工程（Suno UI）**だけで、企画・プロンプト作成と軽量レジームのメディア・公開工程は cloud とする。基盤制約による暫定例外として、`overlays.enabled: true` の重量レジームだけはメディア工程から publishAt upload まで local とする。OAuth、ffmpeg、ローカルファイルの存在自体は local の理由にしない。詳細と判定 CLI は `references/schedule.md` を正とする。
+
 ## 修飾フラグ
 
 | flag | 対象 mode | 用途 |

--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -19,7 +19,7 @@ automation のリリース追従は `/automation --update`、本体リリース�
 
 1. **`allow_external_publish: true` は明示承認なしに有効化しない。** 対象・頻度・YouTube 書き込みの影響を表示し、「有効化する / しない（既定）」を確認する。
 2. **config と外部 scheduler は dry-run 提示・承認後だけ変更する。** config diff と `schedule_backend.py plan` の全項目を先に表示する。
-3. **ローカル依存を Cloud Job へ登録しない。** ローカルファイル、OAuth、Chrome、Suno Helper、ffmpeg、ローカル media のいずれかが必要なら `local`。対応する local Scheduled Task が利用不能なら停止する。
+3. **実行場所は必要能力で決める。** local の本来条件は人間のブラウザ工程（Suno UI）だけとし、企画・プロンプト作成は cloud とする。メディア・公開は `overlays.enabled: false` の軽量レジームなら cloud、`overlays.enabled: true` の重量レジームなら基盤制約による暫定例外として publishAt upload まで local とする。OAuth、ffmpeg、media、ローカルファイルの存在自体を local の理由にしない。local と判定した工程に対応する Scheduled Task が利用不能なら停止する。
 4. **OS fallback は自動選択しない。** 理由・常時起動要件・製品側の履歴/停止UIを使えない制約を示し、明示承認後だけ `--confirm-os-fallback` を使う。
 5. **同一チャンネルに複数 backend を作らない。** `schedule_backend.py show/guard` で active backend を確認し、切替時は旧 backend を先に disable する。外部登録成功後だけ ID を `record` する。
 6. Step 0 の `fail` が残る場合は停止する。認証操作だけは人間に依頼し、コマンド実行・設定作成は AI が行う。
@@ -60,7 +60,16 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py show
 ```
 
 1. `product-codex` / `product-claude` を既定候補にする。判定不能時だけユーザーに製品を確認する。
-2. 対象 workflow の依存を `cloud` / `local` に分類し、分類根拠を表示する。既定 `wf-new --auto` は local（Chrome / OAuth / media / ffmpeg を利用）として扱う。
+2. 対象工程を `planning` / `prompt` / `suno` / `media` / `publish` から選び、`schedule_backend.py plan --stage` に分類させる。返された `dependency_mode` と `boundary_reason` を表示する。工程別の正準判定は次のとおり。
+
+   | 工程 | 軽量 (`overlays.enabled: false`) | 重量 (`overlays.enabled: true`) | 根拠 |
+   |---|---|---|---|
+   | 企画 (`planning`) / プロンプト (`prompt`) | cloud | cloud | AI 工程は人間のブラウザを必要としない |
+   | Suno (`suno`) | local | local | 人間のブラウザ工程（Suno UI）が必要 |
+   | メディア (`media`) | cloud | local | 重量だけ実行時間・ディスク制約による暫定例外 |
+   | 公開 (`publish`) | cloud | local | 重量は大容量成果物の往復を避け、upload まで同じ local owner が担う |
+
+   したがって 002ch 型の重量チャンネルは企画・prompt が cloud、Suno・media・publish が local、003ch 型の軽量チャンネルは Suno だけが local で他は cloud になる。
 3. active な別 backend があれば、旧 backend の disable が承認・成功するまで停止する。
 
 ### Step 1. config と native task の dry-run
@@ -72,7 +81,7 @@ uv run python .claude/skills/wf-new/references/schedule_config.py generate --dry
   [--target-workflow "wf-new --auto"] [--max-retries <N>] \
   [--retry-delay-seconds <N>] [--notification terminal|none]
 uv run python .claude/skills/wf-new/references/schedule_backend.py plan \
-  --product <codex|claude> --dependency-mode <cloud|local> \
+  --product <codex|claude> --stage <planning|prompt|suno|media|publish> \
   --run-time <HH:MM> --cadence <mon,wed,fri> [--timezone <IANA>] \
   [--target-workflow "wf-new --auto"] [--max-retries <N>] \
   [--retry-delay-seconds <N>] [--notification terminal|none]

--- a/.claude/skills/wf-new/references/schedule_backend.py
+++ b/.claude/skills/wf-new/references/schedule_backend.py
@@ -20,13 +20,26 @@ BACKENDS = (
     "os-fallback",
 )
 PRODUCTS = ("codex", "claude")
-DEPENDENCY_MODES = ("cloud", "local")
+EXECUTION_STAGES = ("planning", "prompt", "suno", "media", "publish")
 WRITE_TOKEN_REFRESH_COMMAND = "uv run yt-oauth --refresh-only"
 WRITE_TOKEN_REAUTH_COMMAND = "uv run yt-oauth"
 
 
 class BackendError(ValueError):
     """Backend selection or state transition is unsafe."""
+
+
+def classify_dependency_mode(*, stage: str, overlays_enabled: bool) -> tuple[str, str]:
+    """Classify a workflow stage by required capability, plus the heavy-media exception."""
+    if stage not in EXECUTION_STAGES:
+        raise BackendError(f"unsupported execution stage: {stage}")
+    if stage in {"planning", "prompt"}:
+        return "cloud", "ai_stage_cloud"
+    if stage == "suno":
+        return "local", "human_browser_required"
+    if overlays_enabled:
+        return "local", "heavy_overlay_temporary_exception"
+    return "cloud", "lightweight_media_cloud"
 
 
 def select_backend(*, product: str, dependency_mode: str, os_fallback: bool = False) -> str:
@@ -60,13 +73,17 @@ def _rrule(run_time: str, cadence: list[str]) -> str:
 def build_plan(
     *,
     product: str,
-    dependency_mode: str,
+    stage: str,
     os_fallback: bool = False,
     overrides: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Build a product-neutral dry-run payload from effective workflow config."""
     config = load_config()
     scheduled = config.workflow.scheduled_automation
+    dependency_mode, boundary_reason = classify_dependency_mode(
+        stage=stage,
+        overlays_enabled=config.youtube.overlays.enabled,
+    )
     overrides = overrides or {}
     run_time = str(overrides.get("run_time") or scheduled.run_time)
     raw_cadence = overrides.get("cadence") or list(scheduled.cadence)
@@ -110,6 +127,7 @@ def build_plan(
         "timezone": str(overrides.get("timezone") or scheduled.timezone),
         "recurrence": _rrule(run_time, cadence),
         "dependency_mode": dependency_mode,
+        "boundary_reason": boundary_reason,
         "target_workflow": target_workflow,
         "max_retries": max_retries,
         "retry_delay_seconds": retry_delay_seconds,
@@ -117,6 +135,7 @@ def build_plan(
         "notification": overrides.get("notification", scheduled.notification),
         "allow_external_publish": allow_external_publish,
     }
+    plan["execution_stage"] = stage
     if backend == "codex-automation":
         plan["management"] = "ChatGPT desktop/web Scheduled; local dependencies require desktop local project"
     elif backend == "claude-code-cloud":
@@ -196,7 +215,7 @@ def _parser() -> argparse.ArgumentParser:
 
     plan = sub.add_parser("plan")
     plan.add_argument("--product", choices=PRODUCTS, required=True)
-    plan.add_argument("--dependency-mode", choices=DEPENDENCY_MODES, required=True)
+    plan.add_argument("--stage", choices=EXECUTION_STAGES, required=True)
     plan.add_argument("--os-fallback", action="store_true")
     plan.add_argument("--timezone")
     plan.add_argument("--run-time")
@@ -230,7 +249,7 @@ def main(argv: list[str] | None = None) -> int:
                 os.chdir(root)
                 payload = build_plan(
                     product=args.product,
-                    dependency_mode=args.dependency_mode,
+                    stage=args.stage,
                     os_fallback=args.os_fallback,
                     overrides={
                         key: value

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(hybrid)`: `/wf-new --schedule` の実行場所判定を能力ベースへ置き換え、Suno UIだけを本来のlocal条件、重量overlayのmedia〜publishを暫定local例外として固定する（#4052）。
 - `feat(hybrid)`: Suno DL後のmanifest key + root SHA-256をworkflow-stateへ記録して`cloud_owned`へ一方向遷移し、resolverが引き渡し前のcloud／引き渡し後のlocalを`no-op`にする工程所有権契約を追加する（#4051）。
 - `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
 - `feat(hybrid)`: MediaStore の R2 bucket・bucket-scoped runtime token・object / multipart lifecycle を Cloudflare provider v5 の独立 Terraform stack で管理し、GCS backend・secret 非永続化・無料枠 retention guardrail・offline mock plan 契約を追加する（#4047）。

--- a/tests/repo/test_automation_schedule_backends.py
+++ b/tests/repo/test_automation_schedule_backends.py
@@ -28,6 +28,55 @@ backend = _load_backend_module()
 
 
 @pytest.mark.parametrize(
+    ("overlays_enabled", "expected"),
+    [
+        (
+            True,
+            {
+                "planning": "cloud",
+                "prompt": "cloud",
+                "suno": "local",
+                "media": "local",
+                "publish": "local",
+            },
+        ),
+        (
+            False,
+            {
+                "planning": "cloud",
+                "prompt": "cloud",
+                "suno": "local",
+                "media": "cloud",
+                "publish": "cloud",
+            },
+        ),
+    ],
+)
+def test_capability_boundary_matches_heavy_and_light_channel_regimes(overlays_enabled, expected):
+    assert {
+        stage: backend.classify_dependency_mode(stage=stage, overlays_enabled=overlays_enabled)[0]
+        for stage in backend.EXECUTION_STAGES
+    } == expected
+
+
+def test_capability_boundary_rejects_unknown_stage():
+    with pytest.raises(backend.BackendError, match="unsupported execution stage"):
+        backend.classify_dependency_mode(stage="oauth", overlays_enabled=False)
+
+
+def test_skill_self_describes_capability_boundary_without_removed_dependency_list():
+    skill = (ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md").read_text(encoding="utf-8")
+    schedule = (REFERENCE_DIR / "schedule.md").read_text(encoding="utf-8")
+    contract = skill + schedule
+
+    assert "人間のブラウザ工程（Suno UI）" in contract
+    assert "overlays.enabled: true" in contract
+    assert "企画・プロンプト" in contract
+    assert "軽量レジーム" in contract
+    assert "ローカルファイル、OAuth、Chrome、Suno Helper、ffmpeg、ローカル media" not in contract
+
+
+@pytest.mark.parametrize(
     ("product", "dependency_mode", "os_fallback", "expected"),
     [
         ("codex", "cloud", False, "codex-automation"),
@@ -56,13 +105,16 @@ def test_plan_is_dry_run_and_preserves_external_publish_gate(tmp_path, monkeypat
     monkeypatch.setattr(
         backend,
         "load_config",
-        lambda: SimpleNamespace(workflow=SimpleNamespace(scheduled_automation=scheduled)),
+        lambda: SimpleNamespace(
+            workflow=SimpleNamespace(scheduled_automation=scheduled),
+            youtube=SimpleNamespace(overlays=SimpleNamespace(enabled=False)),
+        ),
     )
     monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
 
     plan = backend.build_plan(
         product="codex",
-        dependency_mode="local",
+        stage="suno",
         overrides={"run_time": "10:15", "cadence": "tue,thu", "max_retries": 4},
     )
 
@@ -100,14 +152,47 @@ def test_cloud_plan_does_not_require_local_write_token_maintenance(tmp_path, mon
     monkeypatch.setattr(
         backend,
         "load_config",
-        lambda: SimpleNamespace(workflow=SimpleNamespace(scheduled_automation=scheduled)),
+        lambda: SimpleNamespace(
+            workflow=SimpleNamespace(scheduled_automation=scheduled),
+            youtube=SimpleNamespace(overlays=SimpleNamespace(enabled=False)),
+        ),
     )
     monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
 
-    plan = backend.build_plan(product="claude", dependency_mode="cloud")
+    plan = backend.build_plan(product="claude", stage="planning")
 
     assert plan["prompt"].startswith("/wf-new --auto")
     assert "yt-oauth" not in plan["prompt"]
+
+
+def test_plan_derives_dependency_mode_from_stage_and_overlay_regime(tmp_path, monkeypatch):
+    scheduled = SimpleNamespace(
+        target_workflow="wf-new --auto",
+        allow_external_publish=False,
+        timezone="Asia/Tokyo",
+        run_time="09:05",
+        cadence=("mon",),
+        max_retries=0,
+        retry_delay_seconds=300,
+        prevent_concurrent_runs=True,
+        notification="none",
+    )
+    monkeypatch.setattr(
+        backend,
+        "load_config",
+        lambda: SimpleNamespace(
+            workflow=SimpleNamespace(scheduled_automation=scheduled),
+            youtube=SimpleNamespace(overlays=SimpleNamespace(enabled=True)),
+        ),
+    )
+    monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
+
+    plan = backend.build_plan(product="claude", stage="media")
+
+    assert plan["dependency_mode"] == "local"
+    assert plan["execution_stage"] == "media"
+    assert plan["boundary_reason"] == "heavy_overlay_temporary_exception"
+    assert plan["backend"] == "claude-cowork-local"
 
 
 @pytest.mark.parametrize("removed_target", ["automation-run", "wf-auto"])
@@ -126,14 +211,17 @@ def test_plan_rejects_removed_target_override(tmp_path, monkeypatch, removed_tar
     monkeypatch.setattr(
         backend,
         "load_config",
-        lambda: SimpleNamespace(workflow=SimpleNamespace(scheduled_automation=scheduled)),
+        lambda: SimpleNamespace(
+            workflow=SimpleNamespace(scheduled_automation=scheduled),
+            youtube=SimpleNamespace(overlays=SimpleNamespace(enabled=False)),
+        ),
     )
     monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
 
     with pytest.raises(backend.BackendError, match=rf"{removed_target}.*wf-new --auto"):
         backend.build_plan(
             product="codex",
-            dependency_mode="local",
+            stage="planning",
             overrides={"target_workflow": removed_target},
         )
 


### PR DESCRIPTION
## 概要

automation scheduleのcloud/local境界を手動dependency modeから、stageとchannel capabilityによる決定的判定へ置換します。

## 変更内容

- plan入力をcanonical `--stage`へ統一
- overlay capabilityからcloud/local executorを導出
- 重量channelはplanning/prompt=cloud、suno/media/publish=local
- 軽量channelはsunoのみlocal、他stageはcloud
- boundary reasonをplanへ出力
- active skill/referenceから旧OAuth/ffmpeg列挙を撤廃

## 検証

- focused: 103 passed
- full（rebase前）: 9595 passed, 3 skipped
- ruff / format / Any / yt-skills / site 53 / build / wheel: green

Closes #4052