### PR TITLE
feat(hybrid): Suno DL後のR2引き渡しを自動化する (#4048)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(hybrid)`: Git clone、検証済みMediaStore pull、単一agent境界、成果物push、state commit/pushをuv直行で束ねる基盤非依存サンドイッチrunnerを追加する（#4053）。
 - `refactor(hybrid)`: `/wf-new --schedule` の実行場所判定を能力ベースへ置き換え、Suno UIだけを本来のlocal条件、重量overlayのmedia〜publishを暫定local例外として固定する（#4052）。
+- `feat(hybrid)`: suno-helper の一括 DL 完了後に音源を再実行安全な manifest-last R2 handoff へ自動送信し、検証済み manifest key と root SHA-256 の state 記録後に通知 event を発火する（#4048）。
 - `feat(hybrid)`: Suno DL後のmanifest key + root SHA-256をworkflow-stateへ記録して`cloud_owned`へ一方向遷移し、resolverが引き渡し前のcloud／引き渡し後のlocalを`no-op`にする工程所有権契約を追加する（#4051）。
 - `feat(hybrid)`: Git制御面stateを読む前のfast-forward pullと、更新後の即時commit + pushを共通化し、non-fast-forward競合では自動merge/rebaseせず通知eventを発火して停止する（#4050）。
 - `feat(hybrid)`: MediaStore の R2 bucket・bucket-scoped runtime token・object / multipart lifecycle を Cloudflare provider v5 の独立 Terraform stack で管理し、GCS backend・secret 非永続化・無料枠 retention guardrail・offline mock plan 契約を追加する（#4047）。

--- a/src/youtube_automation/application/media_handoff.py
+++ b/src/youtube_automation/application/media_handoff.py
@@ -57,7 +57,7 @@ def _assert_metadata(
         )
 
 
-def _assert_file(expected: HandoffFile, path: Path, *, operation: str) -> None:
+def _assert_file(expected: HandoffFile | MediaObjectMetadata, path: Path, *, operation: str) -> None:
     size, checksum = sha256_file(path)
     if size != expected.size or checksum != expected.sha256:
         raise MediaStoreError(f"受け渡し object {operation} content checksum が一致しません: {expected.path}")
@@ -88,8 +88,10 @@ def push_handoff(
         verification_root = Path(verification_directory)
         for entry in manifest.files:
             key = _key(identity, entry.path)
-            pushed = store.push(sources_by_path[entry.path], key)
-            _assert_metadata(entry, pushed, object_path=entry.path, operation="push")
+            remote = store.metadata(key)
+            if remote is None or remote.size != entry.size or remote.sha256 != entry.sha256:
+                pushed = store.push(sources_by_path[entry.path], key)
+                _assert_metadata(entry, pushed, object_path=entry.path, operation="push")
             _assert_metadata(entry, store.metadata(key), object_path=entry.path, operation="remote")
             verification_path = verification_root.joinpath(*entry.path.split("/"))
             pulled = store.pull(key, verification_path)
@@ -100,8 +102,14 @@ def push_handoff(
         manifest_path.write_bytes(manifest.to_json_bytes())
         expected_manifest = _manifest_file(manifest_path)
         manifest_key = _key(identity, MANIFEST_NAME)
-        pushed_manifest = store.push(manifest_path, manifest_key)
-        _assert_metadata(expected_manifest, pushed_manifest, object_path=MANIFEST_NAME, operation="manifest push")
+        remote_manifest = store.metadata(manifest_key)
+        if (
+            remote_manifest is None
+            or remote_manifest.size != expected_manifest.size
+            or remote_manifest.sha256 != expected_manifest.sha256
+        ):
+            pushed_manifest = store.push(manifest_path, manifest_key)
+            _assert_metadata(expected_manifest, pushed_manifest, object_path=MANIFEST_NAME, operation="manifest push")
         _assert_metadata(
             expected_manifest,
             store.metadata(manifest_key),
@@ -122,18 +130,15 @@ def push_handoff(
     return manifest
 
 
-def pull_handoff(store: MediaStore, identity: HandoffIdentity, destination: Path) -> HandoffManifest:
+def read_handoff_manifest(store: MediaStore, identity: HandoffIdentity) -> HandoffManifest:
     manifest_key = _key(identity, MANIFEST_NAME)
     manifest_metadata = store.metadata(manifest_key)
     if manifest_metadata is None:
         raise MediaHandoffNotFoundError(
             f"受け渡し manifest が見つかりません: {identity.channel}/{identity.collection}/{identity.handoff}"
         )
-
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    with tempfile.TemporaryDirectory(prefix="yt-handoff-pull-", dir=destination.parent) as staging_directory:
-        staging_root = Path(staging_directory)
-        manifest_path = staging_root / MANIFEST_NAME
+    with tempfile.TemporaryDirectory(prefix="yt-handoff-manifest-") as staging_directory:
+        manifest_path = Path(staging_directory) / MANIFEST_NAME
         pulled_manifest = store.pull(manifest_key, manifest_path)
         if pulled_manifest != manifest_metadata:
             raise MediaStoreError("受け渡し manifest metadata が読み取り中に変化しました")
@@ -143,7 +148,15 @@ def pull_handoff(store: MediaStore, identity: HandoffIdentity, destination: Path
         manifest = HandoffManifest.from_json_bytes(manifest_path.read_bytes())
         if manifest.identity != identity:
             raise MediaStoreError("受け渡し manifest key と identity が一致しません")
+        return manifest
 
+
+def pull_handoff(store: MediaStore, identity: HandoffIdentity, destination: Path) -> HandoffManifest:
+    manifest = read_handoff_manifest(store, identity)
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="yt-handoff-pull-", dir=destination.parent) as staging_directory:
+        staging_root = Path(staging_directory)
         for entry in manifest.files:
             staging_path = staging_root.joinpath(*entry.path.split("/"))
             pulled = store.pull(_key(identity, entry.path), staging_path)

--- a/src/youtube_automation/application/suno_download_handoff.py
+++ b/src/youtube_automation/application/suno_download_handoff.py
@@ -1,0 +1,127 @@
+"""Suno download 完了から cloud 所有への境界引き渡し。"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from youtube_automation.application.media_handoff import (
+    HandoffSource,
+    push_handoff,
+    read_handoff_manifest,
+)
+from youtube_automation.core.errors import MediaStoreError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
+from youtube_automation.domains.media_handoff_manifest import MANIFEST_NAME, HandoffIdentity, HandoffManifest
+from youtube_automation.domains.media_store import MediaKey, MediaStore
+from youtube_automation.domains.suno.downloaded.archive import list_audio_files
+from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
+
+_HANDOFF_POINT = "suno_download"
+_HANDOFF_KEY_SEGMENT = "suno-download"
+_MUSIC_DIRECTORY = "02-Individual-music"
+
+
+class SunoDownloadHandoffEventKind(StrEnum):
+    COMPLETED = "completed"
+
+
+@dataclass(frozen=True, slots=True)
+class SunoDownloadHandoffEvent:
+    kind: SunoDownloadHandoffEventKind
+    channel: str
+    collection: str
+    manifest_key: str
+    root_sha256: str
+
+
+SunoDownloadHandoffEventSink = Callable[[SunoDownloadHandoffEvent], None]
+
+
+@dataclass(frozen=True, slots=True)
+class SunoDownloadHandoffResult:
+    manifest_key: str
+    root_sha256: str
+    already_completed: bool
+
+
+class SunoDownloadHandoff:
+    def __init__(
+        self,
+        *,
+        store: MediaStore,
+        channel: str,
+        on_event: SunoDownloadHandoffEventSink | None = None,
+    ) -> None:
+        self._store = store
+        self._channel = channel
+        self._on_event = on_event
+
+    def complete(self, collection_dir: Path) -> SunoDownloadHandoffResult:
+        paths = CollectionPaths(collection_dir)
+        identity = HandoffIdentity(self._channel, paths.root.name, _HANDOFF_KEY_SEGMENT)
+        manifest_key = MediaKey(identity.channel, identity.collection, identity.handoff, MANIFEST_NAME).as_posix()
+        state = read_workflow_state(paths.workflow_state_path)
+        completed = self._completed_manifest(state, identity, manifest_key)
+        if completed is not None:
+            return SunoDownloadHandoffResult(manifest_key, completed.root_sha256, True)
+
+        preview = WorkflowState(state.to_dict())
+        preview.record_cloud_handoff(
+            point=_HANDOFF_POINT,
+            manifest_key=manifest_key,
+            root_sha256="0" * 64,
+        )
+        sources = self._sources(paths.music_dir)
+        manifest = push_handoff(self._store, identity, sources)
+        update_workflow_state(
+            paths.workflow_state_path,
+            lambda current: current.record_cloud_handoff(
+                point=_HANDOFF_POINT,
+                manifest_key=manifest_key,
+                root_sha256=manifest.root_sha256,
+            ),
+        )
+        event = SunoDownloadHandoffEvent(
+            kind=SunoDownloadHandoffEventKind.COMPLETED,
+            channel=identity.channel,
+            collection=identity.collection,
+            manifest_key=manifest_key,
+            root_sha256=manifest.root_sha256,
+        )
+        if self._on_event is not None:
+            self._on_event(event)
+        return SunoDownloadHandoffResult(manifest_key, manifest.root_sha256, False)
+
+    def _completed_manifest(
+        self,
+        state: WorkflowState,
+        identity: HandoffIdentity,
+        manifest_key: str,
+    ) -> HandoffManifest | None:
+        if state.phase != "cloud_owned":
+            return None
+        handoff = state.handoff
+        if (
+            handoff is None
+            or handoff.point != _HANDOFF_POINT
+            or handoff.owner != "cloud"
+            or handoff.manifest_key != manifest_key
+            or handoff.root_sha256 is None
+        ):
+            raise WorkflowStateError("workflow-state cloud handoff reference is incomplete or conflicting")
+        manifest = read_handoff_manifest(self._store, identity)
+        if manifest.root_sha256 != handoff.root_sha256:
+            raise MediaStoreError("受け渡し manifest root checksum が workflow-state と一致しません")
+        return manifest
+
+    @staticmethod
+    def _sources(music_dir: Path) -> tuple[HandoffSource, ...]:
+        audio_files = list_audio_files(music_dir)
+        if not audio_files:
+            raise MediaStoreError("Suno download 引き渡し対象の音声ファイルがありません")
+        return tuple(HandoffSource(path, f"{_MUSIC_DIRECTORY}/{path.name}") for path in audio_files)

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -46,6 +46,7 @@ from pathlib import Path
 
 from youtube_automation import __version__
 from youtube_automation.application.distrokid.disc_query import find_distrokid_discs
+from youtube_automation.application.suno_download_handoff import SunoDownloadHandoff
 from youtube_automation.commands.collections.collection_serve_discovery import (
     DISCOVERY_PORT,
     RegistryState,
@@ -53,7 +54,7 @@ from youtube_automation.commands.collections.collection_serve_discovery import (
     handle_registry_request,
 )
 from youtube_automation.configuration import Distrokid, channel_dir, load_config
-from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.core.errors import ConfigError, MediaStoreError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.distrokid.metadata import parse_album_metadata
 from youtube_automation.domains.distrokid.release import (
@@ -73,7 +74,10 @@ from youtube_automation.domains.suno.downloaded import (
     parse_downloaded_payload,
     read_pattern_count,
 )
-from youtube_automation.domains.suno.downloaded.apply import apply_downloaded_artifacts_detailed
+from youtube_automation.domains.suno.downloaded.apply import (
+    apply_downloaded_artifacts_detailed,
+    cleanup_downloaded_archive,
+)
 from youtube_automation.domains.suno.downloaded.models import (
     COLLECTIONS_ROUTE,
     DOCUMENTATION_DIRNAME,
@@ -93,6 +97,7 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
 )
 from youtube_automation.infrastructure.file_lock import file_lock
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
+from youtube_automation.infrastructure.media_store import R2MediaStore, R2MediaStoreConfig
 
 DEFAULT_PORT = 7873
 DEFAULT_IDLE_TIMEOUT_SECONDS = 60 * 60
@@ -117,6 +122,7 @@ _COLLECTION_DIR_SUFFIX = "-collection"
 # DistroKid dir mode: リリース記録の出力先 JSON（`<root>/config/distrokid-releases.json`）（#934）。
 _DISTROKID_RELEASES_OUTPUT_RELPATH = Path("config") / "distrokid-releases.json"
 _DISTROKID_CAPTURE_ROOT_ENV = "DISTROKID_CAPTURE_ROOT"
+_R2_HANDOFF_ENVIRONMENT = frozenset({"R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_API_TOKEN", "R2_BUCKET", "R2_PREFIX"})
 
 # 30-distrokid サブディレクトリ名（#934）。コレクション配下のこのサブディレクトリが disc を含む。
 _DISTROKID_DIRNAME = "30-distrokid"
@@ -947,6 +953,7 @@ def _configuration_fingerprint(
     capture_root: Path | None,
     distrokid_source: str | None,
     idle_timeout_seconds: float,
+    downloaded_handoff_enabled: bool,
 ) -> str:
     payload = json.dumps(
         {
@@ -956,6 +963,7 @@ def _configuration_fingerprint(
             "capture_root": str(capture_root.resolve()) if capture_root is not None else None,
             "distrokid_source": distrokid_source,
             "idle_timeout_seconds": idle_timeout_seconds,
+            "downloaded_handoff_enabled": downloaded_handoff_enabled,
         },
         sort_keys=True,
         separators=(",", ":"),
@@ -1037,6 +1045,7 @@ def create_server(
     idle_timeout_seconds: float = DEFAULT_IDLE_TIMEOUT_SECONDS,
     lifecycle_record: _LifecycleRecord | None = None,
     lifecycle_root: Path | None = None,
+    downloaded_handoff: SunoDownloadHandoff | None = None,
 ) -> ThreadingHTTPServer:
     """サブパス分離した GET / POST / CORS preflight を返すサーバーを生成する.
 
@@ -1168,6 +1177,7 @@ def create_server(
                     coll_dir,
                     downloaded,
                     prompt_entries_reader=read_suno_prompt_entries,
+                    defer_archive_cleanup=True,
                 )
             except DownloadedPayloadError:
                 self.send_error(400, "Bad Request")
@@ -1175,6 +1185,13 @@ def create_server(
             except DownloadedArtifactError as exc:
                 self._send_json_error(500, str(exc))
                 return
+            if downloaded.download_path and downloaded_handoff is not None:
+                try:
+                    downloaded_handoff.complete(coll_dir)
+                except (MediaStoreError, WorkflowStateError) as exc:
+                    self._send_json_error(500, str(exc))
+                    return
+            cleanup_downloaded_archive(downloaded)
             resp: dict = {"ok": True, "collection_id": cid, "placed_count": apply_result.placed_count}
             # playlist URL だけを記録する先行 POST は legacy 応答を維持し、実 ZIP 適用後だけ summary を返す。
             if downloaded.download_path:
@@ -1628,6 +1645,21 @@ def _resolve_distrokid_capture_root(root_arg: str | None) -> Path | None:
     return Path(root).expanduser() if root is not None else None
 
 
+def _r2_handoff_requested() -> bool:
+    return any(name in os.environ for name in _R2_HANDOFF_ENVIRONMENT)
+
+
+def _build_downloaded_handoff(channel_short: str) -> SunoDownloadHandoff | None:
+    """明示された R2 設定だけを download 完了 handoff に配線する。"""
+    if not _r2_handoff_requested():
+        return None
+    channel = re.sub(r"[^a-z0-9]+", "-", channel_short.strip().lower()).strip("-")
+    if not channel:
+        raise ConfigError("R2 handoff の channel identifier を channel_short から解決できません")
+    config = R2MediaStoreConfig.from_environment()
+    return SunoDownloadHandoff(store=R2MediaStore(config), channel=channel)
+
+
 def _resolve_allow_origin(
     allow_origin: str | None, allow_extension: str | None
 ) -> tuple[str | None, ChromeExtensionOrigin | None]:
@@ -1724,6 +1756,7 @@ def main() -> None:
     capture_root = _resolve_distrokid_capture_root(args.distrokid_capture_root)
     allow_origin, detected_extension = _resolve_allow_origin(args.allow_origin, args.allow_extension)
     embedded_registry_state = RegistryState() if args.port == DISCOVERY_PORT else None
+    r2_handoff_requested = _r2_handoff_requested()
 
     # path が `*-collection/` を並べたディレクトリなら dir mode（#816）。
     collection_dirs = find_collection_dirs(args.path)
@@ -1735,6 +1768,7 @@ def main() -> None:
         capture_root=capture_root,
         distrokid_source=args.distrokid_source,
         idle_timeout_seconds=args.idle_timeout,
+        downloaded_handoff_enabled=r2_handoff_requested,
     )
     requested_pid_path = _pid_file_path(lifecycle_root, args.port)
     lifecycle_record = _LifecycleRecord(
@@ -1752,10 +1786,13 @@ def main() -> None:
             channel_name = config.meta.channel_name
             channel_short = config.meta.channel_short
         except ConfigError:
+            if r2_handoff_requested:
+                raise
             distrokid_cfg = None
             channel_name = "YouTube Automation"
             channel_short = "YA"
         distrokid_capture_active = distrokid_cfg is not None and distrokid_cfg.enabled
+        downloaded_handoff = _build_downloaded_handoff(channel_short)
     else:
         # community-draft だけを使う collection は suno-prompts.json を持たなくても起動可能。
         prompts_path = _resolve_single_mode_prompts_path(args.path)
@@ -1790,6 +1827,7 @@ def main() -> None:
                 idle_timeout_seconds=args.idle_timeout,
                 lifecycle_record=lifecycle_record,
                 lifecycle_root=lifecycle_root,
+                downloaded_handoff=downloaded_handoff,
             )
         else:
             server = create_server(

--- a/src/youtube_automation/domains/media_store.py
+++ b/src/youtube_automation/domains/media_store.py
@@ -10,6 +10,7 @@ from typing import Protocol, runtime_checkable
 from youtube_automation.core.errors import ValidationError
 
 _KEY_SEGMENT_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*\Z")
+_CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def validate_media_segment(field: str, value: str) -> None:
@@ -24,7 +25,8 @@ def validate_media_relative_path(field: str, value: str) -> None:
     if path.as_posix() != value:
         raise ValidationError(f"MediaKey.{field} は正規化済み path である必要があります: {value!r}")
     for segment in path.parts:
-        validate_media_segment(field, segment)
+        if segment in {"", ".", ".."} or _CONTROL_CHARACTER_RE.search(segment):
+            raise ValidationError(f"MediaKey.{field} は安全な相対 POSIX path である必要があります: {value!r}")
 
 
 @dataclass(frozen=True)

--- a/src/youtube_automation/domains/suno/downloaded/apply.py
+++ b/src/youtube_automation/domains/suno/downloaded/apply.py
@@ -70,6 +70,7 @@ def apply_downloaded_artifacts_detailed(
     payload: DownloadedPayload,
     *,
     prompt_entries_reader: PromptEntriesReader,
+    defer_archive_cleanup: bool = False,
 ) -> DownloadedApplyResult:
     pattern_count = read_pattern_count(coll_dir, prompt_entries_reader=prompt_entries_reader, default=0)
     expected_count = cast(int, expected_download_count(pattern_count, payload.expected_file_count))
@@ -123,12 +124,17 @@ def apply_downloaded_artifacts_detailed(
     finally:
         if music_backup_dir is not None:
             shutil.rmtree(music_backup_dir, ignore_errors=True)
+    if not defer_archive_cleanup:
+        cleanup_downloaded_archive(payload)
+    return result
+
+
+def cleanup_downloaded_archive(payload: DownloadedPayload) -> None:
     if payload.download_path:
         try:
             Path(payload.download_path).unlink()
         except OSError as exc:
             logger.warning("Suno download ZIP cleanup failed for %s: %s", payload.download_path, exc)
-    return result
 
 
 def apply_downloaded_artifacts(

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -35,9 +35,15 @@ class DownloadedArchiveResult:
 
 
 def count_audio_files(music_dir: Path) -> int:
+    return len(list_audio_files(music_dir))
+
+
+def list_audio_files(music_dir: Path) -> tuple[Path, ...]:
     if not music_dir.is_dir():
-        return 0
-    return sum(1 for f in music_dir.iterdir() if f.is_file() and f.suffix.lower() in _AUDIO_EXTENSIONS)
+        return ()
+    return tuple(
+        sorted(path for path in music_dir.iterdir() if path.is_file() and path.suffix.lower() in _AUDIO_EXTENSIONS)
+    )
 
 
 def commit_staged_music_files(coll_dir: Path, staging_dir: Path) -> None:

--- a/tests/application/test_suno_download_handoff.py
+++ b/tests/application/test_suno_download_handoff.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.application.suno_download_handoff import (
+    SunoDownloadHandoff,
+    SunoDownloadHandoffEventKind,
+)
+from youtube_automation.core.errors import MediaStoreError, WorkflowStateError
+from youtube_automation.domains.media_store import MediaKey, MediaObjectMetadata, MediaStore
+from youtube_automation.infrastructure.media_store.local import LocalMediaStore
+
+
+class RecordingStore:
+    def __init__(self, delegate: MediaStore, *, fail_manifest_once: bool = False) -> None:
+        self.delegate = delegate
+        self.fail_manifest_once = fail_manifest_once
+        self.pushes: list[str] = []
+
+    def push(self, source: Path, key: MediaKey) -> MediaObjectMetadata:
+        self.pushes.append(key.as_posix())
+        if key.name == "manifest.json" and self.fail_manifest_once:
+            self.fail_manifest_once = False
+            raise MediaStoreError("fixture manifest interruption")
+        return self.delegate.push(source, key)
+
+    def pull(self, key: MediaKey, destination: Path) -> MediaObjectMetadata:
+        return self.delegate.pull(key, destination)
+
+    def exists(self, key: MediaKey) -> bool:
+        return self.delegate.exists(key)
+
+    def metadata(self, key: MediaKey) -> MediaObjectMetadata | None:
+        return self.delegate.metadata(key)
+
+
+def _collection(tmp_path: Path) -> Path:
+    collection = tmp_path / "20260816-clm-rainy-jazz-collection"
+    music = collection / "02-Individual-music"
+    music.mkdir(parents=True)
+    (music / "01a-Rainy Jazz 夜.mp3").write_bytes(b"first")
+    (music / "01b-Rainy Jazz 夜.mp3").write_bytes(b"second")
+    (collection / "workflow-state.json").write_text(
+        json.dumps(
+            {
+                "phase": "prepared",
+                "planning": {"music": {"engine": "suno"}},
+                "assets": {"music_downloaded": True},
+                "future": {"keep": True},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return collection
+
+
+def test_complete_pushes_manifest_then_records_cloud_owner_and_emits_event(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    store = RecordingStore(LocalMediaStore(tmp_path / "remote"))
+    events = []
+    handoff = SunoDownloadHandoff(store=store, channel="002ch", on_event=events.append)
+
+    result = handoff.complete(collection)
+
+    assert store.pushes[-1] == result.manifest_key
+    assert result.manifest_key == "002ch/20260816-clm-rainy-jazz-collection/suno-download/manifest.json"
+    assert result.already_completed is False
+    state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+    assert state["phase"] == "cloud_owned"
+    assert state["handoff"] == {
+        "point": "suno_download",
+        "owner": "cloud",
+        "manifest_key": result.manifest_key,
+        "root_sha256": result.root_sha256,
+    }
+    assert state["future"] == {"keep": True}
+    assert len(events) == 1
+    assert events[0].kind is SunoDownloadHandoffEventKind.COMPLETED
+    assert events[0].manifest_key == result.manifest_key
+
+
+def test_complete_reuses_verified_manifest_without_pushing_or_emitting_twice(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    store = RecordingStore(LocalMediaStore(tmp_path / "remote"))
+    events = []
+    handoff = SunoDownloadHandoff(store=store, channel="002ch", on_event=events.append)
+    first = handoff.complete(collection)
+    pushes_after_first = tuple(store.pushes)
+
+    second = handoff.complete(collection)
+
+    assert second.manifest_key == first.manifest_key
+    assert second.root_sha256 == first.root_sha256
+    assert second.already_completed is True
+    assert tuple(store.pushes) == pushes_after_first
+    assert len(events) == 1
+
+
+def test_manifest_failure_keeps_prepared_state_and_retry_skips_verified_audio_objects(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    store = RecordingStore(LocalMediaStore(tmp_path / "remote"), fail_manifest_once=True)
+    events = []
+    handoff = SunoDownloadHandoff(store=store, channel="002ch", on_event=events.append)
+
+    with pytest.raises(MediaStoreError, match="fixture manifest interruption"):
+        handoff.complete(collection)
+
+    state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+    assert state["phase"] == "prepared"
+    first_attempt_pushes = tuple(store.pushes)
+    assert not events
+
+    result = handoff.complete(collection)
+
+    assert result.already_completed is False
+    audio_keys = [key for key in store.pushes if key != result.manifest_key]
+    assert len(audio_keys) == 2
+    assert len(first_attempt_pushes) == 3
+    assert len(events) == 1
+
+
+def test_complete_rejects_invalid_state_before_remote_write(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["phase"] = "planning"
+    state_path.write_text(json.dumps(state), encoding="utf-8")
+    store = RecordingStore(LocalMediaStore(tmp_path / "remote"))
+    handoff = SunoDownloadHandoff(store=store, channel="002ch")
+
+    with pytest.raises(WorkflowStateError, match="requires phase prepared"):
+        handoff.complete(collection)
+
+    assert store.pushes == []

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -55,7 +55,7 @@ from youtube_automation.commands.collections.collection_serve import (
     resolve_prompts_path,
 )
 from youtube_automation.commands.collections.collection_serve_discovery import DISCOVERY_PATH, RegistryState
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, MediaStoreError
 from youtube_automation.domains.documents.rendering import render_repository_document
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
 from youtube_automation.domains.suno.downloaded.apply import apply_downloaded_artifacts
@@ -1164,6 +1164,51 @@ def test_main_resolves_allow_extension_to_allow_origin(monkeypatch, capsys, tmp_
     assert "serve token: GET http://test-channel.localhost:7873/auth/token" in stdout
 
 
+def test_build_downloaded_handoff_is_disabled_when_r2_is_not_configured(monkeypatch):
+    for name in ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_API_TOKEN", "R2_BUCKET", "R2_PREFIX"):
+        monkeypatch.delenv(name, raising=False)
+
+    assert collection_serve_module._build_downloaded_handoff("TC") is None
+
+
+def test_build_downloaded_handoff_rejects_partial_r2_configuration(monkeypatch):
+    for name in ("R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_API_TOKEN", "R2_PREFIX"):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("R2_BUCKET", "media-handoffs")
+    monkeypatch.setenv("YOUTUBE_AUTOMATION_DISABLE_OP_READ", "1")
+
+    with pytest.raises(ConfigError, match="R2_ACCOUNT_ID"):
+        collection_serve_module._build_downloaded_handoff("TC")
+
+
+def test_build_downloaded_handoff_wires_configured_r2_store(monkeypatch):
+    sentinel_config = object()
+    sentinel_store = object()
+    sentinel_handoff = object()
+    recorded: dict[str, object] = {}
+
+    class FakeConfig:
+        @classmethod
+        def from_environment(cls):
+            return sentinel_config
+
+    def fake_store(config):
+        assert config is sentinel_config
+        return sentinel_store
+
+    def fake_handoff(*, store, channel):
+        recorded.update(store=store, channel=channel)
+        return sentinel_handoff
+
+    monkeypatch.setenv("R2_BUCKET", "media-handoffs")
+    monkeypatch.setattr(collection_serve_module, "R2MediaStoreConfig", FakeConfig)
+    monkeypatch.setattr(collection_serve_module, "R2MediaStore", fake_store)
+    monkeypatch.setattr(collection_serve_module, "SunoDownloadHandoff", fake_handoff)
+
+    assert collection_serve_module._build_downloaded_handoff("Test Channel") is sentinel_handoff
+    assert recorded == {"store": sentinel_store, "channel": "test-channel"}
+
+
 def test_main_turns_sigterm_into_traceable_exception_and_restores_handler(monkeypatch, tmp_path):
     """SIGTERM は理由を持つ例外として伝播し、終了後に handler を復元する。"""
 
@@ -2101,7 +2146,7 @@ def serve_dir(tmp_path):
     """
     started = []
 
-    def _start(planning: Path, allow_origin=None, capture_root=None):
+    def _start(planning: Path, allow_origin=None, capture_root=None, downloaded_handoff=None):
         server = create_server(
             0,
             allow_origin,
@@ -2110,6 +2155,7 @@ def serve_dir(tmp_path):
             distrokid=None,
             collections_root=planning,
             capture_root=capture_root,
+            downloaded_handoff=downloaded_handoff,
         )
         thread = threading.Thread(target=server.serve_forever, daemon=True)
         thread.start()
@@ -3449,6 +3495,85 @@ def test_post_downloaded_success_removes_download_archive(serve_dir, tmp_path):
     ]
     workflow_state = json.loads((coll / "workflow-state.json").read_text(encoding="utf-8"))
     assert workflow_state["assets"]["music_downloaded"] is True
+
+
+def test_post_downloaded_runs_handoff_after_atomic_music_placement(serve_dir, tmp_path):
+    planning = tmp_path / "planning"
+    coll = _make_collection(
+        planning,
+        "20260601-clm-aaa-collection",
+        entries=[{"name": "曲A — Song A", "style": "s", "lyrics": ""}],
+    )
+    zip_path = _make_zip(tmp_path / "handoff.zip", {"Song A.mp3": b"a", "Song A_1.mp3": b"b"})
+    observations = []
+
+    class Handoff:
+        def complete(self, collection_dir: Path) -> None:
+            state = json.loads((collection_dir / "workflow-state.json").read_text(encoding="utf-8"))
+            observations.append(
+                (
+                    collection_dir,
+                    sorted(path.name for path in (collection_dir / "02-Individual-music").iterdir()),
+                    state["assets"]["music_downloaded"],
+                )
+            )
+
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN, downloaded_handoff=Handoff())
+    token = _fetch_token(base)
+
+    with _post(
+        f"{base}{_COLLECTIONS_ROUTE}/{coll.name}/downloaded",
+        {
+            "file_count": 2,
+            "expected_file_count": 2,
+            "format": "mp3",
+            "download_path": str(zip_path),
+        },
+        headers={"Origin": _EXTENSION_ORIGIN, "X-Serve-Token": token},
+    ) as response:
+        assert response.status == 200
+
+    assert observations == [(coll, ["01a-Song A.mp3", "01b-Song A.mp3"], True)]
+    assert not zip_path.exists()
+
+
+def test_post_downloaded_handoff_failure_keeps_archive_for_safe_retry(serve_dir, tmp_path):
+    planning = tmp_path / "planning"
+    coll = _make_collection(
+        planning,
+        "20260601-clm-aaa-collection",
+        entries=[{"name": "曲A — Song A", "style": "s", "lyrics": ""}],
+    )
+    zip_path = _make_zip(tmp_path / "retry.zip", {"Song A.mp3": b"a", "Song A_1.mp3": b"b"})
+
+    class Handoff:
+        fail = True
+
+        def complete(self, _collection_dir: Path) -> None:
+            if self.fail:
+                self.fail = False
+                raise MediaStoreError("fixture R2 unavailable")
+
+    handoff = Handoff()
+    base = serve_dir(planning, allow_origin=_EXTENSION_ORIGIN, downloaded_handoff=handoff)
+    token = _fetch_token(base)
+    url = f"{base}{_COLLECTIONS_ROUTE}/{coll.name}/downloaded"
+    payload = {
+        "file_count": 2,
+        "expected_file_count": 2,
+        "format": "mp3",
+        "download_path": str(zip_path),
+    }
+    headers = {"Origin": _EXTENSION_ORIGIN, "X-Serve-Token": token}
+
+    with pytest.raises(urllib.error.HTTPError) as raised:
+        _post(url, payload, headers=headers)
+
+    assert raised.value.code == 500
+    assert zip_path.exists()
+    with _post(url, payload, headers=headers) as response:
+        assert response.status == 200
+    assert not zip_path.exists()
 
 
 def test_post_downloaded_archive_cleanup_failure_warns_and_keeps_artifacts(serve_dir, tmp_path, monkeypatch, caplog):

--- a/tests/commands/collections/test_collection_serve_lifecycle.py
+++ b/tests/commands/collections/test_collection_serve_lifecycle.py
@@ -284,6 +284,7 @@ def test_main_reuses_live_server_without_creating_another_process(monkeypatch, c
         capture_root=None,
         distrokid_source=None,
         idle_timeout_seconds=collection_serve.DEFAULT_IDLE_TIMEOUT_SECONDS,
+        downloaded_handoff_enabled=False,
     )
     record = collection_serve._LifecycleRecord(os.getpid(), "reuse-token", configuration)
     server = collection_serve.create_server(
@@ -382,6 +383,7 @@ def test_main_does_not_reuse_server_with_incompatible_configuration(monkeypatch,
         capture_root=None,
         distrokid_source=None,
         idle_timeout_seconds=collection_serve.DEFAULT_IDLE_TIMEOUT_SECONDS,
+        downloaded_handoff_enabled=False,
     )
     record = collection_serve._LifecycleRecord(os.getpid(), "configuration-token", configuration)
     server = collection_serve.create_server(
@@ -432,6 +434,7 @@ def test_main_does_not_reuse_dir_server_for_single_file_mode(monkeypatch, tmp_pa
         capture_root=None,
         distrokid_source=None,
         idle_timeout_seconds=collection_serve.DEFAULT_IDLE_TIMEOUT_SECONDS,
+        downloaded_handoff_enabled=False,
     )
     record = collection_serve._LifecycleRecord(os.getpid(), "mode-token", configuration)
     server = collection_serve.create_server(

--- a/tests/domains/test_media_store.py
+++ b/tests/domains/test_media_store.py
@@ -17,6 +17,17 @@ def test_media_key_builds_the_canonical_handoff_path() -> None:
     assert key.as_posix() == "ambient-lab/rain-night/video-upload/media/Master.mp4"
 
 
+def test_media_key_preserves_safe_suno_filenames_with_spaces_and_unicode() -> None:
+    key = MediaKey(
+        channel="002ch",
+        collection="rain-night",
+        handoff="suno-download",
+        name="02-Individual-music/01a-Rainy Jazz 夜.mp3",
+    )
+
+    assert key.as_posix() == "002ch/rain-night/suno-download/02-Individual-music/01a-Rainy Jazz 夜.mp3"
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [


### PR DESCRIPTION
## 概要

suno-helperのatomic download完了後、音源をR2へmanifest-lastで引き渡し、検証済み参照だけをworkflow-stateへ記録します。

## 変更内容

- DL配置後にMediaStoreへ音源push、manifestを最後に公開
- remote検証後だけstateを`cloud_owned`へ遷移しevent発火
- 途中失敗時はarchiveを保持
- remote metadata一致objectをskipして安全にretry
- manifest済み再実行はremote検証だけ
- R2未設定は従来local、部分設定はfail-closed

## 検証

- focused: 324 passed, 2 skipped
- full（rebase前）: 9603 passed, 3 skipped
- ruff / format / Any / yt-skills / build / wheel smoke: green

Closes #4048