### PR TITLE
feat(hybrid): 日次GHA workflowを下流配布する (#4054)

### DIFF
--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -66,6 +66,8 @@ bash .claude/skills/wf-new/references/run-sandwich.sh \
 
 R2接続は既存 `R2MediaStoreConfig` の環境変数/secret ownerを使う。`--media-store local --local-store-root <path>` は同一runnerをローカルadapterで検証・運用する場合だけ指定する。入力または出力がない工程は対応するhandoff引数一式を省略する。
 
+GitHub Actions の日次ポーリング定義は `uv run yt-skills sync --asset channel-workflow --force` で `.github/workflows/youtube-automation.yml` へ配布する。workflow は同じ `run-sandwich.sh` を1回呼ぶだけで、`YTA_CHANNEL_SLUG` / `YTA_COLLECTION` / `YTA_COLLECTION_DIR` / `YTA_AGENT` / `YTA_AUTOMATION_PROMPT` を repository variables、R2 と Claude の credential を repository secrets から注入する。`concurrency.cancel-in-progress: false` により先行実行を中断せず、後続の日次起動を同一repository内で直列化する。
+
 ## Task: setup / update
 
 すべてチャンネルリポジトリ直下で実行する。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: サンドイッチrunnerだけを呼ぶ日次cron・直列concurrency付きGitHub Actions workflowを追加し、`yt-skills sync` で下流チャンネルへ配布する（#4054）。
 - `feat(hybrid)`: Git clone、検証済みMediaStore pull、単一agent境界、成果物push、state commit/pushをuv直行で束ねる基盤非依存サンドイッチrunnerを追加する（#4053）。
 - `refactor(hybrid)`: `/wf-new --schedule` の実行場所判定を能力ベースへ置き換え、Suno UIだけを本来のlocal条件、重量overlayのmedia〜publishを暫定local例外として固定する（#4052）。
 - `feat(hybrid)`: suno-helper の一括 DL 完了後に音源を再実行安全な manifest-last R2 handoff へ自動送信し、検証済み manifest key と root SHA-256 の state 記録後に通知 event を発火する（#4048）。

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ yt-skills sync --asset claude-md          # 個別: 運営方針テンプレ (.c
 yt-skills sync --asset workflow-cheatsheet  # 個別: workflow チートシート (docs/workflow-cheatsheet.md)
 yt-skills sync --asset features           # 個別: 全 skill カタログ (docs/features.md)
 yt-skills sync --asset auth-template      # 個別: OAuth client_secrets テンプレ (auth/client_secrets.template.json)
+yt-skills sync --asset channel-workflow   # 個別: 日次 GHA workflow (.github/workflows/youtube-automation.yml)
 yt-skills sync --symlink                  # 開発時はシンボリックリンク
 yt-skills diff                            # 全 asset で同梱版との差分表示
 yt-skills sync --force                    # 既存ファイルを上書き

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -178,6 +178,7 @@ Python 版 skill-config の正規キーは `configuration/skills.py` が所有�
 - `src/youtube_automation/commands/channel/channel_init_templates.py` — channel-init が生成する設定テンプレート
 - `.claude/skills/` — 自動化スキル群（Claude Code / Codex 共用）。wheel に `_skills/` として `force-include` され、`yt-skills sync` で各チャンネルへ展開される
 - `.claude/CLAUDE.template.md` — BGM チャンネル運営方針テンプレ（共通骨格）。wheel に `_claude_md/CLAUDE.template.md` として `force-include` され、`yt-skills sync --asset claude-md` で各チャンネルの `.claude/CLAUDE.md` として展開される
+- `src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml` — 下流チャンネルの日次 GitHub Actions workflow 正本。`yt-skills sync --asset channel-workflow` で `.github/workflows/youtube-automation.yml` へ配布し、基盤非依存のサンドイッチrunnerだけを呼び出す
 - `.agents/skills` — `.claude/skills` への symlink。Codex CLI 用の探索パス（Codex 規約 `$REPO_ROOT/.agents/skills`）
 - `AGENTS.md` — Codex CLI 向けエージェント指示。CLAUDE.md と並立し、Codex 視点のドキュメント補足を含む
 - `site/` — Blume ベースの運用者向け公開ドキュメントサイト。release notes と明示 allowlist の原本を読み、Python 配布物とは独立して build・deploy する

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -22,6 +22,7 @@ Asset 種別 (`--asset`):
     features            : 全 skill カタログ (`docs/features.md`、単一ファイル)
     auth-template       : OAuth client secrets テンプレート (`auth/client_secrets.template.json`、単一ファイル)
     channel-gitignore   : channel Git ignore テンプレート (`.gitignore`、単一ファイル・既存は上書きしない)
+    channel-workflow    : channel GHA 日次 automation workflow (`.github/workflows/youtube-automation.yml`)
     settings            : Claude Code 設定 (`.claude/settings.json`、JSON merge)
 
 `yt-skills sync` (asset 未指定) は `--asset all` と同等で、配布物が `docs/`
@@ -95,6 +96,14 @@ _ASSET_SPECS: dict[str, dict[str, str]] = {
         "source_filename": "gitignore.template",
         "default_target": ".gitignore",
         "label": "channel Git ignore テンプレ",
+    },
+    "channel-workflow": {
+        "kind": "file",
+        "resource_name": "infrastructure/resources/channel",
+        "source_subdir": "src/youtube_automation/infrastructure/resources/channel",
+        "source_filename": "youtube-automation.yml",
+        "default_target": ".github/workflows/youtube-automation.yml",
+        "label": "channel GitHub Actions workflow",
     },
     "settings": {
         "kind": "json-merge",

--- a/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
+++ b/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
@@ -1,0 +1,47 @@
+name: YouTube automation
+
+on:
+  schedule:
+    - cron: "23 0 * * *"
+
+concurrency:
+  group: youtube-automation-${{ github.repository }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  automation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+      - name: Run platform-neutral sandwich runner
+        env:
+          REPOSITORY_URL: ${{ github.server_url }}/${{ github.repository }}.git
+          REPOSITORY_REF: ${{ github.ref_name }}
+          YTA_CHANNEL_SLUG: ${{ vars.YTA_CHANNEL_SLUG }}
+          YTA_COLLECTION: ${{ vars.YTA_COLLECTION }}
+          YTA_COLLECTION_DIR: ${{ vars.YTA_COLLECTION_DIR }}
+          YTA_AGENT: ${{ vars.YTA_AGENT }}
+          YTA_AUTOMATION_PROMPT: ${{ vars.YTA_AUTOMATION_PROMPT }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_API_TOKEN: ${{ secrets.R2_API_TOKEN }}
+          R2_BUCKET: ${{ vars.R2_BUCKET }}
+        run: >-
+          bash .claude/skills/wf-new/references/run-sandwich.sh
+          --repository-url "$REPOSITORY_URL"
+          --ref "$REPOSITORY_REF"
+          --workspace "${{ runner.temp }}/yta-hybrid"
+          --
+          --channel-slug "$YTA_CHANNEL_SLUG"
+          --collection "$YTA_COLLECTION"
+          --collection-dir "$YTA_COLLECTION_DIR"
+          --agent "$YTA_AGENT"
+          --prompt "$YTA_AUTOMATION_PROMPT"

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -148,6 +148,9 @@ def test_cmd_sync_default_all_includes_auth_template(
     assert (downstream / "docs" / "features.md").exists()
     assert (downstream / "auth" / "client_secrets.template.json").exists()
     assert "# yt-state-git control plane (ADR-0024)" in (downstream / ".gitignore").read_text(encoding="utf-8")
+    assert "run-sandwich.sh" in (downstream / ".github" / "workflows" / "youtube-automation.yml").read_text(
+        encoding="utf-8"
+    )
 
 
 def test_cmd_sync_never_overwrites_existing_channel_gitignore_even_with_force(

--- a/tests/commands/system/test_skills_sync_package.py
+++ b/tests/commands/system/test_skills_sync_package.py
@@ -71,6 +71,16 @@ def test_channel_gitignore_asset_is_packaged_with_state_git_policy() -> None:
     assert "auth/token*.json" in text
 
 
+def test_channel_workflow_asset_is_packaged_for_default_sync() -> None:
+    from youtube_automation.commands.system.skills_sync import _ASSET_SPECS, _asset_root
+
+    spec = _ASSET_SPECS["channel-workflow"]
+    template = _asset_root("channel-workflow") / spec["source_filename"]
+    assert spec["default_target"] == ".github/workflows/youtube-automation.yml"
+    assert template.is_file()
+    assert "run-sandwich.sh" in template.read_text(encoding="utf-8")
+
+
 def test_auth_template_is_included_in_wheel_and_sdist_manifests() -> None:
     pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
 

--- a/tests/repo/test_hybrid_github_actions_workflow.py
+++ b/tests/repo/test_hybrid_github_actions_workflow.py
@@ -1,0 +1,101 @@
+"""Downstream hybrid GitHub Actions workflow distribution contract (#4054)."""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+_WORKFLOW = REPO_ROOT / "src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml"
+
+
+def _document() -> dict[str, object]:
+    document = yaml.load(_WORKFLOW.read_text(encoding="utf-8"), Loader=yaml.BaseLoader)
+    assert isinstance(document, dict)
+    return document
+
+
+def test_workflow_polls_daily_and_serializes_runs_without_cancelling() -> None:
+    document = _document()
+    triggers = document["on"]
+    assert isinstance(triggers, dict)
+    schedules = triggers["schedule"]
+    assert isinstance(schedules, list) and len(schedules) == 1
+    schedule = schedules[0]
+    assert isinstance(schedule, dict)
+    cron = schedule["cron"]
+    assert isinstance(cron, str)
+    fields = cron.split()
+    assert len(fields) == 5
+    assert fields[2:] == ["*", "*", "*"]
+
+    concurrency = document["concurrency"]
+    assert isinstance(concurrency, dict)
+    assert concurrency == {
+        "group": "youtube-automation-${{ github.repository }}",
+        "cancel-in-progress": "false",
+    }
+
+
+def test_workflow_is_a_thin_platform_wrapper_for_sandwich_script() -> None:
+    document = _document()
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict) and list(jobs) == ["automation"]
+    job = jobs["automation"]
+    assert isinstance(job, dict)
+    steps = job["steps"]
+    assert isinstance(steps, list)
+
+    shell_steps = [step for step in steps if isinstance(step, dict) and "run" in step]
+    assert len(shell_steps) == 1
+    command = shell_steps[0]["run"]
+    assert isinstance(command, str)
+    assert command.count("run-sandwich.sh") == 1
+    assert "uv run" not in command
+    assert not re.search(r"\b(if|for|while|case|ffmpeg|yt-workflow-state)\b", command)
+
+    env = shell_steps[0]["env"]
+    assert isinstance(env, dict)
+    assert {
+        key: env[key]
+        for key in (
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "R2_ACCESS_KEY_ID",
+            "R2_ACCOUNT_ID",
+            "R2_API_TOKEN",
+            "R2_BUCKET",
+        )
+    } == {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+        "R2_ACCESS_KEY_ID": "${{ secrets.R2_ACCESS_KEY_ID }}",
+        "R2_ACCOUNT_ID": "${{ secrets.R2_ACCOUNT_ID }}",
+        "R2_API_TOKEN": "${{ secrets.R2_API_TOKEN }}",
+        "R2_BUCKET": "${{ vars.R2_BUCKET }}",
+    }
+    assert {
+        key: env[key]
+        for key in (
+            "YTA_CHANNEL_SLUG",
+            "YTA_COLLECTION",
+            "YTA_COLLECTION_DIR",
+            "YTA_AGENT",
+            "YTA_AUTOMATION_PROMPT",
+        )
+    } == {
+        "YTA_CHANNEL_SLUG": "${{ vars.YTA_CHANNEL_SLUG }}",
+        "YTA_COLLECTION": "${{ vars.YTA_COLLECTION }}",
+        "YTA_COLLECTION_DIR": "${{ vars.YTA_COLLECTION_DIR }}",
+        "YTA_AGENT": "${{ vars.YTA_AGENT }}",
+        "YTA_AUTOMATION_PROMPT": "${{ vars.YTA_AUTOMATION_PROMPT }}",
+    }
+
+
+def test_workflow_actions_are_immutable_pins() -> None:
+    text = _WORKFLOW.read_text(encoding="utf-8")
+    uses = re.findall(r"^\s*- uses: ([^\s]+)\s+#\s+(\S+)\s*$", text, re.MULTILINE)
+    assert uses == [
+        ("actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
+        ("astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9", "v9.0.0"),
+    ]

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -14,6 +14,9 @@ from youtube_automation.domains.skills.inventory import SkillInventory
 
 _FILE_ASSETS = {
     Path(".gitignore"): Path("src/youtube_automation/infrastructure/resources/channel/gitignore.template"),
+    Path(".github/workflows/youtube-automation.yml"): Path(
+        "src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml"
+    ),
     Path(".claude/CLAUDE.md"): Path(".claude/CLAUDE.template.md"),
     Path("docs/workflow-cheatsheet.md"): Path("docs/workflow-cheatsheet.md"),
     Path("docs/features.md"): Path("docs/features.md"),
@@ -467,7 +470,7 @@ assert "wheel-identity-check" not in legacy._cache
 
     diffed = _run(yt_skills, "diff", cwd=downstream, env=clean_env)
     assert diffed.returncode == 0, diffed.stdout + diffed.stderr
-    assert diffed.stdout.count("差分なし") == 6
+    assert diffed.stdout.count("差分なし") == len(_FILE_ASSETS) + 1  # file assets + skills
     assert "hooks.PreToolUse" in diffed.stdout
 
 


### PR DESCRIPTION
## 概要

下流channelへ配布可能な日次GitHub Actions workflow正本を追加し、canonical sandwich runnerだけを起動する薄い実行境界にします。

## 変更内容

- 日次cronとrepository単位concurrencyを追加
- `cancel-in-progress: false`で直列化
- 固定SHAの環境準備とvars/secrets注入を定義
- workflow本体は`run-sandwich.sh`を1回だけ呼出
- `yt-skills sync`とwheelへ`channel-workflow` assetを同梱
- schedule/README/architecture/CHANGELOGを追従

## 検証

- focused: 137 passed
- full: 9608 passed, 3 skipped
- ruff / format / Any / yt-skills / site 53 / build / wheel smoke: green

Closes #4054