### PR TITLE
feat(hybrid): GitHub Actions backendを追加する (#4055)

### DIFF
--- a/.claude/skills/wf-new/references/github_actions_schedule.py
+++ b/.claude/skills/wf-new/references/github_actions_schedule.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Manage the owned schedule block in the distributed channel workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import tempfile
+from contextlib import suppress
+from pathlib import Path
+
+WORKFLOW_PATH = Path(".github/workflows/youtube-automation.yml")
+SCHEDULE_BEGIN = "  # yt-automation-schedule:begin"
+SCHEDULE_END = "  # yt-automation-schedule:end"
+_ACTIVE_BLOCK = re.compile(r'\n  schedule:\n    - cron: "([^"]+)"\n\Z')
+
+
+class ScheduleWorkflowError(ValueError):
+    """The workflow cannot be safely managed by this adapter."""
+
+
+def _workflow_target(channel_dir: Path) -> Path:
+    root = channel_dir.resolve()
+    target = root / WORKFLOW_PATH
+    current = root
+    for part in WORKFLOW_PATH.parts:
+        current = current / part
+        if current.is_symlink():
+            raise ScheduleWorkflowError(f"workflow path contains a symlink: {current}")
+    return target
+
+
+def _read_workflow(channel_dir: Path) -> tuple[Path, str] | None:
+    target = _workflow_target(channel_dir)
+    if not target.exists():
+        return None
+    if not target.is_file():
+        raise ScheduleWorkflowError(f"workflow is not a regular file: {target}")
+    return target, target.read_text(encoding="utf-8")
+
+
+def _managed_parts(text: str) -> tuple[str, str, str]:
+    if text.count(SCHEDULE_BEGIN) != 1 or text.count(SCHEDULE_END) != 1:
+        raise ScheduleWorkflowError("workflow schedule management markers are missing or duplicated")
+    prefix, remainder = text.split(SCHEDULE_BEGIN, maxsplit=1)
+    managed, suffix = remainder.split(SCHEDULE_END, maxsplit=1)
+    return prefix, managed, suffix
+
+
+def _validated_cron(cron: str) -> str:
+    fields = cron.split()
+    if len(fields) != 5 or fields[2:4] != ["*", "*"]:
+        raise ScheduleWorkflowError(f"unsupported GitHub Actions cron: {cron!r}")
+    minute_text, hour_text, _, _, days_text = fields
+    if not minute_text.isdigit() or not hour_text.isdigit():
+        raise ScheduleWorkflowError(f"unsupported GitHub Actions cron: {cron!r}")
+    minute, hour = int(minute_text), int(hour_text)
+    if not 0 <= minute <= 59 or not 0 <= hour <= 23:
+        raise ScheduleWorkflowError(f"unsupported GitHub Actions cron: {cron!r}")
+    if days_text != "*":
+        days = days_text.split(",")
+        if not days or any(not day.isdigit() or not 0 <= int(day) <= 6 for day in days):
+            raise ScheduleWorkflowError(f"unsupported GitHub Actions cron: {cron!r}")
+        if [int(day) for day in days] != sorted({int(day) for day in days}):
+            raise ScheduleWorkflowError(f"GitHub Actions cron weekdays must be unique and sorted: {cron!r}")
+    return f"{minute} {hour} * * {days_text}"
+
+
+def _atomic_write(target: Path, text: str) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(prefix=f".{target.name}.", dir=target.parent)
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, target.stat().st_mode)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, target)
+        directory_descriptor = os.open(target.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_descriptor)
+        finally:
+            os.close(directory_descriptor)
+    except BaseException:
+        with suppress(OSError):
+            os.close(descriptor)
+        with suppress(OSError):
+            temporary.unlink()
+        raise
+
+
+def _result(*, status: str, cron: str | None = None) -> dict[str, str]:
+    result = {
+        "backend": "github-actions",
+        "status": status,
+        "workflow": str(WORKFLOW_PATH),
+    }
+    if cron is not None:
+        result["cron"] = cron
+    return result
+
+
+def configure_schedule(channel_dir: Path, *, cron: str) -> dict[str, str]:
+    validated = _validated_cron(cron)
+    loaded = _read_workflow(channel_dir)
+    if loaded is None:
+        raise ScheduleWorkflowError(
+            "distributed workflow is missing; run `uv run yt-skills sync --asset channel-workflow` first"
+        )
+    target, text = loaded
+    prefix, _, suffix = _managed_parts(text)
+    managed = f'\n  schedule:\n    - cron: "{validated}"\n'
+    updated = prefix + SCHEDULE_BEGIN + managed + SCHEDULE_END + suffix
+    if updated != text:
+        _atomic_write(target, updated)
+    return _result(status="active", cron=validated)
+
+
+def schedule_status(channel_dir: Path) -> dict[str, str]:
+    loaded = _read_workflow(channel_dir)
+    if loaded is None:
+        return _result(status="unconfigured")
+    _, text = loaded
+    _, managed, _ = _managed_parts(text)
+    if managed == "\n":
+        return _result(status="disabled")
+    match = _ACTIVE_BLOCK.fullmatch(managed)
+    if match is None:
+        raise ScheduleWorkflowError("managed workflow schedule block has an unsupported shape")
+    return _result(status="active", cron=_validated_cron(match.group(1)))
+
+
+def disable_schedule(channel_dir: Path) -> dict[str, str]:
+    loaded = _read_workflow(channel_dir)
+    if loaded is None:
+        raise ScheduleWorkflowError("distributed workflow is missing; nothing can be disabled")
+    target, text = loaded
+    prefix, _, suffix = _managed_parts(text)
+    updated = prefix + SCHEDULE_BEGIN + "\n" + SCHEDULE_END + suffix
+    if updated != text:
+        _atomic_write(target, updated)
+    return _result(status="disabled")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--channel-dir", type=Path, default=Path.cwd())
+    sub = parser.add_subparsers(dest="command", required=True)
+    configure = sub.add_parser("configure")
+    configure.add_argument("--cron", required=True)
+    sub.add_parser("status")
+    sub.add_parser("disable")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.command == "configure":
+            result = configure_schedule(args.channel_dir, cron=args.cron)
+        elif args.command == "status":
+            result = schedule_status(args.channel_dir)
+        else:
+            result = disable_schedule(args.channel_dir)
+    except (OSError, UnicodeError, ScheduleWorkflowError) as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, ensure_ascii=False, indent=2))
+        return 1
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -11,7 +11,7 @@
 
 ## Overview
 
-`config/channel/workflow.json::workflow.scheduled_automation` を製品非依存の単一ソースとして、実行中製品のネイティブ scheduler に登録する。Codex は Scheduled Task、Claude は依存性に応じて `/schedule` Cloud Job または Cowork local Scheduled Task を使う。launchd / cron は明示承認された fallback に限る。
+`config/channel/workflow.json::workflow.scheduled_automation` を製品非依存の単一ソースとして scheduler backend へ登録する。cloud 工程は GitHub Actions、local 工程は Codex Scheduled Task または Claude Cowork local Scheduled Task を使う。launchd / cron は明示承認された fallback に限る。
 
 automation のリリース追従は `/automation --update`、本体リリースは `/automation-release`、制作を手動で一段進めるのは `/wf-next` の責務とし、この mode では代行しない。
 
@@ -29,9 +29,10 @@ automation のリリース追従は `/automation --update`、本体リリース�
 
 | 実行製品 / 依存 | backend | 登録・管理 |
 |---|---|---|
-| Codex（cloud / local） | `codex-automation` | ChatGPT desktop/web の Scheduled。local は desktop の local project を必須にする |
-| Claude + cloud 完結 | `claude-code-cloud` | Claude Code `/schedule` Cloud Job |
+| cloud 完結（Codex / Claude） | `github-actions` | 配布済み workflow の UTC `schedule:` cron。`concurrency:` が直列化する |
+| Codex + local 依存 | `codex-automation` | ChatGPT desktop/web の Scheduled。desktop local project を必須にする |
 | Claude + local 依存 | `claude-cowork-local` | Cowork Scheduled で対象 folder を選ぶ。local 実行可否を登録前に確認する |
+| 既存 Claude cloud task の管理 | `claude-code-cloud` | 新規選択はせず、記録済み task の status / disable だけを従来どおり行う |
 | ネイティブ利用不能 + 明示承認 | `os-fallback` | `scheduler_job.sh` の launchd / cron |
 
 Claude Code `/loop` は最長 3 日の一時反復専用で、永続スケジュールには使わない。
@@ -42,7 +43,8 @@ Claude Code `/loop` は最長 3 日の一時反復専用で、永続スケジュ
 |---|---|
 | `references/detect_runtime.sh` | config / uv / 実行中製品 / native 管理面 / OS fallback 可否の診断 |
 | `references/schedule_config.py` | `scheduled_automation` の show / generate / dry-run |
-| `references/schedule_backend.py` | 4 backend の plan、重複防止、外部 ID のローカル記録 |
+| `references/schedule_backend.py` | 5 backend の plan、重複防止、外部 ID のローカル記録 |
+| `references/github_actions_schedule.py` | 配布 workflow の管理区間だけを configure / status / disable |
 | `references/scheduler_job.sh` | 明示選択された OS fallback 専用の install / status / disable |
 | `references/run_scheduled.sh` | OS fallback 専用ラッパー。外部公開ゲート・lock・retry・通知を維持 |
 | `references/run-sandwich.sh` | 基盤非依存の clone → manifest pull → agent/既存CLI → manifest push + state commit runner |
@@ -92,7 +94,7 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py show
    したがって 002ch 型の重量チャンネルは企画・prompt が cloud、Suno・media・publish が local、003ch 型の軽量チャンネルは Suno だけが local で他は cloud になる。
 3. active な別 backend があれば、旧 backend の disable が承認・成功するまで停止する。
 
-### Step 1. config と native task の dry-run
+### Step 1. config と scheduler task の dry-run
 
 ```bash
 uv run python .claude/skills/wf-new/references/schedule_config.py show
@@ -107,7 +109,7 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py plan \
   [--retry-delay-seconds <N>] [--notification terminal|none]
 ```
 
-時刻・曜日が未指定なら確認し、勝手に決めない。config dry-run と `plan` へ同じ候補値を渡す。`plan` は JSON を表示するだけで config / OS / 外部状態を変更しない。外部公開承認前は `--allow-external-publish` を付けない。
+時刻・曜日が未指定なら確認し、勝手に決めない。config dry-run と `plan` へ同じ候補値を渡す。`plan` は JSON を表示するだけで config / OS / 外部状態を変更しない。`github-actions` の plan は IANA timezone を UTC cron へ変換する。UTC offset が季節で変わり固定 cron に写像できない timezone は停止する。外部公開承認前は `--allow-external-publish` を付けない。
 
 ### Step 2. 承認後に config を書く
 
@@ -122,9 +124,15 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py guard --backe
 ```
 
 - `codex-automation`: Codex/ChatGPT の Scheduled Task 管理 capability を使う。CLI の `codex exec` や launchd / cron は使わない。local 依存では desktop local project と cwd を指定する。同じ external ID があれば更新する。
-- `claude-code-cloud`: `plan` の prompt と schedule で `/schedule` Cloud Job を作成/更新する。local 依存が判明したら中止する。
+- `github-actions`: `plan` の `cron` を使い、次で配布 workflow の管理区間だけを更新する。workflow が未配布、symlink、管理 marker 不整合なら停止する。
 - `claude-cowork-local`: Cowork Scheduled Task に local folder を指定して作成/更新する。製品側で local folder 実行を選べない場合は中止する。
+- `claude-code-cloud`: 既存の記録済み task を status / disable するときだけ従来の `/schedule` 管理面を使う。新規作成先には選ばない。
 - `os-fallback`: ネイティブが使えない理由と制約を提示して別途承認を取り、次だけを実行する。
+
+```bash
+uv run python .claude/skills/wf-new/references/github_actions_schedule.py \
+  configure --cron '<plan.cron>'
+```
 
 統合前の絶対 script path を登録済みの OS fallback job は自動更新しない。ユーザーへ再インストールが必要な理由を案内し、承認後に現在の `scheduler_job.sh disable`、続けて `scheduler_job.sh install` の順で実行する。
 
@@ -140,27 +148,30 @@ uv run python .claude/skills/wf-new/references/schedule_backend.py record \
   --backend <backend> --external-id <product-task-id>
 ```
 
+`github-actions` の不変 external ID は `.github/workflows/youtube-automation.yml` とする。
+
 ### Step 4. 検証
 
-`schedule_backend.py show` で backend / external ID を確認し、**同じ backend の製品管理面**で status・次回実行・cadence を確認する。config が `enabled=true` で、別 backend に同名 task がないことまで確認して完了。
+`schedule_backend.py show` で backend / external ID を確認し、**同じ backend の管理面**で status・次回実行・cadence を確認する。`github-actions` は `github_actions_schedule.py status` の cron と plan が一致することを確認する。config が `enabled=true` で、別 backend に同名 task がないことまで確認して完了。
 
 ## status
 
 1. `schedule_backend.py show` と `schedule_config.py show` を実行する。
 2. active backend と external ID を使い、その製品の Scheduled 管理面で状態・次回実行・直近結果を取得する。
 3. state が `unconfigured` なら、製品側を job key `youtube-automation:<channel-dir>` で検索する。見つけても勝手に再作成せず、record の承認を取る。
-4. `os-fallback` の場合だけ `scheduler_job.sh status --backend os-fallback` を使う。
+4. `github-actions` は `github_actions_schedule.py status`、`os-fallback` は `scheduler_job.sh status --backend os-fallback` を使う。
 
 ## disable
 
 1. status を提示して停止確認を取る。
 2. active backend の external ID を指定し、製品の Scheduled 管理面で pause/delete する。別 backend は触らない。
-3. 外部停止成功後に `schedule_backend.py disable --backend <backend>` を実行する。OS の場合だけ `scheduler_job.sh disable --backend os-fallback` が外部停止と state 更新を担う。
-4. 希望された場合のみ `schedule_config.py generate --disable` で config も無効化する。
+3. `github-actions` は `github_actions_schedule.py disable` で schedule trigger を除去する。他 backend は製品管理面で外部停止する。
+4. 停止成功後に `schedule_backend.py disable --backend <backend>` を実行する。OS の場合だけ `scheduler_job.sh disable --backend os-fallback` が外部停止と state 更新を担う。
+5. 希望された場合のみ `schedule_config.py generate --disable` で config も無効化する。
 
 ## Safety contract
 
-- native task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`wf-new --auto` の `.automation-run/` lease、状態再評価、重複 upload 防止は変更しない。
+- scheduler task の prompt にも `allow_external_publish: false` の外部反映禁止を含める。`wf-new --auto` の `.automation-run/` lease、状態再評価、重複 upload 防止は変更しない。
 - retry は backend の再実行機能が契約を満たす場合のみ native 側へ写像する。満たさない場合は prompt 内で `max_retries` / `retry_delay_seconds` を適用する。
 - local native task の prompt と OS fallback は、workflow retry の外側で `uv run yt-oauth --refresh-only` を1回だけ実行する。既存 local native task は `/wf-new --schedule` の update で新しい prompt へ更新する。
 - OS fallback のログは `.automation-schedule/logs/`。ネイティブの履歴は各製品の Scheduled 管理面を正とする。

--- a/.claude/skills/wf-new/references/schedule_backend.py
+++ b/.claude/skills/wf-new/references/schedule_backend.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Native scheduler plan and backend identity state for /wf-new --schedule (#2369)."""
+"""Scheduler plan and backend identity state for /wf-new --schedule."""
 
 from __future__ import annotations
 
@@ -8,8 +8,9 @@ import hashlib
 import json
 import os
 import subprocess
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from youtube_automation.configuration import channel_dir, load_config
 
@@ -18,6 +19,7 @@ BACKENDS = (
     "claude-code-cloud",
     "claude-cowork-local",
     "os-fallback",
+    "github-actions",
 )
 PRODUCTS = ("codex", "claude")
 EXECUTION_STAGES = ("planning", "prompt", "suno", "media", "publish")
@@ -43,16 +45,55 @@ def classify_dependency_mode(*, stage: str, overlays_enabled: bool) -> tuple[str
 
 
 def select_backend(*, product: str, dependency_mode: str, os_fallback: bool = False) -> str:
-    """Select the native backend; OS fallback is never selected implicitly."""
+    """Select the capability-compatible backend; OS fallback is never implicit."""
+    if product not in PRODUCTS or dependency_mode not in {"cloud", "local"}:
+        raise BackendError(f"unsupported product/dependency mode: {product}/{dependency_mode}")
     if os_fallback:
         return "os-fallback"
+    if dependency_mode == "cloud":
+        return "github-actions"
     if product == "codex":
         return "codex-automation"
-    if product == "claude" and dependency_mode == "cloud":
-        return "claude-code-cloud"
-    if product == "claude" and dependency_mode == "local":
+    if product == "claude":
         return "claude-cowork-local"
     raise BackendError(f"unsupported product/dependency mode: {product}/{dependency_mode}")
+
+
+def _fixed_utc_offset(timezone_name: str) -> timedelta:
+    try:
+        timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise BackendError(f"unknown timezone: {timezone_name}") from exc
+    start_year = datetime.now(UTC).year
+    offsets = {
+        datetime(year, month, day, 12, tzinfo=timezone).utcoffset()
+        for year in (start_year, start_year + 1)
+        for month in range(1, 13)
+        for day in (1, 15)
+    }
+    if None in offsets or len(offsets) != 1:
+        raise BackendError(f"GitHub Actions cron cannot preserve a variable UTC offset timezone: {timezone_name}")
+    return offsets.pop()
+
+
+def github_actions_cron(*, run_time: str, cadence: list[str], timezone_name: str) -> str:
+    """Convert a fixed-offset local weekly schedule to GitHub's UTC cron."""
+    day_indexes = {day: index for index, day in enumerate(("mon", "tue", "wed", "thu", "fri", "sat", "sun"))}
+    try:
+        hour_text, minute_text = run_time.split(":", maxsplit=1)
+        hour, minute = int(hour_text), int(minute_text)
+        local_days = [day_indexes[day] for day in cadence]
+    except (ValueError, KeyError) as exc:
+        raise BackendError("run_time or cadence is invalid for GitHub Actions cron") from exc
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59 or not local_days:
+        raise BackendError("run_time or cadence is invalid for GitHub Actions cron")
+    offset = _fixed_utc_offset(timezone_name)
+    offset_minutes = int(offset.total_seconds() // 60)
+    day_delta, utc_minutes = divmod(hour * 60 + minute - offset_minutes, 24 * 60)
+    utc_hour, utc_minute = divmod(utc_minutes, 60)
+    cron_days = sorted({(day + day_delta + 1) % 7 for day in local_days})
+    day_field = "*" if len(cron_days) == 7 else ",".join(str(day) for day in cron_days)
+    return f"{utc_minute} {utc_hour} * * {day_field}"
 
 
 def _rrule(run_time: str, cadence: list[str]) -> str:
@@ -136,7 +177,16 @@ def build_plan(
         "allow_external_publish": allow_external_publish,
     }
     plan["execution_stage"] = stage
-    if backend == "codex-automation":
+    if backend == "github-actions":
+        if not scheduled.prevent_concurrent_runs:
+            raise BackendError("github-actions backend requires prevent_concurrent_runs: true")
+        plan["cron"] = github_actions_cron(
+            run_time=run_time,
+            cadence=cadence,
+            timezone_name=str(plan["timezone"]),
+        )
+        plan["management"] = "GitHub Actions workflow schedule trigger"
+    elif backend == "codex-automation":
         plan["management"] = "ChatGPT desktop/web Scheduled; local dependencies require desktop local project"
     elif backend == "claude-code-cloud":
         plan["management"] = "Claude Code /schedule Cloud Job"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: cloud 工程の定期実行先に `github-actions` backend を追加し、配布 workflow の UTC cron を管理区間限定で設定・確認・停止できるようにする（#4055）。
 - `feat(hybrid)`: サンドイッチrunnerだけを呼ぶ日次cron・直列concurrency付きGitHub Actions workflowを追加し、`yt-skills sync` で下流チャンネルへ配布する（#4054）。
 - `feat(hybrid)`: Git clone、検証済みMediaStore pull、単一agent境界、成果物push、state commit/pushをuv直行で束ねる基盤非依存サンドイッチrunnerを追加する（#4053）。
 - `refactor(hybrid)`: `/wf-new --schedule` の実行場所判定を能力ベースへ置き換え、Suno UIだけを本来のlocal条件、重量overlayのmedia〜publishを暫定local例外として固定する（#4052）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -179,6 +179,7 @@ Python 版 skill-config の正規キーは `configuration/skills.py` が所有�
 - `.claude/skills/` — 自動化スキル群（Claude Code / Codex 共用）。wheel に `_skills/` として `force-include` され、`yt-skills sync` で各チャンネルへ展開される
 - `.claude/CLAUDE.template.md` — BGM チャンネル運営方針テンプレ（共通骨格）。wheel に `_claude_md/CLAUDE.template.md` として `force-include` され、`yt-skills sync --asset claude-md` で各チャンネルの `.claude/CLAUDE.md` として展開される
 - `src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml` — 下流チャンネルの日次 GitHub Actions workflow 正本。`yt-skills sync --asset channel-workflow` で `.github/workflows/youtube-automation.yml` へ配布し、基盤非依存のサンドイッチrunnerだけを呼び出す
+- `.claude/skills/wf-new/references/github_actions_schedule.py` — 配布 workflow 内の schedule 管理 marker だけを原子的に configure / status / disable する GitHub Actions backend adapter
 - `.agents/skills` — `.claude/skills` への symlink。Codex CLI 用の探索パス（Codex 規約 `$REPO_ROOT/.agents/skills`）
 - `AGENTS.md` — Codex CLI 向けエージェント指示。CLAUDE.md と並立し、Codex 視点のドキュメント補足を含む
 - `site/` — Blume ベースの運用者向け公開ドキュメントサイト。release notes と明示 allowlist の原本を読み、Python 配布物とは独立して build・deploy する

--- a/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
+++ b/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
@@ -1,8 +1,8 @@
 name: YouTube automation
 
 on:
-  schedule:
-    - cron: "23 0 * * *"
+  # yt-automation-schedule:begin
+  # yt-automation-schedule:end
 
 concurrency:
   group: youtube-automation-${{ github.repository }}

--- a/tests/repo/test_automation_schedule_backends.py
+++ b/tests/repo/test_automation_schedule_backends.py
@@ -79,9 +79,9 @@ def test_skill_self_describes_capability_boundary_without_removed_dependency_lis
 @pytest.mark.parametrize(
     ("product", "dependency_mode", "os_fallback", "expected"),
     [
-        ("codex", "cloud", False, "codex-automation"),
+        ("codex", "cloud", False, "github-actions"),
         ("codex", "local", False, "codex-automation"),
-        ("claude", "cloud", False, "claude-code-cloud"),
+        ("claude", "cloud", False, "github-actions"),
         ("claude", "local", False, "claude-cowork-local"),
         ("codex", "local", True, "os-fallback"),
     ],
@@ -163,6 +163,55 @@ def test_cloud_plan_does_not_require_local_write_token_maintenance(tmp_path, mon
 
     assert plan["prompt"].startswith("/wf-new --auto")
     assert "yt-oauth" not in plan["prompt"]
+    assert plan["backend"] == "github-actions"
+    assert plan["cron"] == "5 0 * * 1"
+    assert plan["management"] == "GitHub Actions workflow schedule trigger"
+
+
+def test_github_actions_cron_shifts_weekday_across_utc_boundary():
+    assert (
+        backend.github_actions_cron(
+            run_time="00:30",
+            cadence=["mon", "wed"],
+            timezone_name="Asia/Tokyo",
+        )
+        == "30 15 * * 0,2"
+    )
+
+
+def test_github_actions_cron_rejects_timezone_with_variable_utc_offset():
+    with pytest.raises(backend.BackendError, match="UTC offset"):
+        backend.github_actions_cron(
+            run_time="09:00",
+            cadence=["mon"],
+            timezone_name="America/New_York",
+        )
+
+
+def test_cloud_plan_rejects_disabled_concurrency_guard(tmp_path, monkeypatch):
+    scheduled = SimpleNamespace(
+        target_workflow="wf-new --auto",
+        allow_external_publish=False,
+        timezone="Asia/Tokyo",
+        run_time="09:05",
+        cadence=("mon",),
+        max_retries=0,
+        retry_delay_seconds=300,
+        prevent_concurrent_runs=False,
+        notification="none",
+    )
+    monkeypatch.setattr(
+        backend,
+        "load_config",
+        lambda: SimpleNamespace(
+            workflow=SimpleNamespace(scheduled_automation=scheduled),
+            youtube=SimpleNamespace(overlays=SimpleNamespace(enabled=False)),
+        ),
+    )
+    monkeypatch.setattr(backend, "channel_dir", lambda: tmp_path)
+
+    with pytest.raises(backend.BackendError, match="prevent_concurrent_runs"):
+        backend.build_plan(product="claude", stage="planning")
 
 
 def test_plan_derives_dependency_mode_from_stage_and_overlay_regime(tmp_path, monkeypatch):
@@ -237,6 +286,20 @@ def test_backend_identity_is_idempotent_and_blocks_duplicates(tmp_path):
         backend.ensure_backend_available(state_path, backend="os-fallback")
     with pytest.raises(backend.BackendError, match="disable it before"):
         backend.record_state(state_path, backend="claude-code-cloud", external_id="job-2")
+
+
+def test_github_actions_backend_identity_uses_distributed_workflow_id(tmp_path):
+    state_path = tmp_path / "state.json"
+
+    recorded = backend.record_state(
+        state_path,
+        backend="github-actions",
+        external_id=".github/workflows/youtube-automation.yml",
+    )
+
+    assert recorded["backend"] == "github-actions"
+    assert recorded["status"] == "active"
+    assert backend.disable_state(state_path, backend="github-actions")["status"] == "disabled"
 
 
 def test_disable_must_target_recorded_backend(tmp_path):

--- a/tests/repo/test_github_actions_schedule_backend.py
+++ b/tests/repo/test_github_actions_schedule_backend.py
@@ -1,0 +1,123 @@
+"""Executable GitHub Actions schedule backend contracts (#4055)."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+_REFERENCE = REPO_ROOT / ".claude/skills/wf-new/references/github_actions_schedule.py"
+_TEMPLATE = REPO_ROOT / "src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml"
+_WORKFLOW = Path(".github/workflows/youtube-automation.yml")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("github_actions_schedule", _REFERENCE)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _channel(tmp_path: Path) -> Path:
+    target = tmp_path / _WORKFLOW
+    target.parent.mkdir(parents=True)
+    shutil.copyfile(_TEMPLATE, target)
+    return tmp_path
+
+
+def test_configure_status_disable_preserves_workflow_outside_owned_block(tmp_path: Path) -> None:
+    backend = _load_module()
+    channel = _channel(tmp_path)
+    target = channel / _WORKFLOW
+    original = target.read_text(encoding="utf-8")
+    prefix, remainder = original.split(backend.SCHEDULE_BEGIN, maxsplit=1)
+    _, suffix = remainder.split(backend.SCHEDULE_END, maxsplit=1)
+
+    configured = backend.configure_schedule(channel, cron="5 0 * * 1,3,5")
+    configured_text = target.read_text(encoding="utf-8")
+
+    assert configured == {
+        "backend": "github-actions",
+        "status": "active",
+        "cron": "5 0 * * 1,3,5",
+        "workflow": str(_WORKFLOW),
+    }
+    assert configured_text.startswith(prefix + backend.SCHEDULE_BEGIN)
+    assert configured_text.endswith(backend.SCHEDULE_END + suffix)
+    document = yaml.load(configured_text, Loader=yaml.BaseLoader)
+    assert document["on"]["schedule"] == [{"cron": "5 0 * * 1,3,5"}]
+    assert backend.schedule_status(channel) == configured
+
+    disabled = backend.disable_schedule(channel)
+
+    assert disabled == {
+        "backend": "github-actions",
+        "status": "disabled",
+        "workflow": str(_WORKFLOW),
+    }
+    assert backend.schedule_status(channel) == disabled
+    assert target.read_text(encoding="utf-8").startswith(prefix + backend.SCHEDULE_BEGIN)
+    assert target.read_text(encoding="utf-8").endswith(backend.SCHEDULE_END + suffix)
+
+
+def test_configure_is_idempotent_and_replaces_only_owned_cron(tmp_path: Path) -> None:
+    backend = _load_module()
+    channel = _channel(tmp_path)
+
+    backend.configure_schedule(channel, cron="0 0 * * *")
+    first = (channel / _WORKFLOW).read_bytes()
+    backend.configure_schedule(channel, cron="0 0 * * *")
+
+    assert (channel / _WORKFLOW).read_bytes() == first
+
+
+@pytest.mark.parametrize("cron", ["", "0 0 * *", "@daily", "60 0 * * *", "0 24 * * *", "0 0 * * MON"])
+def test_configure_rejects_invalid_cron_without_changing_workflow(tmp_path: Path, cron: str) -> None:
+    backend = _load_module()
+    channel = _channel(tmp_path)
+    target = channel / _WORKFLOW
+    original = target.read_bytes()
+
+    with pytest.raises(backend.ScheduleWorkflowError):
+        backend.configure_schedule(channel, cron=cron)
+
+    assert target.read_bytes() == original
+
+
+def test_configure_rejects_missing_markers_and_symlink_without_writing(tmp_path: Path) -> None:
+    backend = _load_module()
+    channel = _channel(tmp_path)
+    target = channel / _WORKFLOW
+    target.write_text("name: unmanaged\n", encoding="utf-8")
+    original = target.read_bytes()
+
+    with pytest.raises(backend.ScheduleWorkflowError, match="management markers"):
+        backend.configure_schedule(channel, cron="0 0 * * *")
+    assert target.read_bytes() == original
+
+    target.unlink()
+    outside = tmp_path / "outside.yml"
+    outside.write_text("outside\n", encoding="utf-8")
+    target.symlink_to(outside)
+    with pytest.raises(backend.ScheduleWorkflowError, match="symlink"):
+        backend.configure_schedule(channel, cron="0 0 * * *")
+    assert outside.read_text(encoding="utf-8") == "outside\n"
+
+
+def test_cli_status_configure_disable_returns_json_without_external_calls(tmp_path: Path, capsys) -> None:
+    backend = _load_module()
+    channel = _channel(tmp_path)
+
+    assert backend.main(["--channel-dir", str(channel), "status"]) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "disabled"
+    assert backend.main(["--channel-dir", str(channel), "configure", "--cron", "15 3 * * 2"]) == 0
+    assert json.loads(capsys.readouterr().out)["cron"] == "15 3 * * 2"
+    assert backend.main(["--channel-dir", str(channel), "disable"]) == 0
+    assert json.loads(capsys.readouterr().out)["status"] == "disabled"

--- a/tests/repo/test_hybrid_github_actions_workflow.py
+++ b/tests/repo/test_hybrid_github_actions_workflow.py
@@ -17,19 +17,9 @@ def _document() -> dict[str, object]:
     return document
 
 
-def test_workflow_polls_daily_and_serializes_runs_without_cancelling() -> None:
+def test_workflow_stays_unscheduled_until_configured_and_serializes_runs_without_cancelling() -> None:
     document = _document()
-    triggers = document["on"]
-    assert isinstance(triggers, dict)
-    schedules = triggers["schedule"]
-    assert isinstance(schedules, list) and len(schedules) == 1
-    schedule = schedules[0]
-    assert isinstance(schedule, dict)
-    cron = schedule["cron"]
-    assert isinstance(cron, str)
-    fields = cron.split()
-    assert len(fields) == 5
-    assert fields[2:] == ["*", "*", "*"]
+    assert document["on"] in (None, "")
 
     concurrency = document["concurrency"]
     assert isinstance(concurrency, dict)

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -326,6 +326,7 @@ MUTABLE_FILES = frozenset(
     "wf-new/references/detect_runtime.sh",
     "wf-new/references/run_scheduled.sh",
     "wf-new/references/run-sandwich.sh",
+    "wf-new/references/github_actions_schedule.py",
     "wf-new/references/schedule_backend.py",
     "wf-new/references/schedule_config.py",
     "wf-new/references/scheduler_job.sh",


### PR DESCRIPTION
## 概要

automation-scheduleのcloud backendとしてGitHub Actionsを安全にconfigure/status/disableできるようにします。

## 変更内容

- cloud scheduleをgithub-actionsへ選択
- 固定UTC cronのみ受理しDST曖昧性をfail-closed化
- owned markerのあるworkflowだけをconfigure/status/disable
- atomic replace、symlink、malformed workflow拒否
- concurrency設定を必須化
- 既存local 4 backendを維持
- syncだけではcronを起動せず、明示configure後のみ有効化

## 検証

- focused: 51 passed
- full: 9632 passed, 3 skipped
- Any / ruff / format / yt-skills / site 53 / build / wheel smoke: green

Closes #4055