### PR TITLE
feat(hybrid): Discord通知sinkとイベント分類を追加する (#4063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `feat(hybrid)`: cloud 工程の定期実行先に `github-actions` backend を追加し、配布 workflow の UTC cron を管理区間限定で設定・確認・停止できるようにする（#4055）。
+- `feat(hybrid)`: 引き渡し・公開完了と異常停止をtyped eventで正常／異常へ分類し、既存secret ownerからDiscord webhookを解決してbest-effort送信するsinkを追加する（#4063）。
 - `feat(hybrid)`: サンドイッチrunnerだけを呼ぶ日次cron・直列concurrency付きGitHub Actions workflowを追加し、`yt-skills sync` で下流チャンネルへ配布する（#4054）。
 - `feat(hybrid)`: R2 pull 後の個別音源を企画曲数・Suno duration guard・integrated LUFS で fail-closed 検証し、拒否通知 event を発火する `yt-media-acceptance` を追加する（#4057）。
 - `feat(hybrid)`: Git clone、検証済みMediaStore pull、単一agent境界、成果物push、state commit/pushをuv直行で束ねる基盤非依存サンドイッチrunnerを追加する（#4053）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -230,6 +230,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `domains.media` | 音声、字幕、画像、動画の provider-neutral model / policy |
 | `domains.media_store` | 工程境界の `<channel>/<collection>/<handoff>/` key、checksum metadata、push / pull / exists port |
 | `domains.media_handoff_manifest` | versioned handoff manifest schema、正準 file list、root checksum の typed owner |
+| `domains.notifications` | ハイブリッドpipelineの正常／異常event種別とprovider-neutralな分類 |
 | `domains.distrokid` | DistroKid naming、metadata、specification、preparation、release policy |
 | `domains.collections.weekly_vote_log` | 週次投票ログ reader、initializer、schema、保存・検証 |
 | `domains.documents.schema_registry` | リポジトリ所有 JSON Schema の固定 inventory、Draft 7 compile cache、値非表示の検証エラー変換。外部 schema path は受け取らない |
@@ -249,6 +250,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `infrastructure.media.stock` | ボツ画像ストック化（`assets/stock/<theme>/` への退避・列挙・整理、隣接 `.meta.json` 管理） |
 | `infrastructure.auth` | OAuth 2.0 token の読み込み・refresh・atomic 永続化、scope と YouTube service 生成 |
 | `infrastructure.secrets` | シークレット解決（`_SECRET_REFS` で参照定義） |
+| `infrastructure.notifications.discord` | typed pipeline eventを既存secret・webhook owner経由でbest-effort配信するDiscord sink |
 | `application.live_chat.{codex,filters,history,models,runner}` | active broadcast のチャット取得、Codex 構造化判定、入出力フィルタ、PT 日次・時間・連続 user 上限、重複防止履歴、返信投稿 loop |
 | `commands.youtube.live_chat_reply` | `yt-live-chat-reply` 常駐 CLI。`comments.live_chat.enabled` を opt-in とし、VPS では独立した `live-chat-reply.service` から起動 |
 | `commands.system.skills_sync` | `yt-skills` 本体 |

--- a/src/youtube_automation/domains/notifications.py
+++ b/src/youtube_automation/domains/notifications.py
@@ -1,0 +1,44 @@
+"""Provider-neutral pipeline notification events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class NotificationEventCategory(StrEnum):
+    NORMAL = "normal"
+    ABNORMAL = "abnormal"
+
+
+class NotificationEventKind(StrEnum):
+    HANDOFF_COMPLETED = "handoff_completed"
+    PUBLISH_COMPLETED = "publish_completed"
+    NON_FAST_FORWARD_STOPPED = "non_fast_forward_stopped"
+    FAIL_CLOSED_ABORTED = "fail_closed_aborted"
+    GUARD_EXCEEDED = "guard_exceeded"
+    CANARY_FAILED = "canary_failed"
+
+
+_CATEGORY_BY_KIND = {
+    NotificationEventKind.HANDOFF_COMPLETED: NotificationEventCategory.NORMAL,
+    NotificationEventKind.PUBLISH_COMPLETED: NotificationEventCategory.NORMAL,
+    NotificationEventKind.NON_FAST_FORWARD_STOPPED: NotificationEventCategory.ABNORMAL,
+    NotificationEventKind.FAIL_CLOSED_ABORTED: NotificationEventCategory.ABNORMAL,
+    NotificationEventKind.GUARD_EXCEEDED: NotificationEventCategory.ABNORMAL,
+    NotificationEventKind.CANARY_FAILED: NotificationEventCategory.ABNORMAL,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class NotificationEvent:
+    kind: NotificationEventKind
+    channel: str
+    collection: str
+    stage: str
+
+
+def category_for(kind: NotificationEventKind) -> NotificationEventCategory:
+    """Return the stable operator-facing classification for an event kind."""
+
+    return _CATEGORY_BY_KIND[kind]

--- a/src/youtube_automation/infrastructure/notifications/__init__.py
+++ b/src/youtube_automation/infrastructure/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""External notification adapters."""

--- a/src/youtube_automation/infrastructure/notifications/discord.py
+++ b/src/youtube_automation/infrastructure/notifications/discord.py
@@ -1,0 +1,70 @@
+"""Best-effort Discord delivery for typed pipeline events."""
+
+from __future__ import annotations
+
+import sys
+from typing import Protocol
+
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.notifications import NotificationEvent, category_for
+from youtube_automation.infrastructure.secrets import get_secret
+from youtube_automation.infrastructure.youtube.notification import NotificationError, notify
+
+_WEBHOOK_SECRET_NAME = "DISCORD_WEBHOOK_URL"
+
+
+class SecretResolver(Protocol):
+    def __call__(self, name: str) -> str: ...
+
+
+class WebhookSender(Protocol):
+    def __call__(self, *, content: str, webhook_url: str | None) -> None: ...
+
+
+class DiscordNotificationSink:
+    """Deliver classified events without making notification a pipeline gate."""
+
+    def __init__(
+        self,
+        *,
+        secret_resolver: SecretResolver,
+        webhook_sender: WebhookSender,
+    ) -> None:
+        self._secret_resolver = secret_resolver
+        self._webhook_sender = webhook_sender
+
+    def send(self, event: NotificationEvent) -> bool:
+        try:
+            webhook_url = self._secret_resolver(_WEBHOOK_SECRET_NAME)
+            self._webhook_sender(
+                content=_render_event(event),
+                webhook_url=webhook_url,
+            )
+        except (ConfigError, NotificationError):
+            print(
+                "Discord notification was not delivered "
+                f"(event={event.kind.value}, channel={event.channel}, "
+                f"collection={event.collection}, stage={event.stage})",
+                file=sys.stderr,
+            )
+            return False
+        return True
+
+
+def create_discord_notification_sink() -> DiscordNotificationSink:
+    """Compose the Discord adapter with canonical secret and HTTP owners."""
+
+    return DiscordNotificationSink(secret_resolver=get_secret, webhook_sender=notify)
+
+
+def _render_event(event: NotificationEvent) -> str:
+    category = category_for(event.kind).value.upper()
+    return "\n".join(
+        (
+            f"[{category}] YouTube automation pipeline event",
+            f"event: {event.kind.value}",
+            f"channel: {event.channel}",
+            f"collection: {event.collection}",
+            f"stage: {event.stage}",
+        )
+    )

--- a/tests/domains/test_notifications.py
+++ b/tests/domains/test_notifications.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import pytest
+
+from youtube_automation.domains.notifications import (
+    NotificationEventCategory,
+    NotificationEventKind,
+    category_for,
+)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        NotificationEventKind.HANDOFF_COMPLETED,
+        NotificationEventKind.PUBLISH_COMPLETED,
+    ],
+)
+def test_category_for_classifies_successful_pipeline_events_as_normal(
+    kind: NotificationEventKind,
+) -> None:
+    assert category_for(kind) is NotificationEventCategory.NORMAL
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        NotificationEventKind.NON_FAST_FORWARD_STOPPED,
+        NotificationEventKind.FAIL_CLOSED_ABORTED,
+        NotificationEventKind.GUARD_EXCEEDED,
+        NotificationEventKind.CANARY_FAILED,
+    ],
+)
+def test_category_for_classifies_stopped_pipeline_events_as_abnormal(
+    kind: NotificationEventKind,
+) -> None:
+    assert category_for(kind) is NotificationEventCategory.ABNORMAL

--- a/tests/infrastructure/notifications/test_discord.py
+++ b/tests/infrastructure/notifications/test_discord.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import pytest
+
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
+from youtube_automation.infrastructure.notifications import discord
+from youtube_automation.infrastructure.notifications.discord import DiscordNotificationSink
+from youtube_automation.infrastructure.youtube.notification import NotificationError
+
+
+def _event(kind: NotificationEventKind) -> NotificationEvent:
+    return NotificationEvent(
+        kind=kind,
+        channel="ambient-lab",
+        collection="night-rain",
+        stage="media-handoff",
+    )
+
+
+@pytest.mark.parametrize(
+    ("kind", "classification"),
+    [
+        (NotificationEventKind.HANDOFF_COMPLETED, "NORMAL"),
+        (NotificationEventKind.NON_FAST_FORWARD_STOPPED, "ABNORMAL"),
+    ],
+)
+def test_send_resolves_discord_secret_and_posts_classified_event(
+    kind: NotificationEventKind,
+    classification: str,
+) -> None:
+    resolved_names: list[str] = []
+    posted: list[tuple[str, str | None]] = []
+
+    def resolve_secret(name: str) -> str:
+        resolved_names.append(name)
+        return "https://discord.com/api/webhooks/id/token"
+
+    def post_webhook(*, content: str, webhook_url: str | None) -> None:
+        posted.append((content, webhook_url))
+
+    sink = DiscordNotificationSink(
+        secret_resolver=resolve_secret,
+        webhook_sender=post_webhook,
+    )
+
+    delivered = sink.send(_event(kind))
+
+    assert delivered is True
+    assert resolved_names == ["DISCORD_WEBHOOK_URL"]
+    assert len(posted) == 1
+    content, webhook_url = posted[0]
+    assert webhook_url == "https://discord.com/api/webhooks/id/token"
+    assert f"[{classification}]" in content
+    assert f"event: {kind.value}" in content
+    assert "channel: ambient-lab" in content
+    assert "collection: night-rain" in content
+    assert "stage: media-handoff" in content
+
+
+@pytest.mark.parametrize(
+    "failure",
+    [
+        ConfigError("secret unavailable"),
+        NotificationError("webhook POST failed: secret-bearing-detail"),
+    ],
+)
+def test_send_is_best_effort_and_redacts_known_delivery_failures(
+    failure: ConfigError | NotificationError,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    def fail_secret(_: str) -> str:
+        if isinstance(failure, ConfigError):
+            raise failure
+        return "https://discord.com/api/webhooks/id/token"
+
+    def fail_webhook(*, content: str, webhook_url: str | None) -> None:
+        del content, webhook_url
+        if isinstance(failure, NotificationError):
+            raise failure
+
+    sink = DiscordNotificationSink(
+        secret_resolver=fail_secret,
+        webhook_sender=fail_webhook,
+    )
+
+    delivered = sink.send(_event(NotificationEventKind.CANARY_FAILED))
+
+    assert delivered is False
+    stderr = capsys.readouterr().err
+    assert "Discord notification was not delivered" in stderr
+    assert "event=canary_failed" in stderr
+    assert "secret unavailable" not in stderr
+    assert "secret-bearing-detail" not in stderr
+
+
+def test_send_does_not_hide_unexpected_programming_errors() -> None:
+    def explode(*, content: str, webhook_url: str | None) -> None:
+        del content, webhook_url
+        raise RuntimeError("bug")
+
+    sink = DiscordNotificationSink(
+        secret_resolver=lambda _: "https://discord.com/api/webhooks/id/token",
+        webhook_sender=explode,
+    )
+
+    with pytest.raises(RuntimeError, match="bug"):
+        sink.send(_event(NotificationEventKind.HANDOFF_COMPLETED))
+
+
+def test_factory_wires_canonical_secret_and_webhook_owners(monkeypatch: pytest.MonkeyPatch) -> None:
+    resolved: list[str] = []
+    posted: list[str] = []
+
+    def resolve_secret(name: str) -> str:
+        resolved.append(name)
+        return "https://discord.com/api/webhooks/id/token"
+
+    def post_webhook(*, content: str, webhook_url: str | None) -> None:
+        del webhook_url
+        posted.append(content)
+
+    monkeypatch.setattr(discord, "get_secret", resolve_secret)
+    monkeypatch.setattr(discord, "notify", post_webhook)
+
+    delivered = discord.create_discord_notification_sink().send(_event(NotificationEventKind.PUBLISH_COMPLETED))
+
+    assert delivered is True
+    assert resolved == ["DISCORD_WEBHOOK_URL"]
+    assert len(posted) == 1


### PR DESCRIPTION
## 概要

hybrid pipeline eventをtyped分類し、secret-safeなbest-effort Discord sinkを追加します。

## 変更内容

- handoff/publish完了をNORMALへ分類
- non-ff/fail-closed/guard/canary異常をABNORMALへ分類
- `DISCORD_WEBHOOK_URL`をcanonical secret ownerで解決
- 既存HTTPS/host検証webhook ownerへ送信
- Config/NotificationErrorは内容を漏らさずFalse+stderrへ隔離
- 予期しない例外は隠さない

## 検証

- focused/Any/wheel: 71 passed
- full: 9630 passed, 3 skipped
- ruff / format / build: green

Closes #4063