### PR TITLE
feat(hybrid): runner開始前の資源上限guardを追加する (#4058)

### DIFF
--- a/.claude/skills/wf-new/references/schedule.md
+++ b/.claude/skills/wf-new/references/schedule.md
@@ -53,7 +53,7 @@ Claude Code `/loop` は最長 3 日の一時反復専用で、永続スケジュ
 
 ### サンドイッチ runner
 
-cloud / local とも同じ `references/run-sandwich.sh` を使う。runner は空の workspace へ channel repository をcloneし、`uv run --frozen yt-hybrid-runner` へ直行する。Nix devShell、GitHub Actions の環境変数、workflow構文は使わない。入力handoffを指定した場合はGit管理stateのmanifest key/root checksumとMediaStoreからpull・再検証したmanifestが一致した後だけagentを1回起動し、出力handoffは全成果物のpush・検証後にmanifestを最後にpublishする。最後に既存state sync ownerが制御面JSONだけをcommit + pushし、non-fast-forwardやagent失敗では自動merge/rebaseせず停止する。
+cloud / local とも同じ `references/run-sandwich.sh` を使う。runner は空の workspace へ channel repository をcloneし、`uv run --frozen yt-hybrid-runner` へ直行する。Nix devShell、GitHub Actions の環境変数、workflow構文は使わない。開始時にdisk空き2.5GiB以上、MediaStore滞留10GiB以下、追加生成費$0、自己申告run数から算出した月間Actions 2,000分以下を検査し、超過時は通知eventを出してGit pull・MediaStore転送・agent起動前に停止する。入力handoffを指定した場合はGit管理stateのmanifest key/root checksumとMediaStoreからpull・再検証したmanifestが一致した後だけagentを1回起動し、出力handoffは全成果物のpush・検証後にmanifestを最後にpublishする。最後に既存state sync ownerが制御面JSONだけをcommit + pushし、non-fast-forwardやagent失敗では自動merge/rebaseせず停止する。
 
 ```bash
 bash .claude/skills/wf-new/references/run-sandwich.sh \
@@ -61,12 +61,14 @@ bash .claude/skills/wf-new/references/run-sandwich.sh \
   --channel-slug <channel> --collection <collection> \
   --collection-dir collections/<planning|live>/<collection> \
   --agent <claude|codex> --prompt "/wf-new --auto" \
+  --generation-cost-usd 0 --monthly-run-count <今月完了済みrun数> \
+  --estimated-run-minutes 60 \
   --input-handoff suno-download --input-destination <relative-directory> \
   --output-handoff <handoff> --output-root <relative-directory> \
   --output-file <relative-file>
 ```
 
-R2接続は既存 `R2MediaStoreConfig` の環境変数/secret ownerを使う。`--media-store local --local-store-root <path>` は同一runnerをローカルadapterで検証・運用する場合だけ指定する。入力または出力がない工程は対応するhandoff引数一式を省略する。
+R2接続は既存 `R2MediaStoreConfig` の環境変数/secret ownerを使う。容量観測のbucket listingは滞留量の合算だけに使い、handoff pullの正本は引き続きmanifest記載keyに限定する。`--media-store local --local-store-root <path>` は同一runnerをローカルadapterで検証・運用する場合だけ指定する。入力または出力がない工程は対応するhandoff引数一式を省略する。`--monthly-run-count` は今月完了済みrun数を指定し、今回runを加えた概算値が標準エラーの `hybrid_resource_observed` に記録される。
 
 GitHub Actions の日次ポーリング定義は `uv run yt-skills sync --asset channel-workflow --force` で `.github/workflows/youtube-automation.yml` へ配布する。workflow は同じ `run-sandwich.sh` を1回呼ぶだけで、`YTA_CHANNEL_SLUG` / `YTA_COLLECTION` / `YTA_COLLECTION_DIR` / `YTA_AGENT` / `YTA_AUTOMATION_PROMPT` を repository variables、R2 と Claude の credential を repository secrets から注入する。`concurrency.cancel-in-progress: false` により先行実行を中断せず、後続の日次起動を同一repository内で直列化する。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `feat(hybrid)`: cloud 工程の定期実行先に `github-actions` backend を追加し、配布 workflow の UTC cron を管理区間限定で設定・確認・停止できるようにする（#4055）。
 - `feat(hybrid)`: 引き渡し・公開完了と異常停止をtyped eventで正常／異常へ分類し、既存secret ownerからDiscord webhookを解決してbest-effort送信するsinkを追加する（#4063）。
+- `feat(hybrid)`: サンドイッチrunner開始前にdisk空き・R2滞留量・生成従量費・月間Actions分数概算を検査し、0円・容量上限超過を通知event付きでfail-closed停止するresource guardを追加する（#4058）。
 - `feat(hybrid)`: サンドイッチrunnerだけを呼ぶ日次cron・直列concurrency付きGitHub Actions workflowを追加し、`yt-skills sync` で下流チャンネルへ配布する（#4054）。
 - `feat(hybrid)`: R2 pull 後の個別音源を企画曲数・Suno duration guard・integrated LUFS で fail-closed 検証し、拒否通知 event を発火する `yt-media-acceptance` を追加する（#4057）。
 - `feat(hybrid)`: Git clone、検証済みMediaStore pull、単一agent境界、成果物push、state commit/pushをuv直行で束ねる基盤非依存サンドイッチrunnerを追加する（#4053）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 **受け渡しマニフェスト**: 境界を越えるメディア受け渡しの完了マーカー。v1 は `<channel>/<collection>/<handoff>/manifest.json` に、path 昇順の正準ファイル一覧（相対 POSIX path・size・SHA-256）と、その一覧の canonical compact JSON に対する SHA-256 `root_sha256` を保持する。全 object の remote metadata と pull 後 content を検証した後、manifest を最後に atomic PUT する。R2 の強い read-after-write 整合性を completion marker 成立の必須前提とし、この保証を持たない MediaStore adapter は利用しない。後工程は bucket listing を行わず manifest 記載 key だけを検証付きで読み、manifest が無ければ「存在しない」扱いとする。正本は R2 で、Git state にはキー + root checksum のみ記録する（ADR-0024）。
 
-**サンドイッチ runner**: cloud/local共通の基盤非依存実行境界。配布済み `wf-new/references/run-sandwich.sh` がchannel repository clone後にNixを介さず `uv run --frozen yt-hybrid-runner` を呼び、Git state参照と一致するmanifest pull → 既存workflowを動かす単一agent CLI境界 → manifest-last成果物push → 制御面state commit/pushを順序固定する。GitHub Actions固有のtrigger/concurrency/secret記述は後続の薄いworkflowだけが所有する（ADR-0024 決定7 / ADR-0025 決定5）。
+**サンドイッチ runner**: cloud/local共通の基盤非依存実行境界。配布済み `wf-new/references/run-sandwich.sh` がchannel repository clone後にNixを介さず `uv run --frozen yt-hybrid-runner` を呼び、disk空き・MediaStore滞留量・生成費・月間Actions分数概算の開始前guard → Git state参照と一致するmanifest pull → 既存workflowを動かす単一agent CLI境界 → manifest-last成果物push → 制御面state commit/pushを順序固定する。guard拒否時はGit・MediaStore・agentへ副作用を起こさず通知eventを発火する。GitHub Actions固有のtrigger/concurrency/secret記述は後続の薄いworkflowだけが所有する（ADR-0024 決定7 / ADR-0025 決定5・6）。
 
 **MediaStore**: 境界を越えるメディアの pull / push を行う転送層の抽象。第一実装は R2 で、将来のストレージ交換点をここに限定する。工程や resolver へのストレージ抽象の注入は行わない（ADR-0024）。
 

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Protocol
 
 from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
-from youtube_automation.core.errors import StateSyncError, ValidationError
+from youtube_automation.core.errors import AutomationError, ResourceLimitError, StateSyncError, ValidationError
 from youtube_automation.domains.collections.workflow_state import read
+from youtube_automation.domains.hybrid_resource_guard import (
+    HybridResourcePolicy,
+    HybridResourceReport,
+    HybridResourceSnapshot,
+    evaluate_hybrid_resources,
+)
 from youtube_automation.domains.media_handoff_manifest import MANIFEST_NAME, HandoffIdentity, HandoffManifest
 from youtube_automation.domains.media_store import MediaStore, validate_media_relative_path
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
@@ -19,6 +26,27 @@ from youtube_automation.infrastructure.vcs.state_sync import pull_update_commit_
 
 Agent = Literal["claude", "codex"]
 AgentRunner = Callable[[Agent, str, Path], None]
+
+
+class HybridResourceProbe(Protocol):
+    def inspect(self) -> HybridResourceSnapshot: ...
+
+
+class HybridResourceEventKind(StrEnum):
+    OBSERVED = "observed"
+    REJECTED = "rejected"
+
+
+@dataclass(frozen=True, slots=True)
+class HybridResourceEvent:
+    kind: HybridResourceEventKind
+    channel: str
+    collection: str
+    issue_codes: tuple[str, ...]
+    detail: str
+
+
+HybridResourceEventSink = Callable[[HybridResourceEvent], None]
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,13 +112,77 @@ def _verify_input_reference(request: SandwichRequest, manifest: HandoffManifest)
         raise StateSyncError("workflow-state handoff参照とpull済みmanifestが一致しません")
 
 
+def _resource_detail(report: HybridResourceReport) -> str:
+    snapshot = report.snapshot
+    policy = report.policy
+    return (
+        f"disk_free={snapshot.disk_free_bytes}/{policy.minimum_free_disk_bytes} bytes, "
+        f"r2_retained={snapshot.r2_retained_bytes}/{policy.maximum_r2_retained_bytes} bytes, "
+        f"generation_cost=${snapshot.generation_cost_usd}/${policy.maximum_generation_cost_usd}, "
+        f"monthly_runs={snapshot.monthly_run_count + 1}, "
+        f"projected_actions_minutes={report.projected_monthly_actions_minutes}/"
+        f"{policy.maximum_monthly_actions_minutes}"
+    )
+
+
+def _guard_resources(
+    request: SandwichRequest,
+    resource_probe: HybridResourceProbe,
+    on_event: HybridResourceEventSink | None,
+) -> None:
+    try:
+        snapshot = resource_probe.inspect()
+    except AutomationError as error:
+        if on_event is not None:
+            on_event(
+                HybridResourceEvent(
+                    HybridResourceEventKind.REJECTED,
+                    request.channel,
+                    request.collection,
+                    ("probe",),
+                    str(error),
+                )
+            )
+        raise
+    report = evaluate_hybrid_resources(snapshot, HybridResourcePolicy.zero_cost())
+    detail = _resource_detail(report)
+    if report.passed:
+        if on_event is not None:
+            on_event(
+                HybridResourceEvent(
+                    HybridResourceEventKind.OBSERVED,
+                    request.channel,
+                    request.collection,
+                    (),
+                    detail,
+                )
+            )
+        return
+    issue_codes = tuple(issue.code for issue in report.issues)
+    rejection_detail = f"{detail}; " + "; ".join(issue.message for issue in report.issues)
+    if on_event is not None:
+        on_event(
+            HybridResourceEvent(
+                HybridResourceEventKind.REJECTED,
+                request.channel,
+                request.collection,
+                issue_codes,
+                rejection_detail,
+            )
+        )
+    raise ResourceLimitError(f"hybrid resource guard rejected: {rejection_detail}")
+
+
 def run_sandwich(
     request: SandwichRequest,
     store: MediaStore,
     *,
+    resource_probe: HybridResourceProbe,
     agent_runner: AgentRunner = run_agent,
+    on_resource_event: HybridResourceEventSink | None = None,
 ) -> None:
     """Run the existing local-first workflow between verified MediaStore boundaries."""
+    _guard_resources(request, resource_probe, on_resource_event)
     context = build_context(request.channel_dir)
 
     def writer() -> None:

--- a/src/youtube_automation/commands/system/hybrid_runner.py
+++ b/src/youtube_automation/commands/system/hybrid_runner.py
@@ -3,11 +3,14 @@
 from __future__ import annotations
 
 import argparse
+import sys
+from decimal import Decimal
 from pathlib import Path
 
-from youtube_automation.application.hybrid_runner import SandwichRequest, run_sandwich
+from youtube_automation.application.hybrid_runner import HybridResourceEvent, SandwichRequest, run_sandwich
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.infrastructure.hybrid_resources import SystemHybridResourceProbe
 from youtube_automation.infrastructure.media_store.local import LocalMediaStore
 from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
 
@@ -28,7 +31,32 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-file", action="append", default=[])
     parser.add_argument("--media-store", choices=("r2", "local"), default="r2")
     parser.add_argument("--local-store-root", type=Path)
+    parser.add_argument(
+        "--generation-cost-usd",
+        type=Decimal,
+        default=Decimal("0"),
+        help="このrunで新たに発生する生成従量費 (default: 0; 0円原則では正数を拒否)",
+    )
+    parser.add_argument(
+        "--monthly-run-count",
+        type=int,
+        default=0,
+        help="今月完了済みrun数の自己申告値 (default: 0)",
+    )
+    parser.add_argument(
+        "--estimated-run-minutes",
+        type=int,
+        default=60,
+        help="1 runの保守的なActions分数見積り (default: 60)",
+    )
     return parser
+
+
+def _report_resource_event(event: HybridResourceEvent) -> None:
+    print(
+        f"hybrid_resource_{event.kind.value}: channel={event.channel}, collection={event.collection}, {event.detail}",
+        file=sys.stderr,
+    )
 
 
 def run(args: argparse.Namespace) -> int:
@@ -54,7 +82,14 @@ def run(args: argparse.Namespace) -> int:
         output_root=args.output_root,
         output_files=tuple(args.output_file),
     )
-    run_sandwich(request, store)
+    resource_probe = SystemHybridResourceProbe(
+        channel_dir=request.channel_dir,
+        store=store,
+        generation_cost_usd=args.generation_cost_usd,
+        monthly_run_count=args.monthly_run_count,
+        estimated_run_minutes=args.estimated_run_minutes,
+    )
+    run_sandwich(request, store, resource_probe=resource_probe, on_resource_event=_report_resource_event)
     return 0
 
 

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -137,6 +137,10 @@ class StateSyncError(AutomationError):
     """Git制御面stateのpull / commit / push同期エラー。"""
 
 
+class ResourceLimitError(AutomationError):
+    """runner開始前の容量・費用・実行量上限エラー。"""
+
+
 def _http_error_reason(error) -> str | None:
     content = getattr(error, "content", b"")
     if isinstance(content, bytes):

--- a/src/youtube_automation/domains/hybrid_resource_guard.py
+++ b/src/youtube_automation/domains/hybrid_resource_guard.py
@@ -1,0 +1,101 @@
+"""サンドイッチrunner開始前の0円・容量上限判定。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from youtube_automation.core.errors import ValidationError
+
+GIB = 1024**3
+
+
+@dataclass(frozen=True, slots=True)
+class HybridResourcePolicy:
+    minimum_free_disk_bytes: int
+    maximum_r2_retained_bytes: int
+    maximum_generation_cost_usd: Decimal
+    maximum_monthly_actions_minutes: int
+
+    @classmethod
+    def zero_cost(cls) -> HybridResourcePolicy:
+        return cls(
+            minimum_free_disk_bytes=int(Decimal("2.5") * GIB),
+            maximum_r2_retained_bytes=10 * GIB,
+            maximum_generation_cost_usd=Decimal("0"),
+            maximum_monthly_actions_minutes=2_000,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HybridResourceSnapshot:
+    disk_free_bytes: int
+    r2_retained_bytes: int
+    generation_cost_usd: Decimal
+    monthly_run_count: int
+    estimated_run_minutes: int
+
+    def __post_init__(self) -> None:
+        for field in ("disk_free_bytes", "r2_retained_bytes", "monthly_run_count", "estimated_run_minutes"):
+            value = getattr(self, field)
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValidationError(f"hybrid resource {field} は0以上の整数が必要です")
+        cost = Decimal(str(self.generation_cost_usd))
+        if not cost.is_finite() or cost < 0:
+            raise ValidationError("hybrid resource generation_cost_usd は0以上の有限数が必要です")
+        object.__setattr__(self, "generation_cost_usd", cost)
+
+
+@dataclass(frozen=True, slots=True)
+class HybridResourceIssue:
+    code: str
+    message: str
+
+
+@dataclass(frozen=True, slots=True)
+class HybridResourceReport:
+    snapshot: HybridResourceSnapshot
+    policy: HybridResourcePolicy
+    projected_monthly_actions_minutes: int
+    issues: tuple[HybridResourceIssue, ...]
+
+    @property
+    def passed(self) -> bool:
+        return not self.issues
+
+
+def evaluate_hybrid_resources(
+    snapshot: HybridResourceSnapshot,
+    policy: HybridResourcePolicy,
+) -> HybridResourceReport:
+    projected_minutes = (snapshot.monthly_run_count + 1) * snapshot.estimated_run_minutes
+    issues: list[HybridResourceIssue] = []
+    if snapshot.disk_free_bytes < policy.minimum_free_disk_bytes:
+        issues.append(
+            HybridResourceIssue(
+                "disk_free",
+                f"disk free {snapshot.disk_free_bytes} < required {policy.minimum_free_disk_bytes} bytes",
+            )
+        )
+    if snapshot.r2_retained_bytes > policy.maximum_r2_retained_bytes:
+        issues.append(
+            HybridResourceIssue(
+                "r2_retained",
+                f"R2 retained {snapshot.r2_retained_bytes} > limit {policy.maximum_r2_retained_bytes} bytes",
+            )
+        )
+    if snapshot.generation_cost_usd > policy.maximum_generation_cost_usd:
+        issues.append(
+            HybridResourceIssue(
+                "generation_cost",
+                f"generation cost ${snapshot.generation_cost_usd} > limit ${policy.maximum_generation_cost_usd}",
+            )
+        )
+    if projected_minutes > policy.maximum_monthly_actions_minutes:
+        issues.append(
+            HybridResourceIssue(
+                "actions_minutes",
+                f"projected Actions minutes {projected_minutes} > limit {policy.maximum_monthly_actions_minutes}",
+            )
+        )
+    return HybridResourceReport(snapshot, policy, projected_minutes, tuple(issues))

--- a/src/youtube_automation/infrastructure/hybrid_resources.py
+++ b/src/youtube_automation/infrastructure/hybrid_resources.py
@@ -1,0 +1,39 @@
+"""runner開始前のホスト・MediaStore容量観測。"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Protocol
+
+from youtube_automation.core.errors import ResourceLimitError
+from youtube_automation.domains.hybrid_resource_guard import HybridResourceSnapshot
+
+
+class RetainedCapacityProbe(Protocol):
+    def retained_bytes(self) -> int: ...
+
+
+@dataclass(frozen=True, slots=True)
+class SystemHybridResourceProbe:
+    channel_dir: Path
+    store: RetainedCapacityProbe
+    generation_cost_usd: Decimal
+    monthly_run_count: int
+    estimated_run_minutes: int
+
+    def inspect(self) -> HybridResourceSnapshot:
+        try:
+            disk_free_bytes = shutil.disk_usage(self.channel_dir).free
+            r2_retained_bytes = self.store.retained_bytes()
+        except OSError as error:
+            raise ResourceLimitError(f"hybrid resource probe failed: {error}") from error
+        return HybridResourceSnapshot(
+            disk_free_bytes=disk_free_bytes,
+            r2_retained_bytes=r2_retained_bytes,
+            generation_cost_usd=self.generation_cost_usd,
+            monthly_run_count=self.monthly_run_count,
+            estimated_run_minutes=self.estimated_run_minutes,
+        )

--- a/src/youtube_automation/infrastructure/media_store/local.py
+++ b/src/youtube_automation/infrastructure/media_store/local.py
@@ -59,3 +59,11 @@ class LocalMediaStore:
             raise MediaStoreError(f"MediaStore object が通常ファイルではありません: {key.as_posix()}")
         size, checksum = sha256_file(path)
         return MediaObjectMetadata(size=size, sha256=checksum)
+
+    def retained_bytes(self) -> int:
+        total = 0
+        for path in self._root.rglob("*"):
+            reject_symlink_components(path, boundary=self._root)
+            if path.is_file():
+                total += path.stat().st_size
+        return total

--- a/src/youtube_automation/infrastructure/media_store/r2.py
+++ b/src/youtube_automation/infrastructure/media_store/r2.py
@@ -89,6 +89,14 @@ class _S3Client(Protocol):
 
     def abort_multipart_upload(self, *, Bucket: str, Key: str, UploadId: str) -> None: ...
 
+    def list_objects_v2(
+        self,
+        *,
+        Bucket: str,
+        Prefix: str,
+        ContinuationToken: str | None = None,
+    ) -> dict[str, object]: ...
+
 
 @dataclass(frozen=True)
 class MultipartTransferConfig:
@@ -557,3 +565,45 @@ class R2MediaStore:
             sha256=checksum,
             etag=etag.strip('"') if isinstance(etag, str) else None,
         )
+
+    def retained_bytes(self) -> int:
+        prefix = f"{self._config.prefix}/" if self._config.prefix else ""
+        total = 0
+        continuation: str | None = None
+        try:
+            while True:
+                if continuation is None:
+                    response = self._client.list_objects_v2(Bucket=self._config.bucket, Prefix=prefix)
+                else:
+                    response = self._client.list_objects_v2(
+                        Bucket=self._config.bucket,
+                        Prefix=prefix,
+                        ContinuationToken=continuation,
+                    )
+                contents = response.get("Contents", [])
+                if not isinstance(contents, list):
+                    raise MediaStoreError("R2 retained capacity 応答が不正です")
+                for item in contents:
+                    if not isinstance(item, dict):
+                        raise MediaStoreError("R2 retained capacity object が不正です")
+                    key = item.get("Key")
+                    size = item.get("Size")
+                    if (
+                        not isinstance(key, str)
+                        or not key.startswith(prefix)
+                        or not isinstance(size, int)
+                        or isinstance(size, bool)
+                        or size < 0
+                    ):
+                        raise MediaStoreError("R2 retained capacity object が不正です")
+                    total += size
+                if response.get("IsTruncated") is not True:
+                    return total
+                next_continuation = response.get("NextContinuationToken")
+                if not isinstance(next_continuation, str) or not next_continuation or next_continuation == continuation:
+                    raise MediaStoreError("R2 retained capacity pagination が不正です")
+                continuation = next_continuation
+        except MediaStoreError:
+            raise
+        except Exception as exc:
+            raise self._error("retained capacity", exc) from exc

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -4,6 +4,7 @@ import json
 import os
 import subprocess
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -11,7 +12,8 @@ import pytest
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.application.hybrid_runner import SandwichRequest, run_sandwich
 from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
-from youtube_automation.core.errors import StateSyncError
+from youtube_automation.core.errors import ResourceLimitError, StateSyncError
+from youtube_automation.domains.hybrid_resource_guard import GIB, HybridResourceSnapshot
 from youtube_automation.domains.media_handoff_manifest import HandoffIdentity
 from youtube_automation.infrastructure.media_store.local import LocalMediaStore
 
@@ -58,6 +60,17 @@ def _repositories(tmp_path: Path, manifest_key: str, root_sha256: str) -> tuple[
     return remote, seed, worker
 
 
+class PassingResourceProbe:
+    def inspect(self) -> HybridResourceSnapshot:
+        return HybridResourceSnapshot(
+            disk_free_bytes=3 * GIB,
+            r2_retained_bytes=0,
+            generation_cost_usd=Decimal("0"),
+            monthly_run_count=0,
+            estimated_run_minutes=60,
+        )
+
+
 def test_runner_completes_manifest_pull_agent_push_and_state_commit(tmp_path: Path) -> None:
     store = LocalMediaStore(tmp_path / "store")
     source = tmp_path / "song.mp3"
@@ -94,7 +107,7 @@ def test_runner_completes_manifest_pull_agent_push_and_state_commit(tmp_path: Pa
         output_files=("Master.mp4",),
     )
 
-    run_sandwich(request, store, agent_runner=agent)
+    run_sandwich(request, store, resource_probe=PassingResourceProbe(), agent_runner=agent)
 
     assert calls == [("claude", "/wf-new --auto")]
     checkout = tmp_path / "verify"
@@ -153,9 +166,90 @@ def test_runner_rejects_manifest_that_does_not_match_git_state_before_agent(tmp_
     )
 
     with pytest.raises(StateSyncError, match="manifestが一致しません"):
-        run_sandwich(request, store, agent_runner=agent)
+        run_sandwich(request, store, resource_probe=PassingResourceProbe(), agent_runner=agent)
 
     assert called is False
+
+
+def test_runner_emits_rejection_and_has_no_git_media_or_agent_side_effect_when_resource_limit_exceeded(
+    tmp_path: Path,
+) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    manifest_key = "003ch/demo/suno-download/manifest.json"
+    _, _, worker = _repositories(tmp_path, manifest_key, "0" * 64)
+    head_before = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=worker, check=True, capture_output=True, text=True
+    ).stdout.strip()
+    calls: list[str] = []
+    events = []
+
+    class RejectedResourceProbe:
+        def inspect(self) -> HybridResourceSnapshot:
+            return HybridResourceSnapshot(
+                disk_free_bytes=int(2.5 * GIB) - 1,
+                r2_retained_bytes=0,
+                generation_cost_usd=Decimal("0"),
+                monthly_run_count=0,
+                estimated_run_minutes=60,
+            )
+
+    request = SandwichRequest(
+        channel_dir=worker,
+        collection_dir="collections/planning/demo",
+        channel="003ch",
+        collection="demo",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+        input_handoff="suno-download",
+        input_destination="media",
+    )
+
+    with pytest.raises(ResourceLimitError, match="resource guard rejected"):
+        run_sandwich(
+            request,
+            store,
+            resource_probe=RejectedResourceProbe(),
+            agent_runner=lambda *_args: calls.append("agent"),
+            on_resource_event=events.append,
+        )
+
+    assert calls == []
+    assert not (worker / "media").exists()
+    assert (
+        subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=worker, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        == head_before
+    )
+    assert len(events) == 1
+    assert events[0].issue_codes == ("disk_free",)
+
+
+def test_runner_emits_rejection_and_stops_when_resource_inspection_fails(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    _, _, worker = _repositories(tmp_path, "unused/manifest.json", "0" * 64)
+    events = []
+
+    class FailingResourceProbe:
+        def inspect(self) -> HybridResourceSnapshot:
+            raise ResourceLimitError("capacity probe unavailable")
+
+    request = SandwichRequest(
+        channel_dir=worker,
+        collection_dir="collections/planning/demo",
+        channel="003ch",
+        collection="demo",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+    )
+
+    with pytest.raises(ResourceLimitError, match="probe unavailable"):
+        run_sandwich(request, store, resource_probe=FailingResourceProbe(), on_resource_event=events.append)
+
+    assert len(events) == 1
+    assert events[0].issue_codes == ("probe",)
 
 
 def test_posix_script_completes_local_pull_run_push(tmp_path: Path) -> None:
@@ -259,6 +353,8 @@ exec "$YTA_TEST_PYTHON" "$YTA_AGENT_SCRIPT"
     )
 
     assert result.returncode == 0, result.stderr
+    assert "hybrid_resource_observed" in result.stderr
+    assert "monthly_runs=1" in result.stderr
     verify = tmp_path / "script-verify"
     subprocess.run(["git", "clone", "--branch", "main", str(remote), str(verify)], check=True, capture_output=True)
     state = json.loads((verify / "collections/planning/demo/workflow-state.json").read_text(encoding="utf-8"))

--- a/tests/domains/test_hybrid_resource_guard.py
+++ b/tests/domains/test_hybrid_resource_guard.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.hybrid_resource_guard import (
+    GIB,
+    HybridResourcePolicy,
+    HybridResourceSnapshot,
+    evaluate_hybrid_resources,
+)
+
+
+def _snapshot(**overrides: object) -> HybridResourceSnapshot:
+    values: dict[str, object] = {
+        "disk_free_bytes": 3 * GIB,
+        "r2_retained_bytes": 2 * GIB,
+        "generation_cost_usd": Decimal("0"),
+        "monthly_run_count": 10,
+        "estimated_run_minutes": 45,
+    }
+    values.update(overrides)
+    return HybridResourceSnapshot(**values)  # type: ignore[arg-type]
+
+
+def test_evaluation_accepts_zero_cost_with_capacity_and_minutes_below_limits() -> None:
+    report = evaluate_hybrid_resources(_snapshot(), HybridResourcePolicy.zero_cost())
+
+    assert report.passed is True
+    assert report.projected_monthly_actions_minutes == 495
+    assert report.issues == ()
+
+
+def test_evaluation_accepts_values_exactly_at_each_limit() -> None:
+    report = evaluate_hybrid_resources(
+        _snapshot(
+            disk_free_bytes=int(Decimal("2.5") * GIB),
+            r2_retained_bytes=10 * GIB,
+            monthly_run_count=39,
+            estimated_run_minutes=50,
+        ),
+        HybridResourcePolicy.zero_cost(),
+    )
+
+    assert report.passed is True
+    assert report.projected_monthly_actions_minutes == 2_000
+
+
+@pytest.mark.parametrize(
+    ("overrides", "issue_code"),
+    [
+        ({"disk_free_bytes": int(2.5 * GIB) - 1}, "disk_free"),
+        ({"r2_retained_bytes": 10 * GIB + 1}, "r2_retained"),
+        ({"generation_cost_usd": Decimal("0.01")}, "generation_cost"),
+        ({"monthly_run_count": 44, "estimated_run_minutes": 45}, "actions_minutes"),
+    ],
+)
+def test_evaluation_rejects_each_limit_before_execution(overrides: dict[str, object], issue_code: str) -> None:
+    report = evaluate_hybrid_resources(_snapshot(**overrides), HybridResourcePolicy.zero_cost())
+
+    assert report.passed is False
+    assert tuple(issue.code for issue in report.issues) == (issue_code,)
+
+
+def test_snapshot_rejects_negative_self_reported_usage() -> None:
+    with pytest.raises(ValidationError, match="monthly_run_count"):
+        _snapshot(monthly_run_count=-1)

--- a/tests/infrastructure/media_store/test_local.py
+++ b/tests/infrastructure/media_store/test_local.py
@@ -31,6 +31,17 @@ def test_push_pull_round_trip_preserves_checksum(tmp_path: Path) -> None:
     assert store.metadata(_key()) == pushed
 
 
+def test_retained_bytes_counts_regular_objects_below_store_root(tmp_path: Path) -> None:
+    root = tmp_path / "store"
+    store = LocalMediaStore(root)
+    (root / "one.bin").write_bytes(b"one")
+    nested = root / "nested"
+    nested.mkdir()
+    (nested / "two.bin").write_bytes(b"twenty")
+
+    assert store.retained_bytes() == 9
+
+
 def test_missing_object_is_reported_without_creating_destination(tmp_path: Path) -> None:
     store = LocalMediaStore(tmp_path / "store")
     destination = tmp_path / "download.bin"

--- a/tests/infrastructure/media_store/test_r2.py
+++ b/tests/infrastructure/media_store/test_r2.py
@@ -135,6 +135,23 @@ class FakeS3Client:
         del Bucket, Key
         self.multipart_uploads.pop(UploadId, None)
 
+    def list_objects_v2(
+        self,
+        *,
+        Bucket: str,
+        Prefix: str,
+        ContinuationToken: str | None = None,
+    ) -> dict[str, object]:
+        del ContinuationToken
+        return {
+            "Contents": [
+                {"Key": key, "Size": len(payload)}
+                for (bucket, key), (payload, _metadata) in self.objects.items()
+                if bucket == Bucket and key.startswith(Prefix)
+            ],
+            "IsTruncated": False,
+        }
+
 
 class FakeClientError(Exception):
     def __init__(self, status: int, message: str) -> None:
@@ -173,6 +190,37 @@ def test_r2_push_pull_round_trip_uses_scoped_bucket_and_prefix(tmp_path: Path) -
     assert pushed.sha256 == pulled.sha256 == hashlib.sha256(payload).hexdigest()
     assert store.exists(_key()) is True
     assert store.metadata(_key()) == pushed
+
+
+def test_r2_retained_bytes_uses_only_configured_bucket_prefix() -> None:
+    client = FakeS3Client()
+    client.objects = {
+        ("media-handoffs", "automation/v1/one.bin"): (b"one", {}),
+        ("media-handoffs", "automation/v1/nested/two.bin"): (b"twenty", {}),
+        ("media-handoffs", "other/outside.bin"): (b"ignored", {}),
+        ("another-bucket", "automation/v1/outside.bin"): (b"ignored", {}),
+    }
+    store = R2MediaStore(_config(), client=client, transfer_config=object())
+
+    assert store.retained_bytes() == 9
+
+
+def test_r2_retained_bytes_rejects_malformed_listing() -> None:
+    class MalformedListingClient(FakeS3Client):
+        def list_objects_v2(
+            self,
+            *,
+            Bucket: str,
+            Prefix: str,
+            ContinuationToken: str | None = None,
+        ) -> dict[str, object]:
+            del Bucket, Prefix, ContinuationToken
+            return {"Contents": {"Key": "not-a-list"}, "IsTruncated": False}
+
+    store = R2MediaStore(_config(), client=MalformedListingClient(), transfer_config=object())
+
+    with pytest.raises(MediaStoreError, match="capacity 応答が不正"):
+        store.retained_bytes()
 
 
 def test_r2_config_resolves_api_token_through_the_secret_owner() -> None:


### PR DESCRIPTION
## 概要

hybrid runner開始前に容量・生成費・実行回数の上限をfail-closed判定し、超過時の副作用を防ぎます。

## 変更内容

- disk空き2.5GiB、R2滞留10GiB、生成費$0、月間Actions 2,000分を検証
- 超過・観測失敗時はGit/R2/agent副作用前に停止
- 拒否eventと自己申告run logを出力
- R2 listingは容量観測専用、handoff正本はmanifestを維持

## 検証

- focused（post-rebase）: 36 passed
- full: 9657 passed, 3 skipped
- repo広域: 1679 passed, 1 skipped
- ruff / format / Any / yt-skills / build / wheel: green

Closes #4058