### PR TITLE
feat(hybrid): DistroKid提出完了をstateへ記録する (#4067)

### DIFF
--- a/.claude/skills/distrokid-helper/SKILL.md
+++ b/.claude/skills/distrokid-helper/SKILL.md
@@ -12,7 +12,7 @@ description: "Use when コレクションの楽曲を DistroKid 配信用に準�
 
 ## 成果物
 
-- `書き込む`: `collections/<id>/30-distrokid/spec.json`, `collections/<id>/30-distrokid/cover_art_3000.jpg`, `collections/<id>/30-distrokid/<disc>/release.json`, `collections/<id>/30-distrokid/README.md`
+- `書き込む`: `collections/<id>/30-distrokid/spec.json`, `collections/<id>/30-distrokid/cover_art_3000.jpg`, `collections/<id>/30-distrokid/<disc>/release.json`, `collections/<id>/30-distrokid/README.md`, `collections/<id>/workflow-state.json::human_tasks.distrokid_submission.completed_at`
 - `読み込む`: `collections/<id>/02-Individual-music/*.mp3`, `collections/<id>/10-assets/main.png`, `config/channel/distrokid.json`
 
 ## Overview
@@ -288,6 +288,13 @@ verify が green になったら `.claude/skills/extension/references/serve.md` 
 
 1. distrokid-helper popup の **ローカル配信元** selector を開き、候補更新後に表示された対象を選択する
 2. Chrome 拡張 **distrokid-helper** を使って `30-distrokid/README.md` の手順に従い DistroKid Web フォームへ転記・アップロードを行う
-3. ユーザーが転記・アップロード完了を確認したら `.claude/skills/extension/references/serve.md` の停止契約を実 port へ適用し、対象 process が残っていないことを確認する
+3. ユーザーが転記・アップロード完了を確認した後、提出時点の human-task 完了を次の 1 コマンドで記録する。対象チャンネルの `config/channel/distrokid.json` が通常ファイルとして存在しない場合は state を変更せず停止する
+
+   ```bash
+   uv run yt-workflow-state --collection <collection> record-distrokid-submission
+   ```
+
+   `workflow-state.json` の `human_tasks.distrokid_submission.completed_at` が記録されたことを確認する。再実行時は初回の完了時刻を維持する
+4. `.claude/skills/extension/references/serve.md` の停止契約を実 port へ適用し、対象 process が残っていないことを確認する
 
 DistroKid 申請後の DSP リンク（Spotify / Apple Music）到着は通常 1〜2 週間かかる。

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -71,6 +71,11 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
     "manifest_key": "002ch/sample/suno-download/manifest.json",
     "root_sha256": "64 lowercase hex characters"
   },
+  "human_tasks": {
+    "distrokid_submission": {
+      "completed_at": "ISO 8601"
+    }
+  },
   "music_pair_selection": {
     "updated_at": "ISO 8601",
     "exceptions_over_limit_count": 1,
@@ -164,6 +169,10 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
 | `handoff.root_sha256` | string | manifest正準file一覧のroot SHA-256（lowercase 64 hex） |
 
 stateにはmanifest全文やfile一覧を複製しない。正本はMediaStore上のmanifestであり、Git制御面はkeyとroot checksumだけを保持する。
+
+### human_tasks フィールド詳細
+
+`human_tasks.distrokid_submission.completed_at` は DistroKid Web への転記・アップロードを人間が確認した提出時点を記録する。`config/channel/distrokid.json` が通常ファイルとして存在するチャンネルだけが対象で、`yt-workflow-state record-distrokid-submission` が初回時刻を lock + atomic update する。再実行では初回時刻を上書きせず、human-tasks 生成と live-clean は owner の `distrokid_submission_completed_at` accessor を参照する。
 
 ### stage フィールド詳細
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `docs(hybrid)`: Claude subscription OAuth token の GHA secret 配備・手動検証・失効時の fail-closed 停止・ローテーション手順を追加する（#4056）。
+- `feat(hybrid)`: DistroKid提出完了をhuman-taskの初回完了時刻としてGit管理stateへ冪等記録するowner CLIとskill手順を追加する（#4067）。
 - `feat(hybrid)`: cloud 工程の定期実行先に `github-actions` backend を追加し、配布 workflow の UTC cron を管理区間限定で設定・確認・停止できるようにする（#4055）。
 - `feat(hybrid)`: 引き渡し・公開完了と異常停止をtyped eventで正常／異常へ分類し、既存secret ownerからDiscord webhookを解決してbest-effort送信するsinkを追加する（#4063）。
 - `feat(hybrid)`: サンドイッチrunner開始前にdisk空き・R2滞留量・生成従量費・月間Actions分数概算を検査し、0円・容量上限超過を通知event付きでfail-closed停止するresource guardを追加する（#4058）。

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -76,6 +76,10 @@ def build_parser() -> argparse.ArgumentParser:
     handoff_parser.add_argument("--point", choices=("suno_download",), required=True)
     handoff_parser.add_argument("--manifest-key", required=True, help="R2上のmanifest.json相対key")
     handoff_parser.add_argument("--root-sha256", required=True, help="manifestのroot SHA-256")
+    subparsers.add_parser(
+        "record-distrokid-submission",
+        help="確認済みDistroKid提出をhuman-task完了として記録",
+    )
     for command, help_text in (
         ("set-thumbnail-approved", "thumbnail 承認状態を更新"),
         ("set-description-generated", "概要欄生成状態を更新"),
@@ -86,10 +90,6 @@ def build_parser() -> argparse.ArgumentParser:
     shorts_parser.add_argument("value", help="short record の JSON 配列")
     subparsers.add_parser("touch", help="updated_at を現在時刻へ更新")
     return parser
-
-
-def _state_path(collection: str | None) -> Path:
-    return resolve_collection_dir(collection) / "workflow-state.json"
 
 
 def _get_keypath(document: Mapping[str, JSONValue], keypath: str) -> JSONValue:
@@ -171,6 +171,23 @@ def _record_handoff(state: WorkflowState, args: argparse.Namespace) -> None:
         _touch(state)
 
 
+def _channel_root_for_collection(collection_dir: Path) -> Path:
+    for candidate in (collection_dir, *collection_dir.parents):
+        if (candidate / "config" / "channel").is_dir():
+            return candidate
+    raise WorkflowStateError(
+        f"collection と同じチャンネルに config/channel/distrokid.json の通常ファイルが必要です: {collection_dir}"
+    )
+
+
+def _record_distrokid_submission(state: WorkflowState) -> None:
+    before = state.to_dict()
+    completed_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    state.record_distrokid_submission(completed_at)
+    if state.to_dict() != before:
+        _touch(state)
+
+
 def _set_completion_flag(
     state: WorkflowState,
     *,
@@ -185,7 +202,8 @@ def _set_completion_flag(
 
 
 def run(args: argparse.Namespace) -> int:
-    state_path = _state_path(args.collection)
+    collection_dir = resolve_collection_dir(args.collection)
+    state_path = collection_dir / "workflow-state.json"
     if args.command == "get":
         value = _get_keypath(read_workflow_state(state_path).to_dict(), args.keypath)
         print(json.dumps(value, ensure_ascii=False))
@@ -211,6 +229,13 @@ def run(args: argparse.Namespace) -> int:
         update_workflow_state(state_path, lambda state: _set_post_upload_shorts(state, _json_value(args.value)))
     elif args.command == "record-handoff":
         update_workflow_state(state_path, lambda state: _record_handoff(state, args))
+    elif args.command == "record-distrokid-submission":
+        config_path = _channel_root_for_collection(collection_dir) / "config" / "channel" / "distrokid.json"
+        if config_path.is_symlink() or not config_path.is_file():
+            raise WorkflowStateError(
+                f"DistroKid提出記録には config/channel/distrokid.json の通常ファイルが必要です: {config_path}"
+            )
+        update_workflow_state(state_path, _record_distrokid_submission)
     elif args.command == "touch":
         update_workflow_state(state_path, _touch)
     return 0

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -7,6 +7,7 @@ import os
 import tempfile
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from copy import deepcopy
+from datetime import datetime
 from pathlib import Path, PurePosixPath
 from typing import Literal, TypedDict, cast
 
@@ -67,6 +68,14 @@ class HandoffDocument(TypedDict, total=False):
     owner: ExecutionOwner
     manifest_key: str
     root_sha256: str
+
+
+class HumanTaskCompletionDocument(TypedDict, total=False):
+    completed_at: str
+
+
+class HumanTasksDocument(TypedDict, total=False):
+    distrokid_submission: HumanTaskCompletionDocument
 
 
 class MusicPairSelectionExceptionDocument(TypedDict, total=False):
@@ -154,6 +163,7 @@ class WorkflowStateDocument(TypedDict, total=False):
     title_template_check: TitleTemplateCheckDocument
     assets: AssetsDocument
     handoff: HandoffDocument
+    human_tasks: HumanTasksDocument
     music_pair_selection: MusicPairSelectionDocument
     upload: UploadDocument
     post_upload: PostUploadDocument
@@ -171,6 +181,7 @@ _KNOWN_OBJECT_SECTIONS = frozenset(
         "assets",
         "description",
         "handoff",
+        "human_tasks",
         "music_pair_selection",
         "planning",
         "post_upload",
@@ -480,6 +491,41 @@ class HandoffState(_ObjectSection):
         return value
 
 
+class HumanTasksState(_ObjectSection):
+    """API 非対応の人手作業について完了事実を保持する型付き view。"""
+
+    @property
+    def distrokid_submission_completed_at(self) -> str | None:
+        value = self._data.get("distrokid_submission")
+        if value is None:
+            return None
+        if not isinstance(value, dict):
+            raise WorkflowStateError("workflow-state.json::human_tasks.distrokid_submission must be an object")
+        completed_at = _optional_string(
+            value,
+            "completed_at",
+            "workflow-state.json::human_tasks.distrokid_submission.completed_at",
+        )
+        if completed_at is not None:
+            _validate_iso_datetime(
+                completed_at,
+                "workflow-state.json::human_tasks.distrokid_submission.completed_at",
+            )
+        return completed_at
+
+    def record_distrokid_submission(self, completed_at: str) -> None:
+        _validate_iso_datetime(
+            completed_at,
+            "workflow-state.json::human_tasks.distrokid_submission.completed_at",
+        )
+        existing = self.distrokid_submission_completed_at
+        if existing is not None:
+            return
+        task = self._data.setdefault("distrokid_submission", {})
+        assert isinstance(task, dict)
+        task["completed_at"] = completed_at
+
+
 class WorkflowState(MutableMapping[str, JSONValue]):
     """既知 section を型付きで扱い、未知キーも保持する document object。"""
 
@@ -517,6 +563,9 @@ class WorkflowState(MutableMapping[str, JSONValue]):
             _owner = handoff.owner
             _manifest_key = handoff.manifest_key
             _root_sha256 = handoff.root_sha256
+        human_tasks = self.human_tasks
+        if human_tasks is not None:
+            _distrokid_submission_completed_at = human_tasks.distrokid_submission_completed_at
 
     @property
     def phase(self) -> Phase | None:
@@ -572,6 +621,22 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def handoff(self) -> HandoffState | None:
         value = self._data.get("handoff")
         return HandoffState(value) if isinstance(value, dict) else None
+
+    @property
+    def human_tasks(self) -> HumanTasksState | None:
+        value = self._data.get("human_tasks")
+        return HumanTasksState(value) if isinstance(value, dict) else None
+
+    @property
+    def distrokid_submission_completed_at(self) -> str | None:
+        human_tasks = self.human_tasks
+        return human_tasks.distrokid_submission_completed_at if human_tasks is not None else None
+
+    def record_distrokid_submission(self, completed_at: str) -> None:
+        """DistroKid提出の初回完了時刻を保持し、再実行では上書きしない。"""
+        human_tasks = self._data.setdefault("human_tasks", {})
+        assert isinstance(human_tasks, dict)
+        HumanTasksState(human_tasks).record_distrokid_submission(completed_at)
 
     def record_cloud_handoff(
         self,
@@ -762,6 +827,17 @@ def _validate_manifest_key(manifest_key: str) -> None:
 def _validate_root_sha256(root_sha256: str) -> None:
     if len(root_sha256) != 64 or any(character not in "0123456789abcdef" for character in root_sha256):
         raise WorkflowStateError("workflow-state handoff.root_sha256 must be 64 lowercase hex characters")
+
+
+def _validate_iso_datetime(value: str, label: str) -> None:
+    if not isinstance(value, str):
+        raise WorkflowStateError(f"{label} must be a string or null")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise WorkflowStateError(f"{label} must be an ISO 8601 datetime") from exc
+    if parsed.tzinfo is None:
+        raise WorkflowStateError(f"{label} must include a timezone")
 
 
 def _read_payload(path: Path) -> dict[str, JSONValue]:

--- a/tests/commands/collections/test_workflow_state_cli.py
+++ b/tests/commands/collections/test_workflow_state_cli.py
@@ -26,6 +26,13 @@ def _read_state(collection: Path) -> dict[str, object]:
     return json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
 
 
+def _distrokid_collection(tmp_path: Path, state: dict[str, object] | None = None) -> Path:
+    channel = tmp_path / "channel"
+    (channel / "config" / "channel").mkdir(parents=True)
+    (channel / "config" / "channel" / "distrokid.json").write_text("{}\n", encoding="utf-8")
+    return _collection(channel / "collections" / "live", state)
+
+
 def test_get_outputs_json_value_and_missing_key_as_null(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     collection = _collection(tmp_path, {"upload": {"video_id": "video-123"}})
 
@@ -127,6 +134,56 @@ def test_record_handoff_uses_typed_owner_transition(tmp_path: Path) -> None:
         == 0
     )
     assert (collection / "workflow-state.json").read_bytes() == before_retry
+
+
+def test_record_distrokid_submission_is_one_command_idempotent_state_update(tmp_path: Path) -> None:
+    collection = _distrokid_collection(
+        tmp_path,
+        {
+            "human_tasks": {"future": {"keep": True}},
+            "unknown": {"keep": True},
+        },
+    )
+
+    assert workflow_state_cli.main(["--collection", str(collection), "record-distrokid-submission"]) == 0
+
+    state = _read_state(collection)
+    human_tasks = state["human_tasks"]
+    assert isinstance(human_tasks, dict)
+    submission = human_tasks["distrokid_submission"]
+    assert isinstance(submission, dict)
+    assert isinstance(submission["completed_at"], str)
+    assert human_tasks["future"] == {"keep": True}
+    assert state["unknown"] == {"keep": True}
+    assert isinstance(state["updated_at"], str)
+
+    before_retry = (collection / "workflow-state.json").read_bytes()
+    assert workflow_state_cli.main(["--collection", str(collection), "record-distrokid-submission"]) == 0
+    assert (collection / "workflow-state.json").read_bytes() == before_retry
+
+
+@pytest.mark.parametrize("config_kind", ["missing", "directory", "symlink"])
+def test_record_distrokid_submission_requires_regular_channel_config(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    config_kind: str,
+) -> None:
+    collection = _distrokid_collection(tmp_path, {"unknown": {"keep": True}})
+    config_path = tmp_path / "channel" / "config" / "channel" / "distrokid.json"
+    config_path.unlink()
+    if config_kind == "directory":
+        config_path.mkdir()
+    elif config_kind == "symlink":
+        outside = tmp_path / "outside.json"
+        outside.write_text("{}\n", encoding="utf-8")
+        config_path.symlink_to(outside)
+    state_path = collection / "workflow-state.json"
+    before = state_path.read_bytes()
+
+    assert workflow_state_cli.main(["--collection", str(collection), "record-distrokid-submission"]) == 1
+
+    assert "config/channel/distrokid.json の通常ファイルが必要です" in capsys.readouterr().err
+    assert state_path.read_bytes() == before
 
 
 def test_set_upload_creates_section_and_only_overwrites_supplied_fields(tmp_path: Path) -> None:

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -269,6 +269,66 @@ def test_record_cloud_handoff_fails_closed_before_mutation(
     assert state.to_dict() == before
 
 
+def test_record_distrokid_submission_preserves_first_completion_and_unknown_fields() -> None:
+    state = WorkflowState(
+        {
+            "human_tasks": {
+                "future": {"keep": True},
+                "distrokid_submission": {"future": "keep"},
+            },
+            "unknown": {"keep": True},
+        }
+    )
+
+    state.record_distrokid_submission("2026-08-16T01:02:03.000Z")
+
+    assert state.distrokid_submission_completed_at == "2026-08-16T01:02:03.000Z"
+    assert state.to_dict() == {
+        "human_tasks": {
+            "future": {"keep": True},
+            "distrokid_submission": {
+                "future": "keep",
+                "completed_at": "2026-08-16T01:02:03.000Z",
+            },
+        },
+        "unknown": {"keep": True},
+    }
+
+    state.record_distrokid_submission("2026-08-17T04:05:06.000Z")
+
+    assert state.distrokid_submission_completed_at == "2026-08-16T01:02:03.000Z"
+
+
+@pytest.mark.parametrize(
+    ("payload", "message"),
+    [
+        ({"human_tasks": []}, "human_tasks must be an object"),
+        (
+            {"human_tasks": {"distrokid_submission": True}},
+            "human_tasks.distrokid_submission must be an object",
+        ),
+        (
+            {"human_tasks": {"distrokid_submission": {"completed_at": True}}},
+            "human_tasks.distrokid_submission.completed_at must be a string",
+        ),
+        (
+            {"human_tasks": {"distrokid_submission": {"completed_at": "not-a-time"}}},
+            "human_tasks.distrokid_submission.completed_at must be an ISO 8601 datetime",
+        ),
+        (
+            {"human_tasks": {"distrokid_submission": {"completed_at": "2026-08-16T01:02:03"}}},
+            "human_tasks.distrokid_submission.completed_at must include a timezone",
+        ),
+    ],
+)
+def test_distrokid_submission_state_fails_closed_on_invalid_known_shape(
+    payload: dict[str, JSONValue],
+    message: str,
+) -> None:
+    with pytest.raises(WorkflowStateError, match=message):
+        WorkflowState(payload)
+
+
 def test_update_creates_missing_document_under_the_same_contract(tmp_path: Path) -> None:
     state_path = tmp_path / "workflow-state.json"
 

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1164,6 +1164,15 @@ def test_distrokid_helper_docs_describe_dynamic_selector_fetch_contract() -> Non
     assert "サーバー URL に `http://localhost:7874` を設定" not in skill
 
 
+def test_distrokid_helper_records_confirmed_submission_through_workflow_state_owner() -> None:
+    skill = _read(".claude/skills/distrokid-helper/SKILL.md")
+
+    command = "uv run yt-workflow-state --collection <collection> record-distrokid-submission"
+    assert skill.count(command) == 1
+    assert "ユーザーが転記・アップロード完了を確認した後" in skill
+    assert "human_tasks.distrokid_submission.completed_at" in skill
+
+
 def test_suno_helper_docs_use_the_visible_server_source_picker_contract() -> None:
     skill = _read(".claude/skills/music/references/generate.md")
     readme = _read("extensions/suno-helper/README.md")


### PR DESCRIPTION
## 概要

DistroKid提出完了をworkflow-stateのtyped ownerへ記録し、後続の容量回収が機械判定できる境界を追加します。

Closes #4067

## 変更内容

- `human_tasks.distrokid_submission.completed_at` のtyped accessorと初回のみのatomic記録を追加
- `yt-workflow-state ... record-distrokid-submission` を追加し、同一channelの通常ファイル `distrokid.json` を必須化
- `/distrokid-helper` の転記・upload確認後の手順をowner CLI 1コマンドへ接続
- unknown field保持と未設定・directory・symlink時のstate不変をTDDで固定

## 検証

- full pytest: 9697 passed, 3 skipped
- focused: 166 passed
- ruff check / format、Any gate、yt-skills lint/catalog/artifacts
- uv build、installed-wheel smoke 2 passed

## 実行していないもの

- 実DistroKid操作、外部API、ブラウザ実機確認