### PR TITLE
feat(hybrid): パイプライン発火点をDiscord通知へ接続する (#4064)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `docs(hybrid)`: Claude subscription OAuth token の GHA secret 配備・手動検証・失効時の fail-closed 停止・ローテーション手順を追加する（#4056）。
 - `feat(hybrid)`: DistroKid提出完了をhuman-taskの初回完了時刻としてGit管理stateへ冪等記録するowner CLIとskill手順を追加する（#4067）。
+- `feat(hybrid)`: state同期競合・Suno handoff・media受入拒否・upload事前検証失敗・公開完了・quota guardの既存発火点をDiscord通知bridgeへ接続し、配布workflowへwebhook secretを渡す（#4064）。
 - `feat(hybrid)`: cloud 工程の定期実行先に `github-actions` backend を追加し、配布 workflow の UTC cron を管理区間限定で設定・確認・停止できるようにする（#4055）。
 - `feat(hybrid)`: 引き渡し・公開完了と異常停止をtyped eventで正常／異常へ分類し、既存secret ownerからDiscord webhookを解決してbest-effort送信するsinkを追加する（#4063）。
 - `feat(hybrid)`: サンドイッチrunner開始前にdisk空き・R2滞留量・生成従量費・月間Actions分数概算を検査し、0円・容量上限超過を通知event付きでfail-closed停止するresource guardを追加する（#4058）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -242,6 +242,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `application.documents.channel_strategy` | direction / persona / scene / constraints の schema と文書間 ID 参照を検証し、共通 migration workflow による原子的保存を調停 |
 | `application.documents.collection_plan` | collection plan の schema・候補/evidence ID・選択状態を検証し、JSON+HTML pair 公開成功後の planning state 投影を調停 |
 | `application.media_handoff` | 全 object の remote metadata/content 検証、manifest-last push、manifest-only pull、local rollback を調停 |
+| `application.pipeline_notifications` | 各pipeline ownerのtyped eventと公開・guard結果をprovider-neutral通知eventへ写像し、配送sinkへ委譲 |
 | `application.analytics.video_report` | 動画解析結果を audit report schema へ写像し、共通運用文書 migration による JSON+HTML 公開を調停 |
 | `.claude/skills/channel-research/references/channel-research-report.schema.json` | benchmark / market / viewer voice / thumbnail 調査の比較表・勝ちパターン・根拠・適用候補を共通定義し、skill writer と全 downstream reader の正本になる |
 | `infrastructure.filesystem` | provider-neutral な filesystem I/O と、複数 text file の fsync・rollback・公開後 verifier 付き transaction |

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -22,7 +22,7 @@ from youtube_automation.domains.media_handoff_manifest import MANIFEST_NAME, Han
 from youtube_automation.domains.media_store import MediaStore, validate_media_relative_path
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
 from youtube_automation.infrastructure.vcs.state_git import build_context
-from youtube_automation.infrastructure.vcs.state_sync import pull_update_commit_push
+from youtube_automation.infrastructure.vcs.state_sync import EventSink, pull_update_commit_push
 
 Agent = Literal["claude", "codex"]
 AgentRunner = Callable[[Agent, str, Path], None]
@@ -180,6 +180,7 @@ def run_sandwich(
     resource_probe: HybridResourceProbe,
     agent_runner: AgentRunner = run_agent,
     on_resource_event: HybridResourceEventSink | None = None,
+    on_state_sync_event: EventSink | None = None,
 ) -> None:
     """Run the existing local-first workflow between verified MediaStore boundaries."""
     _guard_resources(request, resource_probe, on_resource_event)
@@ -198,4 +199,9 @@ def run_sandwich(
             sources = tuple(HandoffSource(_inside(root, path), path) for path in request.output_files)
             push_handoff(store, HandoffIdentity(request.channel, request.collection, request.output_handoff), sources)
 
-    pull_update_commit_push(context, writer, commit_message=request.commit_message)
+    pull_update_commit_push(
+        context,
+        writer,
+        commit_message=request.commit_message,
+        on_event=on_state_sync_event,
+    )

--- a/src/youtube_automation/application/pipeline_notifications.py
+++ b/src/youtube_automation/application/pipeline_notifications.py
@@ -1,0 +1,91 @@
+"""Translate pipeline-owned events into provider-neutral notifications."""
+
+from __future__ import annotations
+
+from typing import assert_never
+
+from youtube_automation.application.hybrid_runner import HybridResourceEvent, HybridResourceEventKind
+from youtube_automation.application.media_acceptance import (
+    MediaAcceptanceEvent,
+    MediaAcceptanceEventKind,
+)
+from youtube_automation.application.suno_download_handoff import (
+    SunoDownloadHandoffEvent,
+    SunoDownloadHandoffEventKind,
+)
+from youtube_automation.domains.notifications import (
+    NotificationEvent,
+    NotificationEventKind,
+    NotificationSink,
+)
+from youtube_automation.infrastructure.vcs.state_sync import StateSyncEvent, StateSyncEventKind
+
+
+class PipelineNotificationBridge:
+    """Keep pipeline event ownership separate from delivery providers."""
+
+    def __init__(self, sink: NotificationSink) -> None:
+        self._sink = sink
+
+    def emit(
+        self,
+        kind: NotificationEventKind,
+        *,
+        channel: str,
+        collection: str,
+        stage: str,
+    ) -> bool:
+        return self._sink.send(NotificationEvent(kind, channel, collection, stage))
+
+    def state_sync(
+        self,
+        event: StateSyncEvent,
+        *,
+        channel: str,
+        collection: str,
+    ) -> bool:
+        if event.kind is StateSyncEventKind.NON_FAST_FORWARD:
+            return self.emit(
+                NotificationEventKind.NON_FAST_FORWARD_STOPPED,
+                channel=channel,
+                collection=collection,
+                stage="state-sync",
+            )
+        assert_never(event.kind)
+
+    def suno_handoff(self, event: SunoDownloadHandoffEvent) -> bool:
+        if event.kind is SunoDownloadHandoffEventKind.COMPLETED:
+            return self.emit(
+                NotificationEventKind.HANDOFF_COMPLETED,
+                channel=event.channel,
+                collection=event.collection,
+                stage="suno-download-handoff",
+            )
+        assert_never(event.kind)
+
+    def media_acceptance(
+        self,
+        event: MediaAcceptanceEvent,
+        *,
+        channel: str,
+    ) -> bool:
+        if event.kind is MediaAcceptanceEventKind.REJECTED:
+            return self.emit(
+                NotificationEventKind.FAIL_CLOSED_ABORTED,
+                channel=channel,
+                collection=event.collection,
+                stage="media-acceptance",
+            )
+        assert_never(event.kind)
+
+    def hybrid_resources(self, event: HybridResourceEvent) -> bool | None:
+        if event.kind is HybridResourceEventKind.REJECTED:
+            return self.emit(
+                NotificationEventKind.GUARD_EXCEEDED,
+                channel=event.channel,
+                collection=event.collection,
+                stage="resource-guard",
+            )
+        if event.kind is HybridResourceEventKind.OBSERVED:
+            return None
+        assert_never(event.kind)

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -46,6 +46,7 @@ from pathlib import Path
 
 from youtube_automation import __version__
 from youtube_automation.application.distrokid.disc_query import find_distrokid_discs
+from youtube_automation.application.pipeline_notifications import PipelineNotificationBridge
 from youtube_automation.application.suno_download_handoff import SunoDownloadHandoff
 from youtube_automation.commands.collections.collection_serve_discovery import (
     DISCOVERY_PORT,
@@ -98,6 +99,7 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
 from youtube_automation.infrastructure.file_lock import file_lock
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 from youtube_automation.infrastructure.media_store import R2MediaStore, R2MediaStoreConfig
+from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
 
 DEFAULT_PORT = 7873
 DEFAULT_IDLE_TIMEOUT_SECONDS = 60 * 60
@@ -1657,7 +1659,12 @@ def _build_downloaded_handoff(channel_short: str) -> SunoDownloadHandoff | None:
     if not channel:
         raise ConfigError("R2 handoff の channel identifier を channel_short から解決できません")
     config = R2MediaStoreConfig.from_environment()
-    return SunoDownloadHandoff(store=R2MediaStore(config), channel=channel)
+    notifications = PipelineNotificationBridge(create_discord_notification_sink())
+    return SunoDownloadHandoff(
+        store=R2MediaStore(config),
+        channel=channel,
+        on_event=notifications.suno_handoff,
+    )
 
 
 def _resolve_allow_origin(

--- a/src/youtube_automation/commands/media/media_acceptance.py
+++ b/src/youtube_automation/commands/media/media_acceptance.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 
 import argparse
 import json
+from functools import partial
 from pathlib import Path
 
 from youtube_automation.application.media_acceptance import validate_collection_audio
+from youtube_automation.application.pipeline_notifications import PipelineNotificationBridge
 from youtube_automation.commands._shared.cli_harness import run_cli
+from youtube_automation.configuration import load_config
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
@@ -16,6 +19,7 @@ from youtube_automation.domains.media.loudness_receipt import resolve_max_deviat
 from youtube_automation.domains.suno.prompts import read_suno_duration_filter
 from youtube_automation.infrastructure.media.audio_acceptance import FFmpegAudioInspector
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
+from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
 
 _MINIMUM_INTEGRATED_LUFS = -40.0
 _MAXIMUM_INTEGRATED_LUFS = -5.0
@@ -69,7 +73,16 @@ def _print_text(report: MediaAcceptanceReport) -> None:
 def run(args: argparse.Namespace) -> int:
     collection = args.collection.resolve()
     policy = build_media_acceptance_policy(collection)
-    report = validate_collection_audio(collection, policy, FFmpegAudioInspector())
+    notifications = PipelineNotificationBridge(create_discord_notification_sink())
+    report = validate_collection_audio(
+        collection,
+        policy,
+        FFmpegAudioInspector(),
+        on_event=partial(
+            notifications.media_acceptance,
+            channel=load_config().meta.channel_short,
+        ),
+    )
     if args.output == "json":
         print(json.dumps(report.to_dict(), ensure_ascii=False, indent=2))
     else:

--- a/src/youtube_automation/commands/system/hybrid_runner.py
+++ b/src/youtube_automation/commands/system/hybrid_runner.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 import argparse
 import sys
 from decimal import Decimal
+from functools import partial
 from pathlib import Path
 
 from youtube_automation.application.hybrid_runner import HybridResourceEvent, SandwichRequest, run_sandwich
+from youtube_automation.application.pipeline_notifications import PipelineNotificationBridge
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.hybrid_resources import SystemHybridResourceProbe
 from youtube_automation.infrastructure.media_store.local import LocalMediaStore
 from youtube_automation.infrastructure.media_store.r2 import R2MediaStore, R2MediaStoreConfig
+from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -59,6 +62,11 @@ def _report_resource_event(event: HybridResourceEvent) -> None:
     )
 
 
+def _handle_resource_event(event: HybridResourceEvent, *, notifications: PipelineNotificationBridge) -> None:
+    _report_resource_event(event)
+    notifications.hybrid_resources(event)
+
+
 def run(args: argparse.Namespace) -> int:
     if args.media_store == "local":
         if args.local_store_root is None:
@@ -89,7 +97,18 @@ def run(args: argparse.Namespace) -> int:
         monthly_run_count=args.monthly_run_count,
         estimated_run_minutes=args.estimated_run_minutes,
     )
-    run_sandwich(request, store, resource_probe=resource_probe, on_resource_event=_report_resource_event)
+    notifications = PipelineNotificationBridge(create_discord_notification_sink())
+    run_sandwich(
+        request,
+        store,
+        resource_probe=resource_probe,
+        on_resource_event=partial(_handle_resource_event, notifications=notifications),
+        on_state_sync_event=partial(
+            notifications.state_sync,
+            channel=request.channel,
+            collection=request.collection,
+        ),
+    )
     return 0
 
 

--- a/src/youtube_automation/commands/uploads/collection_uploader.py
+++ b/src/youtube_automation/commands/uploads/collection_uploader.py
@@ -3,10 +3,18 @@
 import argparse
 import logging
 
+from youtube_automation.application.pipeline_notifications import PipelineNotificationBridge
 from youtube_automation.commands._shared.cli_harness import run_cli
+from youtube_automation.configuration import load_config
 from youtube_automation.core.errors import AutomationError
-from youtube_automation.domains.uploads.collection import CollectionUploader
+from youtube_automation.domains.notifications import NotificationEventKind
+from youtube_automation.domains.uploads.collection import (
+    ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
+    ACTION_COMPLETE_COLLECTION_UPLOADED,
+    CollectionUploader,
+)
 from youtube_automation.infrastructure.google.youtube import create_authenticated_youtube_clients
+from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -29,12 +37,40 @@ def run(args: argparse.Namespace) -> None:
         return
     target = uploader.find_collection(args.collection)
     if target:
-        if not args.status:
+        if args.status:
+            uploader.show_status(target)
+            return
+        notifications = PipelineNotificationBridge(create_discord_notification_sink())
+        channel = load_config().meta.channel_short
+        try:
             uploader.ensure_upload_preflight(target)
-        action = (
-            uploader.show_status if args.status else uploader.show_plan if args.plan else uploader.execute_next_step
-        )
-        action(target)
+        except (AutomationError, OSError, ValueError):
+            notifications.emit(
+                NotificationEventKind.FAIL_CLOSED_ABORTED,
+                channel=channel,
+                collection=target.name,
+                stage="upload-preflight",
+            )
+            raise
+        if args.plan:
+            uploader.show_plan(target)
+        else:
+            result = uploader.execute_next_step(target)
+            action = result.get("action")
+            if action == ACTION_COMPLETE_COLLECTION_UPLOADED:
+                notifications.emit(
+                    NotificationEventKind.PUBLISH_COMPLETED,
+                    channel=channel,
+                    collection=target.name,
+                    stage="youtube-publish",
+                )
+            elif action == ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED:
+                notifications.emit(
+                    NotificationEventKind.GUARD_EXCEEDED,
+                    channel=channel,
+                    collection=target.name,
+                    stage="upload-quota",
+                )
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/src/youtube_automation/domains/notifications.py
+++ b/src/youtube_automation/domains/notifications.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Protocol
 
 
 class NotificationEventCategory(StrEnum):
@@ -36,6 +37,10 @@ class NotificationEvent:
     channel: str
     collection: str
     stage: str
+
+
+class NotificationSink(Protocol):
+    def send(self, event: NotificationEvent) -> bool: ...
 
 
 def category_for(kind: NotificationEventKind) -> NotificationEventCategory:

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -17,7 +17,10 @@ from youtube_automation.core.adapters.youtube import (
 )
 from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
-from youtube_automation.domains.uploads._collection_uploader_constants import ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED
+from youtube_automation.domains.uploads._collection_uploader_constants import (
+    ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
+    ACTION_COMPLETE_COLLECTION_UPLOADED,
+)
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutor
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
@@ -38,6 +41,7 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED",
+    "ACTION_COMPLETE_COLLECTION_UPLOADED",
     "CollectionUploader",
     "CompleteCollectionExecutor",
     "PlaylistAssignment",

--- a/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
+++ b/src/youtube_automation/infrastructure/resources/channel/youtube-automation.yml
@@ -31,6 +31,7 @@ jobs:
           YTA_AGENT: ${{ vars.YTA_AGENT }}
           YTA_AUTOMATION_PROMPT: ${{ vars.YTA_AUTOMATION_PROMPT }}
           CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
           R2_API_TOKEN: ${{ secrets.R2_API_TOKEN }}

--- a/tests/application/test_pipeline_notifications.py
+++ b/tests/application/test_pipeline_notifications.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.application.hybrid_runner import HybridResourceEvent, HybridResourceEventKind
+from youtube_automation.application.media_acceptance import (
+    MediaAcceptanceEvent,
+    MediaAcceptanceEventKind,
+)
+from youtube_automation.application.pipeline_notifications import PipelineNotificationBridge
+from youtube_automation.application.suno_download_handoff import (
+    SunoDownloadHandoffEvent,
+    SunoDownloadHandoffEventKind,
+)
+from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
+from youtube_automation.infrastructure.vcs.state_sync import StateSyncEvent, StateSyncEventKind
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[NotificationEvent] = []
+
+    def send(self, event: NotificationEvent) -> bool:
+        self.events.append(event)
+        return True
+
+
+@pytest.mark.parametrize(
+    ("kind", "stage"),
+    [
+        (NotificationEventKind.PUBLISH_COMPLETED, "publish"),
+        (NotificationEventKind.FAIL_CLOSED_ABORTED, "upload-preflight"),
+        (NotificationEventKind.GUARD_EXCEEDED, "upload-quota"),
+        (NotificationEventKind.CANARY_FAILED, "monthly-canary"),
+    ],
+)
+def test_emit_sends_pipeline_context_with_requested_typed_event(
+    kind: NotificationEventKind,
+    stage: str,
+) -> None:
+    sink = RecordingSink()
+    bridge = PipelineNotificationBridge(sink)
+
+    delivered = bridge.emit(
+        kind,
+        channel="ambient-lab",
+        collection="night-rain",
+        stage=stage,
+    )
+
+    assert delivered is True
+    assert sink.events == [NotificationEvent(kind, "ambient-lab", "night-rain", stage)]
+
+
+def test_state_sync_maps_non_fast_forward_to_abnormal_pipeline_event() -> None:
+    sink = RecordingSink()
+    bridge = PipelineNotificationBridge(sink)
+
+    bridge.state_sync(
+        StateSyncEvent(
+            kind=StateSyncEventKind.NON_FAST_FORWARD,
+            repository=Path("/channel"),
+            message="not forwarded",
+        ),
+        channel="ambient-lab",
+        collection="night-rain",
+    )
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.NON_FAST_FORWARD_STOPPED,
+            "ambient-lab",
+            "night-rain",
+            "state-sync",
+        )
+    ]
+
+
+def test_suno_handoff_preserves_event_channel_and_collection() -> None:
+    sink = RecordingSink()
+    bridge = PipelineNotificationBridge(sink)
+
+    bridge.suno_handoff(
+        SunoDownloadHandoffEvent(
+            kind=SunoDownloadHandoffEventKind.COMPLETED,
+            channel="ambient-lab",
+            collection="night-rain",
+            manifest_key="ambient-lab/night-rain/suno-download/manifest.json",
+            root_sha256="a" * 64,
+        )
+    )
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.HANDOFF_COMPLETED,
+            "ambient-lab",
+            "night-rain",
+            "suno-download-handoff",
+        )
+    ]
+
+
+def test_media_acceptance_maps_rejection_with_explicit_channel() -> None:
+    sink = RecordingSink()
+    bridge = PipelineNotificationBridge(sink)
+
+    bridge.media_acceptance(
+        MediaAcceptanceEvent(
+            kind=MediaAcceptanceEventKind.REJECTED,
+            collection="night-rain",
+            issue_codes=("duration",),
+            detail="too short",
+        ),
+        channel="ambient-lab",
+    )
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.FAIL_CLOSED_ABORTED,
+            "ambient-lab",
+            "night-rain",
+            "media-acceptance",
+        )
+    ]
+
+
+def test_resource_guard_rejection_maps_to_guard_exceeded() -> None:
+    sink = RecordingSink()
+    bridge = PipelineNotificationBridge(sink)
+
+    bridge.hybrid_resources(
+        HybridResourceEvent(
+            HybridResourceEventKind.REJECTED,
+            "ambient-lab",
+            "night-rain",
+            ("disk_free",),
+            "insufficient disk",
+        )
+    )
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.GUARD_EXCEEDED,
+            "ambient-lab",
+            "night-rain",
+            "resource-guard",
+        )
+    ]

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -1196,8 +1196,8 @@ def test_build_downloaded_handoff_wires_configured_r2_store(monkeypatch):
         assert config is sentinel_config
         return sentinel_store
 
-    def fake_handoff(*, store, channel):
-        recorded.update(store=store, channel=channel)
+    def fake_handoff(*, store, channel, on_event):
+        recorded.update(store=store, channel=channel, on_event=on_event)
         return sentinel_handoff
 
     monkeypatch.setenv("R2_BUCKET", "media-handoffs")
@@ -1206,7 +1206,9 @@ def test_build_downloaded_handoff_wires_configured_r2_store(monkeypatch):
     monkeypatch.setattr(collection_serve_module, "SunoDownloadHandoff", fake_handoff)
 
     assert collection_serve_module._build_downloaded_handoff("Test Channel") is sentinel_handoff
-    assert recorded == {"store": sentinel_store, "channel": "test-channel"}
+    assert recorded["store"] is sentinel_store
+    assert recorded["channel"] == "test-channel"
+    assert callable(recorded["on_event"])
 
 
 def test_main_turns_sigterm_into_traceable_exception_and_restores_handler(monkeypatch, tmp_path):

--- a/tests/commands/media/test_media_acceptance.py
+++ b/tests/commands/media/test_media_acceptance.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
 from tests.helpers.music_prompt import write_suno_prompt_pair
 from youtube_automation.commands.media import media_acceptance
 from youtube_automation.domains.media.acceptance import AudioMeasurement
+from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
 
 
 class FixtureInspector:
@@ -42,6 +44,11 @@ def _patch_runtime(monkeypatch) -> None:
         "load_skill_config",
         lambda _skill: {"validation": {"loudness_deviation": {"max_lu": 2.0}}},
     )
+    monkeypatch.setattr(
+        media_acceptance,
+        "load_config",
+        lambda: SimpleNamespace(meta=SimpleNamespace(channel_short="ambient-lab")),
+    )
 
 
 def test_cli_passes_and_emits_json_report(monkeypatch, capsys, tmp_path: Path) -> None:
@@ -60,11 +67,25 @@ def test_cli_passes_and_emits_json_report(monkeypatch, capsys, tmp_path: Path) -
 def test_cli_fails_closed_when_planned_track_is_missing(monkeypatch, capsys, tmp_path: Path) -> None:
     collection = _collection(tmp_path, actual_count=1)
     _patch_runtime(monkeypatch)
+    events: list[NotificationEvent] = []
+    monkeypatch.setattr(
+        media_acceptance,
+        "create_discord_notification_sink",
+        lambda: SimpleNamespace(send=lambda event: events.append(event) or True),
+    )
 
     exit_code = media_acceptance.main([str(collection), "--output", "json"])
 
     assert exit_code == 2
     assert "track_count" in capsys.readouterr().err
+    assert events == [
+        NotificationEvent(
+            NotificationEventKind.FAIL_CLOSED_ABORTED,
+            "ambient-lab",
+            collection.name,
+            "media-acceptance",
+        )
+    ]
 
 
 def test_cli_output_rejects_unknown_choice() -> None:

--- a/tests/commands/test_pipeline_notification_wiring.py
+++ b/tests/commands/test_pipeline_notification_wiring.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from youtube_automation.commands.system import hybrid_runner
+from youtube_automation.commands.uploads import collection_uploader
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
+from youtube_automation.infrastructure.vcs.state_sync import StateSyncEvent, StateSyncEventKind
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.events: list[NotificationEvent] = []
+
+    def send(self, event: NotificationEvent) -> bool:
+        self.events.append(event)
+        return True
+
+
+def test_hybrid_command_connects_non_fast_forward_event_to_notification(monkeypatch, tmp_path: Path) -> None:
+    sink = RecordingSink()
+
+    def fake_run_sandwich(
+        request,
+        _store,
+        *,
+        resource_probe,
+        on_resource_event,
+        on_state_sync_event,
+    ):
+        assert resource_probe is not None
+        assert on_resource_event is not None
+        on_state_sync_event(StateSyncEvent(StateSyncEventKind.NON_FAST_FORWARD, tmp_path, "rejected"))
+
+    monkeypatch.setattr(hybrid_runner, "create_discord_notification_sink", lambda: sink)
+    monkeypatch.setattr(hybrid_runner, "run_sandwich", fake_run_sandwich)
+
+    result = hybrid_runner.run(
+        Namespace(
+            media_store="local",
+            local_store_root=tmp_path / "store",
+            channel_dir=tmp_path,
+            collection_dir="collections/planning/night-rain",
+            channel_slug="ambient-lab",
+            collection="night-rain",
+            agent="claude",
+            prompt="/wf-new --auto",
+            commit_message="chore: state",
+            input_handoff=None,
+            input_destination=None,
+            output_handoff=None,
+            output_root=None,
+            output_file=[],
+            generation_cost_usd=0,
+            monthly_run_count=0,
+            estimated_run_minutes=60,
+        )
+    )
+
+    assert result == 0
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.NON_FAST_FORWARD_STOPPED,
+            "ambient-lab",
+            "night-rain",
+            "state-sync",
+        )
+    ]
+
+
+@pytest.mark.parametrize(
+    ("action", "expected_kind", "expected_stage"),
+    [
+        ("complete_collection_uploaded", NotificationEventKind.PUBLISH_COMPLETED, "youtube-publish"),
+        ("complete_collection_quota_exhausted", NotificationEventKind.GUARD_EXCEEDED, "upload-quota"),
+    ],
+)
+def test_upload_command_notifies_terminal_pipeline_result(
+    monkeypatch,
+    tmp_path: Path,
+    action: str,
+    expected_kind: NotificationEventKind,
+    expected_stage: str,
+) -> None:
+    target = tmp_path / "collections" / "planning" / "night-rain"
+    uploader = MagicMock()
+    uploader.find_collection.return_value = target
+    uploader.execute_next_step.return_value = {"action": action, "details": {}}
+    sink = RecordingSink()
+    monkeypatch.setattr(collection_uploader, "CollectionUploader", lambda **_kwargs: uploader)
+    monkeypatch.setattr(collection_uploader, "create_authenticated_youtube_clients", lambda: object())
+    monkeypatch.setattr(collection_uploader, "create_discord_notification_sink", lambda: sink)
+    monkeypatch.setattr(
+        collection_uploader,
+        "load_config",
+        lambda: SimpleNamespace(meta=SimpleNamespace(channel_short="ambient-lab")),
+    )
+
+    collection_uploader.run(Namespace(config=None, daemon=False, collection="night-rain", status=False, plan=False))
+
+    assert sink.events == [NotificationEvent(expected_kind, "ambient-lab", "night-rain", expected_stage)]
+
+
+def test_upload_preflight_failure_notifies_before_error_propagates(monkeypatch, tmp_path: Path) -> None:
+    target = tmp_path / "collections" / "planning" / "night-rain"
+    uploader = MagicMock()
+    uploader.find_collection.return_value = target
+    uploader.ensure_upload_preflight.side_effect = ConfigError("channel mismatch")
+    sink = RecordingSink()
+    monkeypatch.setattr(collection_uploader, "CollectionUploader", lambda **_kwargs: uploader)
+    monkeypatch.setattr(collection_uploader, "create_authenticated_youtube_clients", lambda: object())
+    monkeypatch.setattr(collection_uploader, "create_discord_notification_sink", lambda: sink)
+    monkeypatch.setattr(
+        collection_uploader,
+        "load_config",
+        lambda: SimpleNamespace(meta=SimpleNamespace(channel_short="ambient-lab")),
+    )
+
+    with pytest.raises(ConfigError, match="channel mismatch"):
+        collection_uploader.run(Namespace(config=None, daemon=False, collection="night-rain", status=False, plan=False))
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.FAIL_CLOSED_ABORTED,
+            "ambient-lab",
+            "night-rain",
+            "upload-preflight",
+        )
+    ]
+    uploader.execute_next_step.assert_not_called()

--- a/tests/repo/test_hybrid_github_actions_workflow.py
+++ b/tests/repo/test_hybrid_github_actions_workflow.py
@@ -59,6 +59,7 @@ def test_workflow_is_a_thin_platform_wrapper_for_sandwich_script() -> None:
         key: env[key]
         for key in (
             "CLAUDE_CODE_OAUTH_TOKEN",
+            "DISCORD_WEBHOOK_URL",
             "R2_ACCESS_KEY_ID",
             "R2_ACCOUNT_ID",
             "R2_API_TOKEN",
@@ -66,6 +67,7 @@ def test_workflow_is_a_thin_platform_wrapper_for_sandwich_script() -> None:
         )
     } == {
         "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+        "DISCORD_WEBHOOK_URL": "${{ secrets.DISCORD_WEBHOOK_URL }}",
         "R2_ACCESS_KEY_ID": "${{ secrets.R2_ACCESS_KEY_ID }}",
         "R2_ACCOUNT_ID": "${{ secrets.R2_ACCOUNT_ID }}",
         "R2_API_TOKEN": "${{ secrets.R2_API_TOKEN }}",


### PR DESCRIPTION
## 概要

ハイブリッドpipelineの主要な成功・異常停止イベントを、typed分類を保ったままDiscord通知sinkへ接続します。

Closes #4064

## 変更内容

- state non-ff、Suno handoff、media acceptance拒否、upload preflight失敗を通知bridgeへ接続
- publish完了、quota/resource guard超過を通知bridgeへ接続
- canary用typed発火APIとworkflow secret配布契約を追加
- architecture / CHANGELOG / TDD契約を追従

## 検証

- full pytest: 9684 passed, 3 skipped
- focused: 365 passed
- ruff check / format、Any gate、yt-skills lint
- sdist/wheel build、installed-wheel smoke 2 passed

## 実行していないもの

- 実Discord送信、外部API、ブラウザ実機確認