### PR TITLE
feat(hybrid): live cleanをpull済みstateで判定する (#4068)

### DIFF
--- a/.claude/skills/publish/SKILL.md
+++ b/.claude/skills/publish/SKILL.md
@@ -82,7 +82,7 @@ description: "Use when 完成した動画を公開工程へ進めるとき。--p
 
 `--pinned` では `references/pinned.md` を読み、`yt-pinned-comment` の `--dry-run` で PASS 条件を確認してから、承認ゲート後に `--apply` で投稿する。ピン留め自体は Studio UI で手動実行する。
 
-`--clean` では `references/clean.md` を読み、公開完了の 3 条件を同一 skill 内で検証する。対象と容量を dry-run 表示し、不可逆な物理削除への明示承認を得た場合だけ削除する。clean は任意操作のため chain manifest へ追加しない。
+`--clean` では `references/clean.md` を読み、Git state の pull 成功後に公開完了の 4 条件を read-only preflight で検証する。対象と容量を dry-run 表示し、不可逆な物理削除への明示承認を得た場合だけ削除する。clean は任意操作のため chain manifest へ追加しない。
 
 upload 完了後も同じ chain を続行し、community、pinned を順に状態判定する。metadata 監査はこの chain に含めず、必要な場合は `/audit --metadata` を独立して実行する。
 

--- a/.claude/skills/publish/references/clean-scan.py
+++ b/.claude/skills/publish/references/clean-scan.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Pull Git control state, then classify live collections for safe cleanup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import NamedTuple, TypedDict
+
+from youtube_automation.core.errors import AutomationError, StateSyncError, WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.infrastructure.vcs.state_git import build_pull_context
+from youtube_automation.infrastructure.vcs.state_sync import pull_then_read
+
+EXIT_READY = 0
+EXIT_BLOCKED = 20
+
+
+class CleanupDecision(NamedTuple):
+    eligible: bool
+    reason: str | None
+
+
+class CollectionDecision(TypedDict):
+    collection: str
+    reason: str
+
+
+class EligibleCollection(TypedDict):
+    collection: str
+    video_id: str
+
+
+class CleanScanReport(TypedDict):
+    eligible: list[EligibleCollection]
+    skipped: list[CollectionDecision]
+
+
+def _publish_at_elapsed(value: str, now: datetime) -> CleanupDecision:
+    try:
+        publish_at = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return CleanupDecision(False, "publish_at_invalid")
+    if publish_at.tzinfo is None:
+        return CleanupDecision(False, "publish_at_invalid")
+    if publish_at > now:
+        return CleanupDecision(False, "publish_at_not_elapsed")
+    return CleanupDecision(True, None)
+
+
+def evaluate(state: WorkflowState, now: datetime) -> CleanupDecision:
+    """Evaluate the existing three gates plus elapsed ``upload.publish_at``."""
+    if now.tzinfo is None:
+        raise ValueError("now must include a timezone")
+    try:
+        if state.stage != "live":
+            return CleanupDecision(False, "stage_not_live")
+        if state.phase != "complete":
+            return CleanupDecision(False, "phase_not_complete")
+        upload = state.upload
+        if upload is None or not (upload.video_id or "").strip():
+            return CleanupDecision(False, "video_id_missing")
+        publish_at = upload.publish_at
+    except WorkflowStateError:
+        return CleanupDecision(False, "workflow_state_invalid")
+    if publish_at is None:
+        return CleanupDecision(True, None)
+    return _publish_at_elapsed(publish_at, now)
+
+
+def scan(channel_dir: Path, now: datetime) -> CleanScanReport:
+    live_dir = channel_dir / "collections" / "live"
+    eligible: list[EligibleCollection] = []
+    skipped: list[CollectionDecision] = []
+    if live_dir.is_symlink():
+        raise StateSyncError(f"collections/live must not be a symlink: {live_dir}")
+    if not live_dir.is_dir():
+        return {"eligible": eligible, "skipped": skipped}
+
+    for collection in sorted(live_dir.iterdir(), key=lambda path: path.name):
+        if collection.is_symlink() or not collection.is_dir():
+            continue
+        state_path = collection / "workflow-state.json"
+        if not state_path.exists() and not state_path.is_symlink():
+            continue
+        try:
+            state = read_workflow_state(state_path)
+        except WorkflowStateError:
+            skipped.append({"collection": collection.name, "reason": "workflow_state_invalid"})
+            continue
+        decision = evaluate(state, now)
+        if decision.eligible:
+            upload = state.upload
+            assert upload is not None
+            video_id = upload.video_id
+            assert video_id is not None
+            eligible.append({"collection": collection.name, "video_id": video_id})
+        else:
+            assert decision.reason is not None
+            skipped.append({"collection": collection.name, "reason": decision.reason})
+    return {"eligible": eligible, "skipped": skipped}
+
+
+def pull_and_scan(channel_dir: Path, now: datetime) -> CleanScanReport:
+    """Run classification only after the Git state pull gate succeeds."""
+    context = build_pull_context(channel_dir)
+    return pull_then_read(context, lambda: scan(context.channel_dir, now))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="pull済みGit stateからpublish clean対象を分類します")
+    parser.add_argument("--channel-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        report = pull_and_scan(args.channel_dir, datetime.now(timezone.utc))
+    except StateSyncError as exc:
+        print(f"publish clean blocked: {exc}", file=sys.stderr)
+        return EXIT_BLOCKED
+    except AutomationError as exc:
+        print(f"publish clean preflight failed: {exc}", file=sys.stderr)
+        return EXIT_BLOCKED
+    print(json.dumps(report, ensure_ascii=False, sort_keys=True))
+    return EXIT_READY
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/publish/references/clean.md
+++ b/.claude/skills/publish/references/clean.md
@@ -31,7 +31,7 @@
 以下を確認し、満たさなければ案内して終了する（外部 API・認証には依存しないローカル操作）:
 
 - 実行場所がチャンネルリポジトリ（`CHANNEL_DIR`）配下で、`collections/` ディレクトリが存在すること。無ければ対象なしとして終了する
-- 通常モードでは `collections/live/*/workflow-state.json` を持つ公開済みコレクションが 1 件以上存在すること。無ければ削除対象なしとして終了し、公開前なら `/publish --upload` が前工程であることを案内する（削除可否は Step 1 の 3 条件 — `stage: "live"` / `phase: "complete"` / `upload.video_id` 非空 — で機械判定する）
+- 通常モードでは `collections/live/*/workflow-state.json` を持つ公開済みコレクションが 1 件以上存在すること。無ければ削除対象なしとして終了し、公開前なら `/publish --upload` が前工程であることを案内する（削除可否は Step 1 の 4 条件 — `stage: "live"` / `phase: "complete"` / `upload.video_id` 非空 / 存在する `upload.publish_at` の経過 — で機械判定する）
 - `workflow-state.json` が読めない / JSON 破損のコレクションは安全条件未達としてスキップし、削除しない
 
 ## Quick Reference
@@ -48,15 +48,22 @@
 
 ### Step 1: スキャン & 安全性検証
 
-`collections/live/*/workflow-state.json` を Glob で列挙し、各ファイルを Read で読み込む。
+削除対象ファイルを列挙する前に、次の read-only preflight を 1 回実行する。この script は clean な Git worktree で `git pull --ff-only` を完了した後だけ、owner 経由で `collections/live/*/workflow-state.json` を読み、対象候補と安全条件未達を JSON に分類する。
 
-以下の **3条件すべて** を満たすコレクションのみクリーンアップ対象とする:
+```bash
+uv run python .claude/skills/publish/references/clean-scan.py --channel-dir "$CHANNEL_DIR"
+```
+
+exit 20 または pull に失敗した場合は、表示された理由を報告して直ちに終了する。古いローカル state を読まず、削除対象の特定やドライラン表示へ進まないため、承認・削除も行わない。自動 merge / rebase や `--no-ff` への切り替えは行わない。
+
+exit 0 の JSON にある `eligible` だけをクリーンアップ候補とし、`skipped` は理由とともに「安全条件未達（スキップ）」へ分類する。以下の **4条件すべて** を満たすコレクションだけが `eligible` になる:
 
 1. `stage` が `"live"`
 2. `phase` が `"complete"`
 3. `upload.video_id` が存在し、空文字でない
+4. `upload.publish_at` が存在する場合は、timezone 付き ISO 8601 として解釈でき、現在時刻を経過済みである。field が無い、または `null` の既存コレクションは後方互換としてこの条件を満たす
 
-条件を満たさないコレクションはスキップし、理由を表示する。
+未来の `upload.publish_at` は `publish_at_not_elapsed`、形式不正または timezone 無しは `publish_at_invalid` としてスキップし、削除しない。
 
 `$ARGUMENTS` が指定されている場合は、コレクションのディレクトリ名に対する部分一致でフィルタする。
 
@@ -69,7 +76,7 @@
 du -sh 01-master/master.mp3 01-master/master-mix.wav 01-master/*-Master.mp4 02-Individual-music/*.mp3 10-assets/loop_normalized.mp4 2>/dev/null
 ```
 
-**削除対象**: skill-config `delete_patterns`（YouTube に存在 or 再生成可能なもののみ。既定: raw マスター / ミックスダウン wav / YouTube マスター動画 / 個別ソーストラック / 正規化キャッシュ）
+**削除対象**: Step 1 の `eligible` に含まれるコレクションに限り、skill-config `delete_patterns`（YouTube に存在 or 再生成可能なもののみ。既定: raw マスター / ミックスダウン wav / YouTube マスター動画 / 個別ソーストラック / 正規化キャッシュ）
 
 **絶対に削除しないファイル**: skill-config `protect_patterns`（既定: `workflow-state.json` / `10-assets/main.png|jpg` / `10-assets/thumbnail.jpg|png` / 再生成不可のオリジナル `10-assets/loop.mp4` / `20-documentation/*`）。`delete_patterns` と重なった場合は `protect_patterns` が優先。
 
@@ -212,7 +219,7 @@ tmp/ 残骸クリーンアップ完了
 | `<CHANNEL_DIR>/tmp/veo-operations/` の resume state | /thumbnail --loop（不要時の手動削除手順は同 skill 参照） |
 | `<CHANNEL_DIR>/tmp/lyria-recovered/` の退避音源 | /music --generate |
 
-tmp/ 掃除は「スキャン → ドライラン → 明示承認 → 削除 → レポート」という本 skill の既存安全フローと完全に同型であり、専用 CLI（yt-clean 等）を新設すると承認ゲートを CLI 側に再実装する重複が生じるため、本 skill への統合とした（#1671）。
+tmp/ 掃除は「スキャン → ドライラン → 明示承認 → 削除 → レポート」という本 skill の既存安全フローと完全に同型であり、削除 CLI（yt-clean 等）を新設すると承認ゲートを CLI 側に再実装する重複が生じるため、本 skill への統合とした（#1671）。通常モードの `clean-scan.py` は pull 後の安全条件分類だけを担う read-only preflight で、削除・承認は行わない。
 
 ## 障害時ガイダンス
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: `/publish --clean` の削除候補判定をGit stateのfast-forward pull成功後に限定し、未来または不正な`upload.publish_at`を安全条件未達として保護する（#4068）。
 - `docs(hybrid)`: Claude subscription OAuth token の GHA secret 配備・手動検証・失効時の fail-closed 停止・ローテーション手順を追加する（#4056）。
 - `feat(hybrid)`: DistroKid提出完了をhuman-taskの初回完了時刻としてGit管理stateへ冪等記録するowner CLIとskill手順を追加する（#4067）。
 - `feat(hybrid)`: state同期競合・Suno handoff・media受入拒否・upload事前検証失敗・公開完了・quota guardの既存発火点をDiscord通知bridgeへ接続し、配布workflowへwebhook secretを渡す（#4064）。

--- a/src/youtube_automation/infrastructure/vcs/state_git.py
+++ b/src/youtube_automation/infrastructure/vcs/state_git.py
@@ -159,7 +159,8 @@ def _validate_control_file(path: Path) -> None:
         raise ConfigError(f"secretを含む可能性があるためGit管理へ移行できません: {path}")
 
 
-def build_context(channel_dir: Path) -> StateGitContext:
+def build_pull_context(channel_dir: Path) -> StateGitContext:
+    """Resolve a channel Git boundary without reading control-plane documents."""
     raw = channel_dir.expanduser()
     if raw.is_symlink():
         raise ConfigError(f"channel directory に symlink は使えません: {raw}")
@@ -173,10 +174,15 @@ def build_context(channel_dir: Path) -> StateGitContext:
         raise ConfigError(f"channel directory が Git repository 外です: {channel}")
     gitignore = channel / ".gitignore"
     _regular_file(gitignore, label="channel .gitignore")
-    control_files = _discover_control_files(channel)
+    return StateGitContext(channel, repository, gitignore, ())
+
+
+def build_context(channel_dir: Path) -> StateGitContext:
+    base = build_pull_context(channel_dir)
+    control_files = _discover_control_files(base.channel_dir)
     for path in control_files:
         _validate_control_file(path)
-    return StateGitContext(channel, repository, gitignore, control_files)
+    return StateGitContext(base.channel_dir, base.repository, base.gitignore, control_files)
 
 
 def _repo_relative(context: StateGitContext, path: Path) -> str:

--- a/tests/repo/test_publish_clean_scan.py
+++ b/tests/repo/test_publish_clean_scan.py
@@ -1,0 +1,207 @@
+"""``/publish --clean`` の pull-first 安全条件 preflight 契約。"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.core.errors import StateSyncError
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+
+SCRIPT = REPO_ROOT / ".claude" / "skills" / "publish" / "references" / "clean-scan.py"
+NOW = datetime(2026, 8, 16, 12, 0, tzinfo=timezone.utc)
+
+
+def _module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("publish_clean_scan", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _state(*, publish_at: object = None) -> WorkflowState:
+    return WorkflowState(
+        {
+            "stage": "live",
+            "phase": "complete",
+            "upload": {"video_id": "video-123", "publish_at": publish_at},
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    ("payload", "reason"),
+    [
+        ({"stage": "planning", "phase": "complete", "upload": {"video_id": "v"}}, "stage_not_live"),
+        ({"stage": "live", "phase": "publishing", "upload": {"video_id": "v"}}, "phase_not_complete"),
+        ({"stage": "live", "phase": "complete", "upload": {"video_id": ""}}, "video_id_missing"),
+    ],
+)
+def test_existing_cleanup_conditions_remain_fail_closed(payload: dict[str, object], reason: str) -> None:
+    module = _module()
+
+    decision = module.evaluate(WorkflowState(payload), NOW)
+
+    assert decision.eligible is False
+    assert decision.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("publish_at", "eligible", "reason"),
+    [
+        (None, True, None),
+        ("2026-08-16T11:59:59Z", True, None),
+        ("2026-08-16T12:00:00+00:00", True, None),
+        ("2026-08-16T21:00:01+09:00", False, "publish_at_not_elapsed"),
+        ("not-a-time", False, "publish_at_invalid"),
+        ("2026-08-16T12:00:00", False, "publish_at_invalid"),
+    ],
+)
+def test_publish_at_is_required_to_have_elapsed_only_when_present(
+    publish_at: object,
+    eligible: bool,
+    reason: str | None,
+) -> None:
+    module = _module()
+
+    decision = module.evaluate(_state(publish_at=publish_at), NOW)
+
+    assert decision.eligible is eligible
+    assert decision.reason == reason
+
+
+def _git(directory: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=directory,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _write_state(repository: Path, publish_at: str) -> None:
+    state_path = repository / "collections" / "live" / "sample" / "workflow-state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        json.dumps(
+            {
+                "stage": "live",
+                "phase": "complete",
+                "upload": {"video_id": "video-123", "publish_at": publish_at},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _repositories(tmp_path: Path) -> tuple[Path, Path]:
+    remote = tmp_path / "remote.git"
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(remote)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init", "--initial-branch=main")
+    _git(seed, "config", "user.email", "test@example.com")
+    _git(seed, "config", "user.name", "Test User")
+    (seed / ".gitignore").write_text("\n", encoding="utf-8")
+    _write_state(seed, "2099-01-01T00:00:00Z")
+    _git(seed, "add", ".")
+    _git(seed, "commit", "-m", "initial")
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-u", "origin", "main")
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(remote), str(local)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    _git(local, "config", "user.email", "test@example.com")
+    _git(local, "config", "user.name", "Test User")
+    return seed, local
+
+
+def test_scan_reads_remote_state_only_after_successful_pull(tmp_path: Path) -> None:
+    module = _module()
+    seed, local = _repositories(tmp_path)
+    _write_state(seed, "2000-01-01T00:00:00Z")
+    _git(seed, "add", "collections")
+    _git(seed, "commit", "-m", "published")
+    _git(seed, "push")
+
+    report = module.pull_and_scan(local, NOW)
+
+    assert report["eligible"] == [{"collection": "sample", "video_id": "video-123"}]
+    assert report["skipped"] == []
+    pulled = json.loads((local / "collections/live/sample/workflow-state.json").read_text(encoding="utf-8"))
+    assert pulled["upload"]["publish_at"] == "2000-01-01T00:00:00Z"
+
+
+def test_scan_stops_before_classification_when_pull_fails(tmp_path: Path) -> None:
+    module = _module()
+    _, local = _repositories(tmp_path)
+    _git(local, "remote", "set-url", "origin", str(tmp_path / "missing.git"))
+
+    with pytest.raises(StateSyncError, match="git pull --ff-only"):
+        module.pull_and_scan(local, NOW)
+
+
+def test_cli_reports_pull_failure_and_returns_blocked(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    module = _module()
+    _, local = _repositories(tmp_path)
+    _git(local, "remote", "set-url", "origin", str(tmp_path / "missing.git"))
+
+    assert module.main(["--channel-dir", str(local)]) == module.EXIT_BLOCKED
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert "publish clean blocked" in captured.err
+    assert "git pull --ff-only" in captured.err
+
+
+def test_scan_stops_when_pull_cannot_fast_forward(tmp_path: Path) -> None:
+    module = _module()
+    seed, local = _repositories(tmp_path)
+    _write_state(local, "2050-01-01T00:00:00Z")
+    _git(local, "add", "collections")
+    _git(local, "commit", "-m", "local")
+    _write_state(seed, "2000-01-01T00:00:00Z")
+    _git(seed, "add", "collections")
+    _git(seed, "commit", "-m", "remote")
+    _git(seed, "push")
+
+    with pytest.raises(StateSyncError, match="git pull --ff-only"):
+        module.pull_and_scan(local, NOW)
+
+
+def test_broken_state_is_reported_as_skipped_after_pull(tmp_path: Path) -> None:
+    module = _module()
+    seed, local = _repositories(tmp_path)
+    state_path = seed / "collections/live/sample/workflow-state.json"
+    state_path.write_text("{broken\n", encoding="utf-8")
+    _git(seed, "add", "collections")
+    _git(seed, "commit", "-m", "broken state")
+    _git(seed, "push")
+
+    report = module.pull_and_scan(local, NOW)
+
+    assert report["eligible"] == []
+    assert report["skipped"] == [{"collection": "sample", "reason": "workflow_state_invalid"}]

--- a/tests/repo/test_publish_clean_skill_contract.py
+++ b/tests/repo/test_publish_clean_skill_contract.py
@@ -29,9 +29,17 @@ def test_publish_owns_clean_as_the_fifth_exclusive_mode() -> None:
 def test_clean_requires_publish_completion_and_explicit_approval() -> None:
     clean = (PUBLISH / "references" / "clean.md").read_text(encoding="utf-8")
 
-    for condition in ('`stage` が `"live"`', '`phase` が `"complete"`', "`upload.video_id`"):
+    for condition in (
+        '`stage` が `"live"`',
+        '`phase` が `"complete"`',
+        "`upload.video_id`",
+        "`upload.publish_at`",
+    ):
         assert condition in clean
-    assert "3条件すべて" in clean
+    assert "4条件すべて" in clean
+    assert "clean-scan.py" in clean
+    assert "git pull --ff-only" in clean
+    assert "pull に失敗" in clean and "ドライラン表示へ進まない" in clean
     assert "削除を実行する" in clean and "キャンセル" in clean
     assert "承認されるまで" in clean
     assert "削除しない" in clean

--- a/tests/repo/test_skills_sync_installed_wheel.py
+++ b/tests/repo/test_skills_sync_installed_wheel.py
@@ -365,6 +365,7 @@ assert "wheel-identity-check" not in legacy._cache
 
     workflow_state_scripts = (
         target_skills / "publish" / "references" / "generate_batch.py",
+        target_skills / "publish" / "references" / "clean-scan.py",
         target_skills / "publish" / "references" / "publish-chain-state.py",
         target_skills / "wf-new" / "references" / "wf-auto-state.py",
         target_skills / "wf-next" / "references" / "master_audio_transition.py",

--- a/tests/repo/test_workflow_upload_setup_redirect_contract.py
+++ b/tests/repo/test_workflow_upload_setup_redirect_contract.py
@@ -311,6 +311,7 @@ MUTABLE_FILES = frozenset(
     "publish/references/posting-checklist.md",
     "publish/references/community.md",
     "publish/references/clean.md",
+    "publish/references/clean-scan.py",
     "publish/references/generate_batch.py",
     "publish/references/pinned.md",
     "publish/references/publish-chain-manifest.json",


### PR DESCRIPTION
## 概要

`/publish --clean` を最新のGit管理stateだけで判定し、公開時刻を含む削除条件をfail-closedにします。

Closes #4068

## 変更内容

- `git pull --ff-only` 成功後だけ対象分類へ進むread-only preflightを追加
- 既存3条件に `upload.publish_at` 経過条件を追加
- publish_at欠落/nullは後方互換、未来・不正・naive日時はskip
- pull失敗時は対象表示・dry-run・承認・削除へ進まない契約を固定
- 既存dry-run・明示承認・削除手順は維持

## 検証

- full pytest: 9728 passed, 3 skipped
- repo広域: 1603 passed, 1 skipped
- post-rebase focused: 44 passed
- ruff/format/Any、yt-skills lint/catalog/artifacts、site build/test 53、build/wheel smoke 2

## 実行していないもの

- 実削除、外部API、ブラウザ実機確認