### PR TITLE
feat(hybrid): live cleanにDistroKid保護分岐を追加する (#4069)

### DIFF
--- a/.claude/skills/publish/config.default.yaml
+++ b/.claude/skills/publish/config.default.yaml
@@ -83,6 +83,10 @@ clean:
     - "02-Individual-music/*.mp3"
     - "10-assets/loop_normalized.mp4"
 
+  # DistroKid提出完了済みのときだけ追加するdisc音声コピー
+  distrokid_audio_patterns:
+    - "30-distrokid/*/*.mp3"
+
   # delete_patterns と重なった場合も必ず保護する成果物
   protect_patterns:
     - "workflow-state.json"
@@ -92,3 +96,7 @@ clean:
     - "10-assets/thumbnail.png"
     - "10-assets/loop.mp4"
     - "20-documentation/*"
+    - "30-distrokid/spec.json"
+    - "30-distrokid/*/metadata.md"
+    - "30-distrokid/cover_art_3000.jpg"
+    - "30-distrokid/README.md"

--- a/.claude/skills/publish/references/clean-scan.py
+++ b/.claude/skills/publish/references/clean-scan.py
@@ -8,9 +8,10 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import NamedTuple, TypedDict
+from typing import Literal, NamedTuple, TypedDict
 
-from youtube_automation.core.errors import AutomationError, StateSyncError, WorkflowStateError
+from youtube_automation.configuration.skills import load_skill_config
+from youtube_automation.core.errors import AutomationError, ConfigError, StateSyncError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.infrastructure.vcs.state_git import build_pull_context
@@ -33,11 +34,58 @@ class CollectionDecision(TypedDict):
 class EligibleCollection(TypedDict):
     collection: str
     video_id: str
+    distrokid: Literal["disabled", "pending", "submitted"]
+    delete_patterns: list[str]
 
 
 class CleanScanReport(TypedDict):
     eligible: list[EligibleCollection]
     skipped: list[CollectionDecision]
+
+
+def _distrokid_enabled(channel_dir: Path) -> bool:
+    config_path = channel_dir / "config" / "channel" / "distrokid.json"
+    if config_path.is_symlink():
+        raise StateSyncError(f"distrokid.json must be a regular file: {config_path}")
+    if not config_path.exists():
+        return False
+    if not config_path.is_file():
+        raise StateSyncError(f"distrokid.json must be a regular file: {config_path}")
+    return True
+
+
+def _distrokid_cleanup_state(
+    state: WorkflowState,
+    *,
+    enabled: bool,
+) -> Literal["disabled", "pending", "submitted"]:
+    if not enabled:
+        return "disabled"
+    return "submitted" if state.distrokid_submission_completed_at is not None else "pending"
+
+
+def _pattern_list(clean_config: dict[str, object], key: str) -> list[str]:
+    value = clean_config.get(key)
+    if not isinstance(value, list):
+        raise ConfigError(f"publish.clean.{key} must be a string list")
+    patterns = [pattern for pattern in value if isinstance(pattern, str) and pattern]
+    if len(patterns) != len(value):
+        raise ConfigError(f"publish.clean.{key} must be a string list")
+    return patterns
+
+
+def _effective_delete_patterns(
+    clean_config: dict[str, object],
+    distrokid: Literal["disabled", "pending", "submitted"],
+) -> list[str]:
+    base = _pattern_list(clean_config, "delete_patterns")
+    if distrokid == "disabled":
+        return base
+    if distrokid == "pending":
+        protected_roots = ("02-Individual-music/", "30-distrokid/")
+        return [pattern for pattern in base if not pattern.startswith(protected_roots)]
+    distrokid_audio = _pattern_list(clean_config, "distrokid_audio_patterns")
+    return list(dict.fromkeys([*base, *distrokid_audio]))
 
 
 def _publish_at_elapsed(value: str, now: datetime) -> CleanupDecision:
@@ -80,6 +128,11 @@ def scan(channel_dir: Path, now: datetime) -> CleanScanReport:
         raise StateSyncError(f"collections/live must not be a symlink: {live_dir}")
     if not live_dir.is_dir():
         return {"eligible": eligible, "skipped": skipped}
+    distrokid_enabled = _distrokid_enabled(channel_dir)
+    publish_config = load_skill_config("publish", use_cache=False, channel_dir=channel_dir)
+    clean_config = publish_config.get("clean")
+    if not isinstance(clean_config, dict):
+        raise ConfigError("publish.clean must be an object")
 
     for collection in sorted(live_dir.iterdir(), key=lambda path: path.name):
         if collection.is_symlink() or not collection.is_dir():
@@ -98,7 +151,15 @@ def scan(channel_dir: Path, now: datetime) -> CleanScanReport:
             assert upload is not None
             video_id = upload.video_id
             assert video_id is not None
-            eligible.append({"collection": collection.name, "video_id": video_id})
+            distrokid = _distrokid_cleanup_state(state, enabled=distrokid_enabled)
+            eligible.append(
+                {
+                    "collection": collection.name,
+                    "video_id": video_id,
+                    "distrokid": distrokid,
+                    "delete_patterns": _effective_delete_patterns(clean_config, distrokid),
+                }
+            )
         else:
             assert decision.reason is not None
             skipped.append({"collection": collection.name, "reason": decision.reason})

--- a/.claude/skills/publish/references/clean.md
+++ b/.claude/skills/publish/references/clean.md
@@ -56,7 +56,7 @@ uv run python .claude/skills/publish/references/clean-scan.py --channel-dir "$CH
 
 exit 20 または pull に失敗した場合は、表示された理由を報告して直ちに終了する。古いローカル state を読まず、削除対象の特定やドライラン表示へ進まないため、承認・削除も行わない。自動 merge / rebase や `--no-ff` への切り替えは行わない。
 
-exit 0 の JSON にある `eligible` だけをクリーンアップ候補とし、`skipped` は理由とともに「安全条件未達（スキップ）」へ分類する。以下の **4条件すべて** を満たすコレクションだけが `eligible` になる:
+exit 0 の JSON にある `eligible` だけをクリーンアップ候補とし、`skipped` は理由とともに「安全条件未達（スキップ）」へ分類する。以下の **4条件すべて** を満たすコレクションだけが `eligible` になる。各候補の `distrokid` は、pull 後の `config/channel/distrokid.json` と typed state から `disabled` / `pending` / `submitted` のいずれかに確定済みである:
 
 1. `stage` が `"live"`
 2. `phase` が `"complete"`
@@ -69,16 +69,20 @@ exit 0 の JSON にある `eligible` だけをクリーンアップ候補とし�
 
 ### Step 2: 削除対象ファイルの特定
 
-安全性検証を通過したコレクションについて、skill-config `delete_patterns`（既定値と各パターンの理由コメントは `config.default.yaml` 参照）に一致するファイルの存在とサイズを確認する。
+安全性検証を通過したコレクションについて、Step 1 が各候補へ返した `delete_patterns` に一致するファイルの存在とサイズを確認する。このリストは skill-config（既定値と各パターンの理由コメントは `config.default.yaml` 参照）と pull 後の DistroKid 分類から確定済みである:
+
+- `disabled`: 基底の `delete_patterns` をそのまま返し、`30-distrokid/` は削除候補へ加えない
+- `pending`: `02-Individual-music/` と `30-distrokid/` 配下の pattern を除いて返す
+- `submitted`: 基底 pattern に `distrokid_audio_patterns` を追加して返す
 
 ```bash
 # 各コレクションディレクトリで実行（delete_patterns の内容に合わせて展開する。以下は既定値の例）
-du -sh 01-master/master.mp3 01-master/master-mix.wav 01-master/*-Master.mp4 02-Individual-music/*.mp3 10-assets/loop_normalized.mp4 2>/dev/null
+du -sh 01-master/master.mp3 01-master/master-mix.wav 01-master/*-Master.mp4 02-Individual-music/*.mp3 10-assets/loop_normalized.mp4 30-distrokid/*/*.mp3 2>/dev/null
 ```
 
-**削除対象**: Step 1 の `eligible` に含まれるコレクションに限り、skill-config `delete_patterns`（YouTube に存在 or 再生成可能なもののみ。既定: raw マスター / ミックスダウン wav / YouTube マスター動画 / 個別ソーストラック / 正規化キャッシュ）
+**削除対象**: Step 1 の `eligible` に含まれるコレクションに限り、その候補に返された `delete_patterns`（YouTube に存在、再生成可能、または DistroKid 提出済みの音声コピーのみ）
 
-**絶対に削除しないファイル**: skill-config `protect_patterns`（既定: `workflow-state.json` / `10-assets/main.png|jpg` / `10-assets/thumbnail.jpg|png` / 再生成不可のオリジナル `10-assets/loop.mp4` / `20-documentation/*`）。`delete_patterns` と重なった場合は `protect_patterns` が優先。
+**絶対に削除しないファイル**: skill-config `protect_patterns`（既定: `workflow-state.json` / `10-assets/main.png|jpg` / `10-assets/thumbnail.jpg|png` / 再生成不可のオリジナル `10-assets/loop.mp4` / `20-documentation/*` / `30-distrokid/spec.json` / `30-distrokid/*/metadata.md` / `30-distrokid/cover_art_3000.jpg` / `30-distrokid/README.md`）。`delete_patterns` や `distrokid_audio_patterns` と重なった場合は `protect_patterns` が優先。
 
 削除対象ファイルが 1 つもないコレクションは「クリーンアップ済み」として表示する。
 
@@ -109,7 +113,7 @@ Live Collection クリーンアップ — ドライラン
 
 ### Step 4: 削除実行
 
-「削除を実行する」が明示的に選ばれた場合のみ、skill-config `delete_patterns` に一致するファイルをファイル単位で `rm -f` する（以下は既定値の例）。
+「削除を実行する」が明示的に選ばれた場合のみ、Step 1 が候補ごとに返した `delete_patterns` に一致するファイルをファイル単位で `rm -f` する（以下は既定値の例）。
 
 ```bash
 # マスターファイル
@@ -118,7 +122,11 @@ rm -f "collections/live/<dir>/01-master/master-mix.wav"
 rm -f collections/live/<dir>/01-master/*-Master.mp4
 
 # 個別トラック
+# distrokid=pending のコレクションでは実行しない
 rm -f collections/live/<dir>/02-Individual-music/*.mp3
+
+# DistroKid提出済みのdisc音声コピー（distrokid=submitted のときだけ）
+rm -f collections/live/<dir>/30-distrokid/*/*.mp3
 
 # キャッシュ
 rm -f "collections/live/<dir>/10-assets/loop_normalized.mp4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(hybrid)`: DistroKid有効チャンネルの`/publish --clean`で提出完了前の個別音源を保護し、完了後だけdisc音声コピーを削除候補へ加える（#4069）。
 - `feat(hybrid)`: `/publish --clean` の削除候補判定をGit stateのfast-forward pull成功後に限定し、未来または不正な`upload.publish_at`を安全条件未達として保護する（#4068）。
 - `feat(hybrid)`: DistroKid有効チャンネルの完了済みstateから未提出collectionを決定的に抽出し、`human-tasks.md` の原子生成とDiscord要約をsandwich完了後に実行する `yt-human-tasks` を追加する（#4065）。
 - `feat(hybrid)`: GitHub Actions の Claude Code headless 実行で最古の planning collection（なければ新規企画）を選び、企画・音楽promptの検証済みJSON/HTML pairと`prepared` stateを単一commitで確定するcloud planning stageを追加する（#4061）。

--- a/tests/repo/test_publish_clean_scan.py
+++ b/tests/repo/test_publish_clean_scan.py
@@ -37,6 +37,67 @@ def _state(*, publish_at: object = None) -> WorkflowState:
     )
 
 
+def _live_collection(channel_dir: Path, *, submitted: bool) -> Path:
+    collection = channel_dir / "collections" / "live" / "sample"
+    collection.mkdir(parents=True)
+    payload: dict[str, object] = {
+        "stage": "live",
+        "phase": "complete",
+        "upload": {"video_id": "video-123"},
+    }
+    if submitted:
+        payload["human_tasks"] = {"distrokid_submission": {"completed_at": "2026-08-16T01:02:03Z"}}
+    (collection / "workflow-state.json").write_text(json.dumps(payload) + "\n", encoding="utf-8")
+    return collection
+
+
+@pytest.mark.parametrize(
+    ("distrokid_enabled", "submitted", "expected"),
+    [
+        (False, False, "disabled"),
+        (True, False, "pending"),
+        (True, True, "submitted"),
+    ],
+)
+def test_scan_classifies_distrokid_audio_cleanup_from_channel_config_and_typed_state(
+    tmp_path: Path,
+    distrokid_enabled: bool,
+    submitted: bool,
+    expected: str,
+) -> None:
+    module = _module()
+    _live_collection(tmp_path, submitted=submitted)
+    if distrokid_enabled:
+        config = tmp_path / "config" / "channel" / "distrokid.json"
+        config.parent.mkdir(parents=True)
+        config.write_text("{}\n", encoding="utf-8")
+
+    report = module.scan(tmp_path, NOW)
+
+    candidate = report["eligible"][0]
+    assert candidate["collection"] == "sample"
+    assert candidate["video_id"] == "video-123"
+    assert candidate["distrokid"] == expected
+    if expected == "pending":
+        assert not any(
+            pattern.startswith(("02-Individual-music/", "30-distrokid/")) for pattern in candidate["delete_patterns"]
+        )
+    else:
+        assert "02-Individual-music/*.mp3" in candidate["delete_patterns"]
+        assert ("30-distrokid/*/*.mp3" in candidate["delete_patterns"]) is (expected == "submitted")
+
+
+def test_scan_fails_closed_when_distrokid_config_is_a_symlink(tmp_path: Path) -> None:
+    module = _module()
+    _live_collection(tmp_path, submitted=True)
+    config = tmp_path / "config" / "channel" / "distrokid.json"
+    config.parent.mkdir(parents=True)
+    config.symlink_to(tmp_path / "missing-distrokid.json")
+
+    with pytest.raises(StateSyncError, match="distrokid.json must be a regular file"):
+        module.scan(tmp_path, NOW)
+
+
 @pytest.mark.parametrize(
     ("payload", "reason"),
     [
@@ -89,23 +150,23 @@ def _git(directory: Path, *args: str) -> str:
     return result.stdout.strip()
 
 
-def _write_state(repository: Path, publish_at: str) -> None:
+def _write_state(repository: Path, publish_at: str, *, submitted: bool = False) -> None:
     state_path = repository / "collections" / "live" / "sample" / "workflow-state.json"
     state_path.parent.mkdir(parents=True, exist_ok=True)
+    payload: dict[str, object] = {
+        "stage": "live",
+        "phase": "complete",
+        "upload": {"video_id": "video-123", "publish_at": publish_at},
+    }
+    if submitted:
+        payload["human_tasks"] = {"distrokid_submission": {"completed_at": "2026-08-16T01:02:03Z"}}
     state_path.write_text(
-        json.dumps(
-            {
-                "stage": "live",
-                "phase": "complete",
-                "upload": {"video_id": "video-123", "publish_at": publish_at},
-            }
-        )
-        + "\n",
+        json.dumps(payload) + "\n",
         encoding="utf-8",
     )
 
 
-def _repositories(tmp_path: Path) -> tuple[Path, Path]:
+def _repositories(tmp_path: Path, *, distrokid_enabled: bool = False) -> tuple[Path, Path]:
     remote = tmp_path / "remote.git"
     subprocess.run(
         ["git", "init", "--bare", "--initial-branch=main", str(remote)],
@@ -119,6 +180,10 @@ def _repositories(tmp_path: Path) -> tuple[Path, Path]:
     _git(seed, "config", "user.email", "test@example.com")
     _git(seed, "config", "user.name", "Test User")
     (seed / ".gitignore").write_text("\n", encoding="utf-8")
+    if distrokid_enabled:
+        config = seed / "config" / "channel" / "distrokid.json"
+        config.parent.mkdir(parents=True)
+        config.write_text("{}\n", encoding="utf-8")
     _write_state(seed, "2099-01-01T00:00:00Z")
     _git(seed, "add", ".")
     _git(seed, "commit", "-m", "initial")
@@ -146,10 +211,27 @@ def test_scan_reads_remote_state_only_after_successful_pull(tmp_path: Path) -> N
 
     report = module.pull_and_scan(local, NOW)
 
-    assert report["eligible"] == [{"collection": "sample", "video_id": "video-123"}]
+    assert report["eligible"][0]["collection"] == "sample"
+    assert report["eligible"][0]["video_id"] == "video-123"
+    assert report["eligible"][0]["distrokid"] == "disabled"
     assert report["skipped"] == []
     pulled = json.loads((local / "collections/live/sample/workflow-state.json").read_text(encoding="utf-8"))
     assert pulled["upload"]["publish_at"] == "2000-01-01T00:00:00Z"
+
+
+def test_scan_reads_distrokid_submission_only_after_successful_pull(tmp_path: Path) -> None:
+    module = _module()
+    seed, local = _repositories(tmp_path, distrokid_enabled=True)
+    _write_state(seed, "2000-01-01T00:00:00Z", submitted=True)
+    _git(seed, "add", "collections")
+    _git(seed, "commit", "-m", "distrokid submitted")
+    _git(seed, "push")
+
+    report = module.pull_and_scan(local, NOW)
+
+    candidate = report["eligible"][0]
+    assert candidate["distrokid"] == "submitted"
+    assert "30-distrokid/*/*.mp3" in candidate["delete_patterns"]
 
 
 def test_scan_stops_before_classification_when_pull_fails(tmp_path: Path) -> None:

--- a/tests/repo/test_publish_clean_skill_contract.py
+++ b/tests/repo/test_publish_clean_skill_contract.py
@@ -62,6 +62,13 @@ def test_live_clean_config_migrates_to_publish_clean_namespace(tmp_path) -> None
     assert set(config) == {"upload", "community", "clean"}
     assert "delete_patterns" in config["clean"]
     assert "protect_patterns" in config["clean"]
+    assert config["clean"]["distrokid_audio_patterns"] == ["30-distrokid/*/*.mp3"]
+    assert {
+        "30-distrokid/spec.json",
+        "30-distrokid/*/metadata.md",
+        "30-distrokid/cover_art_3000.jpg",
+        "30-distrokid/README.md",
+    } <= set(config["clean"]["protect_patterns"])
     assert migration == _migrate_config.SkillConfigMigration("publish", "clean")
     assert load_skill_config("live-clean", use_cache=False, channel_dir=tmp_path) == config["clean"]
     assert load_skill_config("publish", use_cache=False, channel_dir=tmp_path) == config


### PR DESCRIPTION
## 概要

`/publish --clean` の削除候補をDistroKid提出状態で分岐し、未提出音源を保護します。

Closes #4069

## 変更内容

- pull後のconfig/stateからDistroKid状態を disabled / pending / submitted に分類
- candidateごとの実効delete patternsを決定生成
- pendingでは `02-Individual-music` と `30-distrokid` を保護
- submitted時だけdisc MP3を削除候補へ追加
- spec/metadata/cover/READMEは常時保護

## 検証

- full pytest: 9756 passed, 3 skipped
- repo広域: 1608 passed, 1 skipped
- post-rebase focused: 105 passed
- ruff/format/Any、yt-skills、build/wheel 2、site 53 green

## 実行していないもの

- 実削除、外部API、ブラウザ実機確認