### PR TITLE
docs(hybrid): Codex bot発火の実測結果を記録する (#4059)

### DIFF
--- a/docs/adr/0025-execution-platform-selection.md
+++ b/docs/adr/0025-execution-platform-selection.md
@@ -48,10 +48,12 @@ AI 工程（企画・プロンプト作成）と軽量レジームのメディ�
 
 Claude 経路が塞がれた場合の切替先を 2 段で定義する。
 
-- **第一 escape: Codex Cloud**（0 円・ChatGPT サブスク消費）。起動は GHA cron からの `@codex` メンションによる間接トリガ。この経路は未文書化パターンであり、bot コメントでメンションが発火するかは実装ツリーの検証 issue で実測確定する。否なら第一・第二を入れ替える。
-- **第二 escape: `openai/codex-action@v1`**（API キー従量・公式文書化済み）。決定 5 のスクリプト境界で CLI を差し替えるだけで移行できる。
+- **第一 escape: `openai/codex-action@v1`**（API キー従量・公式文書化済み）。決定 5 のスクリプト境界で CLI を差し替えるだけで移行できる。GHA cron から自動起動できる経路はこれを正本とする。
+- **第二 escape: Codex Cloud**（0 円・ChatGPT サブスク消費）。人間 actor の `@codex` メンションでは受付を確認できるが、GHA の `github-actions[bot]` actor が投稿した同内容のメンションでは受付されなかった（#4059）。そのため自動 cron には使わず、人間が開始する復旧経路として保持する。
 
 「日常的な両対応」の担保として、第一 escape 経路を**月次 canary** で実際に実行し、生存確認する。
+
+bot / human actor の比較条件と観測結果は `docs/investigations/2026-08-16-codex-cloud-bot-trigger.md` に固定する。
 
 ### 8. 撤退・切替条件
 

--- a/docs/investigations/2026-08-16-codex-cloud-bot-trigger.md
+++ b/docs/investigations/2026-08-16-codex-cloud-bot-trigger.md
@@ -1,0 +1,46 @@
+# Codex Cloud bot メンション発火実測（Issue #4059）
+
+## 結論
+
+GHA cron から `github-actions[bot]` が投稿する `@codex` メンションは、Codex Cloud の自動起動には使えない。同じ repository・issue・指示形式で人間 actor が投稿した positive control は Codex integration に受け付けられた一方、bot actor の投稿には受付 reaction も返信も付かなかった。
+
+したがって ADR-0025 決定 7 の序列を入れ替える。自動起動可能な第一 escape は公式 `openai/codex-action@v1`、Codex Cloud は人間が `@codex` を投稿する第二 escape とする。月次 canary は第一 escape を対象にする。
+
+> 実測日: 2026-08-16（UTC / Asia/Tokyo）。GitHub App の actor policy は将来変わり得るため、再評価時は同じ control を再実行する。
+
+## 実測条件
+
+public repository `daiki-beppu/youtube-automation` の issue #4059 に、ファイル変更・branch作成・PR作成を禁止し、固定markerだけの返信を求める同型のコメントを投稿した。
+
+| control | actor | 投稿日時 (UTC) | 指示marker |
+|---|---|---|---|
+| bot trigger | `github-actions[bot]` | 2026-08-16 08:32:43 | `CODEX_CLOUD_BOT_TRIGGER_OK:31936715562` |
+| positive control | `daiki-beppu` | 2026-08-16 08:36:09 | `CODEX_CLOUD_HUMAN_TRIGGER_OK:20260816T0836Z` |
+
+bot comment は public repository の pull request CIから、job-scoped `issues: write` と `${{ github.token }}` を使って `gh issue comment` で投稿した。workflow run `31936715562` 自体は成功しており、issue comment の作成も成功した。token や外部API keyは追加していない。
+
+## 観測結果
+
+| control | Codex受付 reaction | Codex返信 | 判定 |
+|---|---:|---:|---|
+| `github-actions[bot]` | なし | 10分25秒の観測窓でなし | 自動発火しない |
+| human actor | 処理中に `eyes` あり | 3分41秒後に固定markerとtask linkを返信 | Codex Cloud taskが正常完了 |
+
+bot comment は human positive control より先に投稿され、投稿から10分25秒、human task完了から3分18秒を過ぎても無反応だった。human controlには `chatgpt-codex-connector[bot]` が2026-08-16 08:39:50 UTCに要求どおり返信し、Codex taskへのlinkも付与した。所要時間は投稿から3分41秒だった。repository、issue、mention、権限、Codex integration の有無が共通で actor だけが異なるため、integration未設定やworkflow投稿失敗では説明できない。少なくとも現在の GitHub App event filtering では、Actions bot actor のコメントは Codex Cloud task 起動対象外と判断する。
+
+Codex Cloud の内部実行logは GitHub APIから取得できないため、処理中の `eyes` reaction を受付の観測点とし、要求した固定marker返信とtask linkを完了の観測点とした。今回は副作用を禁止した短いcontrolであり、branch・PR・repository fileはCodex Cloud側から作成されていない。
+
+## 運用上の決定
+
+1. GHA cron からissueへ `@codex` をbot投稿するworkflowは採用しない。
+2. 自動escapeと月次canaryは `openai/codex-action@v1` を使う。API従量・secret・spend capは実装issue #4060でfail-closedにする。
+3. Codex Cloud は人間がGitHub上で明示的に `@codex` を投稿する復旧経路として保持する。
+4. actor policyの変更を示す公式仕様または実測結果が得られた場合だけ序列を再評価する。
+
+## 証跡
+
+- GitHub Actions run: `31936715562`（全job成功）
+- bot comment: issue comment `5306548831`
+- human positive-control comment: issue comment `5306560869`
+- human control reply: issue comment `5306574066`
+- 一時的なprobe jobは実測後にworkflowから除去し、恒久CIには残さない。


### PR DESCRIPTION
## 概要

GHA `github-actions[bot]` と human actor の `@codex` メンションを同一issueで制御比較し、Codex Cloudのactor制約を実測しました。

## 結果

- Actions bot: 10分25秒でreaction・返信ともなし
- human actor: 3分41秒で固定marker返信とCodex task linkを生成
- 一時probe jobは最終差分から除去済み
- ADR-0025のescape序列を入れ替え
  - 第一: `openai/codex-action@v1`（自動cron/canary）
  - 第二: Codex Cloud（human-triggered recovery）

## 検証

- `tests/repo/test_site_repository_contract.py` + CHANGELOG contract: 14 passed
- `ruff check .`: green
- `ruff format --check .`: green
- `git diff --check`: green

Closes #4059
