### PR TITLE
fix(collection-serve): idle timeoutの既定値を4時間へ延長する

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
+
 - `feat(hybrid)`: 月次 `openai/codex-action` canary workflowとtyped Discord結果通知を追加し、Codex escape経路の死亡を無人検知できるようにする（#4060）。
 
 - `feat(hybrid)`: DistroKid有効チャンネルの`/publish --clean`で提出完了前の個別音源を保護し、完了後だけdisc音声コピーを削除候補へ加える（#4069）。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -10,7 +10,7 @@ issue #698: #692 の `yt-suno-serve` を一般化し、エンドポイントを�
 - `GET /community/posts/<index>/image` … 投稿画像の binary 配信
 
 起動中は port 別 PID ファイルを記録し、`--stop --port <PORT>` または HTTP request の
-idle timeout（既定 60 分）で終了する。同一 port かつ同一構成の生存 server は再利用する。
+idle timeout（既定 4 時間）で終了する。同一 port かつ同一構成の生存 server は再利用する。
 
 `distrokid` が None または `enabled == False` のとき `/distrokid/*` は 404。
 CORS はデフォルトで Chrome 拡張オリジン (`chrome-extension://...`) と helper サイト
@@ -102,7 +102,11 @@ from youtube_automation.infrastructure.media_store import R2MediaStore, R2MediaS
 from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
 
 DEFAULT_PORT = 7873
-DEFAULT_IDLE_TIMEOUT_SECONDS = 60 * 60
+# suno-helper の「安全モード」（1 件ずつ完了を待つ逐次生成）は collection-serve への
+# HTTP request を伴わずに Suno UI 上だけで進行するため、旧既定の 60 分では 24 曲規模の
+# 生成が完了する前に idle timeout で自動停止し、直後の playlist 追加 POST が失敗する
+# 事故が報告された。安全モードの実測所要時間に余裕を持たせて 4 時間へ延長する。
+DEFAULT_IDLE_TIMEOUT_SECONDS = 4 * 60 * 60
 VERSION_ROUTE = "/version"
 SERVER_INFO_ROUTE = "/server-info"
 _LIFECYCLE_ROUTE_PREFIX = "/.well-known/yt-collection-serve-lifecycle/"


### PR DESCRIPTION
## Summary
- suno-helper の「安全モード」（1件ずつ完了を待つ逐次生成）は `yt-collection-serve` への HTTP request を伴わず Suno UI 上だけで進行するため、既定の idle timeout（60分）だと 24 曲規模の生成が完了する前にサーバーが自動停止し、直後の playlist 追加 POST が `Failed to fetch` で失敗する事故が実際の運用で発生した
- `DEFAULT_IDLE_TIMEOUT_SECONDS` を 60分→4時間に延長し、安全モードの実測所要時間（24曲で1時間強）に十分な余裕を持たせた

## Test plan
- [x] `tests/commands/collections/test_collection_serve_lifecycle.py -k idle_timeout`（8件）がパスすることを確認
- [x] `--idle-timeout` 明示指定時の挙動（既存テスト）に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)