### PR TITLE
fix(uploads): プレイリスト割り当てを theme slug 部分一致から明示指定へ移す

### DIFF
--- a/.claude/skills/publish/references/playlist.md
+++ b/.claude/skills/publish/references/playlist.md
@@ -17,7 +17,7 @@
 
 `config/channel/playlists.json` を Canonical ソースとして読み、定義されたプレイリストを YouTube 上に反映する。全動画自動追加（`auto_add`）と、レガシーのテーマ別マッチングルール（`auto_add_activities` / `auto_add_themes`）に対応。
 
-## 割り当ての決まり方 (#4330)
+## 割り当ての決まり方 (#4346)
 
 | 優先度 | ソース | 挙動 |
 |---|---|---|
@@ -53,7 +53,7 @@ uv run yt-workflow-state --collection <dir> set-planning playlists '["rain-city-
 |--------|---------|------|
 | **status** | `uv run yt-playlist-status` | 全プレイリストの ID・動画数・マッチングルールを表示（読み取り専用） |
 | **init** | `uv run yt-playlist-manager --init [--dry-run]` | `playlists.json` 定義の全プレイリストを作成 + live/ 配下の全動画を割り当て |
-| **assign** | `uv run yt-playlist-manager --assign VIDEO_ID --theme THEME [--dry-run]` | 単一動画を該当プレイリストに追加（テーマからマッチング） |
+| **assign** | `uv run yt-playlist-manager --assign VIDEO_ID --theme THEME [--collection PATH] [--dry-run]` | 単一動画を該当プレイリストに追加（collection 指定時は明示割り当てを優先） |
 | **clean-deleted** | `uv run yt-playlist-manager --clean-deleted [--dry-run]` | 全プレイリストから削除済み/非公開動画のエントリを除去 |
 
 `uv run yt-playlist-manager --status` も同じ `PlaylistStatusViewer` に委譲するため、`uv run yt-playlist-status` と等価。
@@ -104,11 +104,11 @@ uv run yt-playlist-manager --init              # 実反映
 新しい動画を YouTube にアップロードしたあと、該当プレイリストに追加:
 
 ```bash
-uv run yt-playlist-manager --assign <VIDEO_ID> --theme <THEME>
+uv run yt-playlist-manager --assign <VIDEO_ID> --theme <THEME> --collection <COLLECTION_PATH>
 ```
 
 - `<THEME>` は `workflow-state.json` の `theme` 値（`content.json` の `theme_scenes` で定義されたキー）
-- `--assign` は collection ディレクトリを知らないため `planning.playlists` を読めず、レガシー照合にフォールバックする。新テーマではまず `yt-workflow-state set-planning playlists` で明示してから `yt-playlist-manager --init` を使う
+- `--collection` を指定すると `planning.playlists` を読み、明示割り当てを優先する。省略時だけレガシー照合へフォールバックする
 - マッチするプレイリストキーが返り値として表示される
 - `"all"` プレイリストには末尾追加、それ以外は先頭追加（YouTube 表示順制御）
 

--- a/.claude/skills/publish/references/playlist.md
+++ b/.claude/skills/publish/references/playlist.md
@@ -15,7 +15,25 @@
 
 `uv run yt-playlist-status` と `uv run yt-playlist-manager` を 1 スキルに統合し、プレイリストの状態確認・作成・動画割り当て・クリーンアップを案内する。
 
-`config/channel/playlists.json` を Canonical ソースとして読み、定義されたプレイリストを YouTube 上に反映する。テーマ別マッチングルール（`auto_add_activities` / `auto_add_themes`）や全動画自動追加（`auto_add`）に対応。
+`config/channel/playlists.json` を Canonical ソースとして読み、定義されたプレイリストを YouTube 上に反映する。全動画自動追加（`auto_add`）と、レガシーのテーマ別マッチングルール（`auto_add_activities` / `auto_add_themes`）に対応。
+
+## 割り当ての決まり方 (#4330)
+
+| 優先度 | ソース | 挙動 |
+|---|---|---|
+| 1 | `workflow-state.json::planning.playlists` | 明示された key をそのまま採用。`auto_add` は常に追加。`[]` は「`auto_add` のみ」の明示 |
+| 2 | `auto_add_activities` / `auto_add_themes` | 1 が未指定のときだけ照合するレガシー経路 |
+
+`auto_add_themes` は theme slug の**部分一致**であり、新しいテーマを作るたびにキーワードが未登録で漏れる。漏れると分類プレイリストに入らず `auto_add` のプレイリストだけに入るが、アップロードは成功するため気付けない。そのため:
+
+- `yt-init-collection` は分類プレイリスト（`auto_add` 以外）を定義しているチャンネルで `--playlist` / `--no-playlist` を必須にする
+- アップロード preflight は、分類プレイリストに 1 つも割り当たらない状態を fail-loud で弾く（数 GB を送る前に止まる）
+
+既存コレクションの割り当て先を後から決める場合:
+
+```bash
+uv run yt-workflow-state --collection <dir> set-planning playlists '["rain-city-nights"]'
+```
 
 ## 前提
 
@@ -90,6 +108,7 @@ uv run yt-playlist-manager --assign <VIDEO_ID> --theme <THEME>
 ```
 
 - `<THEME>` は `workflow-state.json` の `theme` 値（`content.json` の `theme_scenes` で定義されたキー）
+- `--assign` は collection ディレクトリを知らないため `planning.playlists` を読めず、レガシー照合にフォールバックする。新テーマではまず `yt-workflow-state set-planning playlists` で明示してから `yt-playlist-manager --init` を使う
 - マッチするプレイリストキーが返り値として表示される
 - `"all"` プレイリストには末尾追加、それ以外は先頭追加（YouTube 表示順制御）
 

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -113,7 +113,7 @@ uv run yt-init-collection "<collection_name>" "<theme_slug>" \
   --playlist <playlist_key>
 ```
 
-単一 record の state 投影には `--selected-plan A` を固定で使う。`--playlist` は分類プレイリスト（`auto_add` 以外）を定義しているチャンネルで必須で、候補は `uv run yt-playlist-status` で確認する。分類しないことが意図の場合だけ `--no-playlist` を明示する (#4330)。新規時は初期化と preflight 成功後に batch record の共通 field を `20-documentation/plan_proposals.json` の proposed candidate 1件へ投影し、`batch_id`、`plan_id`、manifest path を provenance として記録する。`references/collection-plan-documents.md` の owner CLI でdraft pairを公開してから `yt-collection-plan-select --automatic` へ渡し、proposal ID、JSON/preview digest、確定pairの検証と再読込を完了した後だけ、`workflow-state.json::planning.generated = true`、`planning.final_title`、`planning.target_persona` を更新する。
+単一 record の state 投影には `--selected-plan A` を固定で使う。`--playlist` は分類プレイリスト（`auto_add` 以外）を定義しているチャンネルで必須で、候補は `uv run yt-playlist-status` で確認する。分類しないことが意図の場合だけ `--no-playlist` を明示する (#4346)。新規時は初期化と preflight 成功後に batch record の共通 field を `20-documentation/plan_proposals.json` の proposed candidate 1件へ投影し、`batch_id`、`plan_id`、manifest path を provenance として記録する。`references/collection-plan-documents.md` の owner CLI でdraft pairを公開してから `yt-collection-plan-select --automatic` へ渡し、proposal ID、JSON/preview digest、確定pairの検証と再読込を完了した後だけ、`workflow-state.json::planning.generated = true`、`planning.final_title`、`planning.target_persona` を更新する。
 
 同じ provenance の未完了 collection が既にある再開時は `yt-init-collection` と企画文書の再作成を行わず、その directory の preflight、企画文書 provenance、workflow-state を再検証する。整合すれば Phase 2b 以降で最初の未完了 step から通常の再開性契約に従い、整合しなければ既存 state を変更せず停止する。保存・検証・state 更新のいずれかに失敗した場合も Phase 2b へ進まず、同じ collection の未完了手順から再開する。
 
@@ -156,8 +156,12 @@ Phase 0 通過後、Phase 1 の企画生成に入る前に、初回制作前の�
 パイロット手順:
 
 ```bash
-uv run yt-init-collection "Pilot Direction Check" "pilot-direction-check" --track-count 2 --selected-plan A --music-engine <suno|lyria|minimax>
+uv run yt-init-collection "Pilot Direction Check" "pilot-direction-check" \
+  --track-count 2 --selected-plan A --music-engine <suno|lyria|minimax> \
+  --playlist <playlist_key>
 ```
+
+分類プレイリストを定義しているチャンネルでは、パイロットを昇格した場合の割り当て先を `--playlist` で指定する。分類しないことが意図なら `--playlist` の代わりに `--no-playlist` を使う。分類プレイリストが無いチャンネルではどちらも省略する。
 
 1. コマンド出力の `collections/planning/YYYYMMDD-<short>-pilot-direction-check-collection/` を控える。
 2. `/thumbnail pilot-direction-check` を実行し、`10-assets/main.png` / `10-assets/main.jpg` と `10-assets/thumbnail.jpg` で色味・構図を確認する。

--- a/.claude/skills/wf-new/SKILL.md
+++ b/.claude/skills/wf-new/SKILL.md
@@ -109,10 +109,11 @@ Phase 2a では選択 record を 1 案の企画として投影し、次を実行
 
 ```bash
 uv run yt-init-collection "<collection_name>" "<theme_slug>" \
-  --track-count <track_count> --selected-plan A --music-engine <music_engine>
+  --track-count <track_count> --selected-plan A --music-engine <music_engine> \
+  --playlist <playlist_key>
 ```
 
-単一 record の state 投影には `--selected-plan A` を固定で使う。新規時は初期化と preflight 成功後に batch record の共通 field を `20-documentation/plan_proposals.json` の proposed candidate 1件へ投影し、`batch_id`、`plan_id`、manifest path を provenance として記録する。`references/collection-plan-documents.md` の owner CLI でdraft pairを公開してから `yt-collection-plan-select --automatic` へ渡し、proposal ID、JSON/preview digest、確定pairの検証と再読込を完了した後だけ、`workflow-state.json::planning.generated = true`、`planning.final_title`、`planning.target_persona` を更新する。
+単一 record の state 投影には `--selected-plan A` を固定で使う。`--playlist` は分類プレイリスト（`auto_add` 以外）を定義しているチャンネルで必須で、候補は `uv run yt-playlist-status` で確認する。分類しないことが意図の場合だけ `--no-playlist` を明示する (#4330)。新規時は初期化と preflight 成功後に batch record の共通 field を `20-documentation/plan_proposals.json` の proposed candidate 1件へ投影し、`batch_id`、`plan_id`、manifest path を provenance として記録する。`references/collection-plan-documents.md` の owner CLI でdraft pairを公開してから `yt-collection-plan-select --automatic` へ渡し、proposal ID、JSON/preview digest、確定pairの検証と再読込を完了した後だけ、`workflow-state.json::planning.generated = true`、`planning.final_title`、`planning.target_persona` を更新する。
 
 同じ provenance の未完了 collection が既にある再開時は `yt-init-collection` と企画文書の再作成を行わず、その directory の preflight、企画文書 provenance、workflow-state を再検証する。整合すれば Phase 2b 以降で最初の未完了 step から通常の再開性契約に従い、整合しなければ既存 state を変更せず停止する。保存・検証・state 更新のいずれかに失敗した場合も Phase 2b へ進まず、同じ collection の未完了手順から再開する。
 

--- a/.claude/skills/wf-new/references/phase2.md
+++ b/.claude/skills/wf-new/references/phase2.md
@@ -9,7 +9,9 @@ Phase 1 で open insights を渡していた場合は、企画選択の直後に
 `/wf-new` の選択結果を入力にして、コレクションディレクトリと workflow-state.json を自動生成する:
 
 ```bash
-uv run yt-init-collection "<Collection Name>" "<theme-slug>" --track-count <N> --selected-plan <A-E> --music-engine <suno|lyria|minimax>
+uv run yt-init-collection "<Collection Name>" "<theme-slug>" \
+  --track-count <N> --selected-plan <A-E> --music-engine <suno|lyria|minimax> \
+  --playlist <playlist-key>
 ```
 
 - `<Collection Name>`: 企画で決定したコレクション表示名
@@ -19,7 +21,7 @@ uv run yt-init-collection "<Collection Name>" "<theme-slug>" --track-count <N> -
 - `--music-engine`: 音楽エンジン（`suno` / `lyria` / `minimax`）。**省略時は `config/channel/youtube.json` の `music_engine` が使われる**。コレクション単位で上書きしたいときのみ明示する
 - `--playlist <key>`: 所属させるプレイリスト key（`config/channel/playlists.json`）。複数回指定可。**分類プレイリスト（`auto_add` 以外）を定義しているチャンネルでは必須**。分類しないことが意図なら `--no-playlist` を明示する
 
-`--playlist` を必須にしているのは、theme slug のキーワード照合（`auto_add_themes`）が新テーマのたびに漏れ、黙って `auto_add` のプレイリストだけに入る事故を防ぐため (#4330)。候補が分からないときは `uv run yt-playlist-status` で一覧を確認する。
+`--playlist` を必須にしているのは、theme slug のキーワード照合（`auto_add_themes`）が新テーマのたびに漏れ、黙って `auto_add` のプレイリストだけに入る事故を防ぐため (#4346)。候補が分からないときは `uv run yt-playlist-status` で一覧を確認する。
 
 スクリプトが以下を自動実行:
 - `collections/planning/YYYYMMDD-<short>-<theme>-collection/` ディレクトリ作成

--- a/.claude/skills/wf-new/references/phase2.md
+++ b/.claude/skills/wf-new/references/phase2.md
@@ -17,6 +17,9 @@ uv run yt-init-collection "<Collection Name>" "<theme-slug>" --track-count <N> -
 - `--track-count`: 確認済みトラック数（デフォルト 12）
 - `--selected-plan`: 選択された企画（A〜E）
 - `--music-engine`: 音楽エンジン（`suno` / `lyria` / `minimax`）。**省略時は `config/channel/youtube.json` の `music_engine` が使われる**。コレクション単位で上書きしたいときのみ明示する
+- `--playlist <key>`: 所属させるプレイリスト key（`config/channel/playlists.json`）。複数回指定可。**分類プレイリスト（`auto_add` 以外）を定義しているチャンネルでは必須**。分類しないことが意図なら `--no-playlist` を明示する
+
+`--playlist` を必須にしているのは、theme slug のキーワード照合（`auto_add_themes`）が新テーマのたびに漏れ、黙って `auto_add` のプレイリストだけに入る事故を防ぐため (#4330)。候補が分からないときは `uv run yt-playlist-status` で一覧を確認する。
 
 スクリプトが以下を自動実行:
 - `collections/planning/YYYYMMDD-<short>-<theme>-collection/` ディレクトリ作成

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -35,6 +35,7 @@ Phase 3: 公開             /wf-next    動画→概要欄→アップロード�
   "track_count": 12,
   "planning": {
     "activities": "Working",
+    "playlists": ["rain-city-nights"],
     "target_persona": "deep-work listener",
     "final_title": "Rainy Harbor Jazz",
     "generated": true,
@@ -280,7 +281,8 @@ top-level `music_engine` は既存 state の読み取り専用互換 field で�
 
 | キー | populate するスキル | 用途 |
 |-----|-------------------|-----|
-| `planning.activities` | `/wf-new` 等 | プレイリストアクティビティの override (`scripts/playlist_manager.py`) |
+| `planning.playlists` | `yt-init-collection --playlist` | **プレイリスト割り当ての正本** (#4330)。string 配列。`[]` は「`auto_add` のみ」の明示、キー自体の欠落は「未決定」。未決定のままアップロードしようとすると preflight が fail-loud で止める |
+| `planning.activities` | `/wf-new` 等 | プレイリストアクティビティの override（`planning.playlists` 未指定時のみ参照されるレガシー経路） |
 | `planning.target_persona` | `/wf-new` | 企画選択時のターゲットペルソナ記録 |
 | `planning.final_title` | `/wf-new` | 確定タイトル |
 | `planning.generated` | `/wf-new` | 企画完了フラグ |

--- a/.claude/skills/wf-new/references/schema.md
+++ b/.claude/skills/wf-new/references/schema.md
@@ -281,7 +281,7 @@ top-level `music_engine` は既存 state の読み取り専用互換 field で�
 
 | キー | populate するスキル | 用途 |
 |-----|-------------------|-----|
-| `planning.playlists` | `yt-init-collection --playlist` | **プレイリスト割り当ての正本** (#4330)。string 配列。`[]` は「`auto_add` のみ」の明示、キー自体の欠落は「未決定」。未決定のままアップロードしようとすると preflight が fail-loud で止める |
+| `planning.playlists` | `yt-init-collection --playlist` | **プレイリスト割り当ての正本** (#4346)。string 配列。`[]` は「`auto_add` のみ」の明示、キー自体の欠落は「未決定」。未決定のままアップロードしようとすると preflight が fail-loud で止める |
 | `planning.activities` | `/wf-new` 等 | プレイリストアクティビティの override（`planning.playlists` 未指定時のみ参照されるレガシー経路） |
 | `planning.target_persona` | `/wf-new` | 企画選択時のターゲットペルソナ記録 |
 | `planning.final_title` | `/wf-new` | 確定タイトル |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
-- `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4330）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。
+- `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。
 
 - `feat(hybrid)`: 月次 `openai/codex-action` canary workflowとtyped Discord結果通知を追加し、Codex escape経路の死亡を無人検知できるようにする（#4060）。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
+- `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4330）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。
 
 - `feat(hybrid)`: 月次 `openai/codex-action` canary workflowとtyped Discord結果通知を追加し、Codex escape経路の死亡を無人検知できるようにする（#4060）。
 

--- a/src/youtube_automation/commands/collections/init_collection.py
+++ b/src/youtube_automation/commands/collections/init_collection.py
@@ -21,17 +21,36 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
+from youtube_automation.domains.uploads.playlist_resolution import (
+    categorizing_playlist_keys,
+    validate_playlist_keys,
+)
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 
 # --- パス解決 ---
 SCRIPT_DIR = Path(__file__).resolve().parent
 
 
-def build_state(collection_name: str, theme: str, track_count: int, selected_plan: str, music_engine: str) -> dict:
-    """workflow-state.json の初期状態を構築する（v2 スキーマ）。"""
+def build_state(
+    collection_name: str,
+    theme: str,
+    track_count: int,
+    selected_plan: str,
+    music_engine: str,
+    playlists: list[str] | None = None,
+) -> dict:
+    """workflow-state.json の初期状態を構築する（v2 スキーマ）。
+
+    ``playlists`` は所属させるプレイリスト key の明示指定（#4330）。``None`` は
+    未決定として key 自体を書かない。``[]`` は「auto_add 以外へは入れない」の明示。
+    """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    planning: dict = {"music": {"engine": music_engine}}
+    if playlists is not None:
+        planning["playlists"] = list(playlists)
     return {
         "collection_name": collection_name,
         "theme": theme,
@@ -41,7 +60,7 @@ def build_state(collection_name: str, theme: str, track_count: int, selected_pla
         "phase": "planning",
         "selected_plan": selected_plan,
         "track_count": track_count,
-        "planning": {"music": {"engine": music_engine}},
+        "planning": planning,
         "assets": {
             "thumbnail": False,
             "loop_video": False,
@@ -59,6 +78,44 @@ def build_state(collection_name: str, theme: str, track_count: int, selected_pla
     }
 
 
+def _resolve_playlist_argument(config, args) -> list[str] | None:
+    """`--playlist` / `--no-playlist` を検証して planning.playlists の値を決める (#4330).
+
+    分類プレイリスト（`auto_add` 以外）を定義しているチャンネルでは、どちらかの
+    明示を必須にする。theme slug のキーワード照合に任せると新テーマで必ず漏れ、
+    黙って `auto_add` プレイリストだけに入るため。
+    """
+    playlists_config = config.playlists.items
+    categorizing = categorizing_playlist_keys(playlists_config)
+
+    if args.no_playlist:
+        if args.playlists:
+            print("[ERROR] --playlist と --no-playlist は同時に指定できません", file=sys.stderr)
+            sys.exit(1)
+        return []
+
+    if args.playlists:
+        try:
+            validate_playlist_keys(playlists_config, args.playlists, source="--playlist")
+        except ValidationError as exc:
+            print(f"[ERROR] {exc}", file=sys.stderr)
+            sys.exit(1)
+        # 重複指定は正規化する（config 定義順）。
+        selected = set(args.playlists)
+        return [key for key in playlists_config if key in selected]
+
+    if categorizing:
+        print(
+            "[ERROR] プレイリストの割り当て先が未指定です。\n"
+            f"        --playlist で指定してください（候補: {', '.join(categorizing)}）\n"
+            "        分類しないことが意図なら --no-playlist を明示してください",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    return None
+
+
 def main():
     from youtube_automation.configuration import channel_dir, load_config
 
@@ -73,6 +130,21 @@ def main():
         choices=["suno", "lyria", "minimax"],
         help="音楽エンジン（デフォルト: channel_config から自動判定）",
     )
+    parser.add_argument(
+        "--playlist",
+        action="append",
+        dest="playlists",
+        metavar="KEY",
+        help=(
+            "所属させるプレイリスト key（config/channel/playlists.json）。複数指定可。"
+            "分類プレイリストを定義しているチャンネルでは必須"
+        ),
+    )
+    parser.add_argument(
+        "--no-playlist",
+        action="store_true",
+        help="分類プレイリストへは意図的に追加しない（auto_add のみ）ことを明示する",
+    )
     args = parser.parse_args()
 
     config = load_config()
@@ -80,6 +152,7 @@ def main():
     ch_dir = Path(channel_dir())
 
     music_engine = args.music_engine or config.youtube.music_engine
+    playlists = _resolve_playlist_argument(config, args)
 
     date_prefix = datetime.now().strftime("%Y%m%d")
     dir_name = f"{date_prefix}-{short}-{args.theme}-collection"
@@ -99,7 +172,14 @@ def main():
     CollectionPaths(base_path).ensure_required_dirs()
 
     # workflow-state.json 生成
-    state = build_state(args.collection_name, args.theme, args.track_count, args.selected_plan, music_engine)
+    state = build_state(
+        args.collection_name,
+        args.theme,
+        args.track_count,
+        args.selected_plan,
+        music_engine,
+        playlists=playlists,
+    )
     state_path = base_path / "workflow-state.json"
     update_workflow_state(state_path, lambda _current: WorkflowState(state))
 
@@ -108,6 +188,8 @@ def main():
     print(f"  トラック数: {args.track_count}")
     print(f"  選択プラン: {args.selected_plan}")
     print(f"  音楽エンジン: {music_engine}")
+    if playlists is not None:
+        print(f"  プレイリスト: {', '.join(playlists) if playlists else '(auto_add のみ)'}")
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/collections/init_collection.py
+++ b/src/youtube_automation/commands/collections/init_collection.py
@@ -44,7 +44,7 @@ def build_state(
 ) -> dict:
     """workflow-state.json の初期状態を構築する（v2 スキーマ）。
 
-    ``playlists`` は所属させるプレイリスト key の明示指定（#4330）。``None`` は
+    ``playlists`` は所属させるプレイリスト key の明示指定（#4346）。``None`` は
     未決定として key 自体を書かない。``[]`` は「auto_add 以外へは入れない」の明示。
     """
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
@@ -79,7 +79,7 @@ def build_state(
 
 
 def _resolve_playlist_argument(config, args) -> list[str] | None:
-    """`--playlist` / `--no-playlist` を検証して planning.playlists の値を決める (#4330).
+    """`--playlist` / `--no-playlist` を検証して planning.playlists の値を決める (#4346).
 
     分類プレイリスト（`auto_add` 以外）を定義しているチャンネルでは、どちらかの
     明示を必須にする。theme slug のキーワード照合に任せると新テーマで必ず漏れ、
@@ -102,7 +102,15 @@ def _resolve_playlist_argument(config, args) -> list[str] | None:
             sys.exit(1)
         # 重複指定は正規化する（config 定義順）。
         selected = set(args.playlists)
-        return [key for key in playlists_config if key in selected]
+        explicit = [key for key in playlists_config if key in selected]
+        if categorizing and not any(key in categorizing for key in explicit):
+            print(
+                "[ERROR] --playlist には分類プレイリストを1つ以上指定してください。\n"
+                "        分類しないことが意図なら --no-playlist を明示してください",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        return explicit
 
     if categorizing:
         print(

--- a/src/youtube_automation/commands/collections/workflow_state_cli.py
+++ b/src/youtube_automation/commands/collections/workflow_state_cli.py
@@ -42,6 +42,7 @@ _PLANNING_CHOICES: tuple[PlanningKey, ...] = (
     "target_persona",
     "publish_target_at",
     "music",
+    "playlists",
 )
 
 

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -372,18 +372,18 @@ class PlanningState(_ObjectSection):
 
     @property
     def playlists(self) -> list[str] | None:
-        """このコレクションを追加するプレイリスト key の明示指定 (#4330).
+        """このコレクションを追加するプレイリスト key の明示指定 (#4346).
 
         `None` は「未決定」、`[]` は「auto_add 以外へは意図的に追加しない」を意味する。
         両者を取り違えると preflight の未割り当て検出が無意味になるため、
         欠落と空配列は区別して返す。
         """
-        value = self._data.get("playlists")
-        if value is None:
+        if "playlists" not in self._data:
             return None
+        value = self._data["playlists"]
         label = "workflow-state.json::planning.playlists"
         if not isinstance(value, list):
-            raise WorkflowStateError(f"{label} must be an array of strings or null")
+            raise WorkflowStateError(f"{label} must be an array of strings")
         keys: list[str] = []
         for item in value:
             if not isinstance(item, str) or not item:

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -31,7 +31,7 @@ AssetKey = Literal[
     "master_video",
     "description",
 ]
-PlanningKey = Literal["generated", "final_title", "target_persona", "publish_target_at", "music"]
+PlanningKey = Literal["generated", "final_title", "target_persona", "publish_target_at", "music", "playlists"]
 
 
 class MusicPlanningDocument(TypedDict, total=False):
@@ -50,6 +50,7 @@ class PlanningDocument(TypedDict, total=False):
     target_persona: str
     final_title: str
     generated: bool
+    playlists: list[str]
 
 
 class AssetsDocument(TypedDict, total=False):
@@ -370,6 +371,27 @@ class PlanningState(_ObjectSection):
         return _optional_string(self._data, "activities", "workflow-state.json::planning.activities")
 
     @property
+    def playlists(self) -> list[str] | None:
+        """このコレクションを追加するプレイリスト key の明示指定 (#4330).
+
+        `None` は「未決定」、`[]` は「auto_add 以外へは意図的に追加しない」を意味する。
+        両者を取り違えると preflight の未割り当て検出が無意味になるため、
+        欠落と空配列は区別して返す。
+        """
+        value = self._data.get("playlists")
+        if value is None:
+            return None
+        label = "workflow-state.json::planning.playlists"
+        if not isinstance(value, list):
+            raise WorkflowStateError(f"{label} must be an array of strings or null")
+        keys: list[str] = []
+        for item in value:
+            if not isinstance(item, str) or not item:
+                raise WorkflowStateError(f"{label} must contain only non-empty strings")
+            keys.append(item)
+        return keys
+
+    @property
     def scene_emoji(self) -> str | None:
         return _optional_string(self._data, "scene_emoji", "workflow-state.json::planning.scene_emoji")
 
@@ -395,6 +417,12 @@ class PlanningState(_ObjectSection):
                 raise WorkflowStateError("workflow-state.json::planning.music must be an object")
             music = MusicPlanningState(value)
             music.validate_known()
+        elif key == "playlists":
+            label = "workflow-state.json::planning.playlists"
+            if not isinstance(value, list):
+                raise WorkflowStateError(f"{label} must be an array of strings")
+            if not all(isinstance(item, str) and item for item in value):
+                raise WorkflowStateError(f"{label} must contain only non-empty strings")
         elif not isinstance(value, str):
             raise WorkflowStateError(f"workflow-state.json::planning.{key} must be a string")
         self._data[key] = deepcopy(value)

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -90,7 +90,7 @@ class PreflightChecker:
 
     @staticmethod
     def _check_playlist_assignment(state, config) -> None:
-        """分類プレイリストへ 1 つも割り当たらない状態を fail-loud で弾く (#4330).
+        """分類プレイリストへ 1 つも割り当たらない状態を fail-loud で弾く (#4346).
 
         `auto_add_themes` の theme slug 部分一致は、新テーマを作るたびに
         キーワード未登録で漏れ、黙って `auto_add` プレイリストだけに入る。
@@ -189,7 +189,7 @@ class PreflightChecker:
         if msg:
             raise ValidationError(f"❌ {msg}: 1 パターン = 1 chapter で再生成してください。")
 
-        # プレイリスト割り当て（#4330）。アップロード完了後に気付いても手戻りが
+        # プレイリスト割り当て（#4346）。アップロード完了後に気付いても手戻りが
         # 大きいので、数 GB を送る前のこの位置で fail-loud する。
         self._check_playlist_assignment(state, config)
 

--- a/src/youtube_automation/domains/uploads/_preflight.py
+++ b/src/youtube_automation/domains/uploads/_preflight.py
@@ -14,6 +14,10 @@ from youtube_automation.domains.collections.workflow_state import read as read_w
 from youtube_automation.domains.documents.video_description import read_video_description_metadata
 from youtube_automation.domains.metadata import BAHMetadataGenerator
 from youtube_automation.domains.uploads._complete_collection_strategy import resolve_master_video
+from youtube_automation.domains.uploads.playlist_resolution import (
+    check_playlist_assignment,
+    resolve_playlist_keys,
+)
 from youtube_automation.domains.uploads.preflight import (
     check_chapter_count,
     check_chapter_variation_suffix,
@@ -83,6 +87,36 @@ class PreflightChecker:
             if isinstance(title, str):
                 titles.append(title)
         return titles
+
+    @staticmethod
+    def _check_playlist_assignment(state, config) -> None:
+        """分類プレイリストへ 1 つも割り当たらない状態を fail-loud で弾く (#4330).
+
+        `auto_add_themes` の theme slug 部分一致は、新テーマを作るたびに
+        キーワード未登録で漏れ、黙って `auto_add` プレイリストだけに入る。
+        アップロード後の割り当ては非致命的（動画は既に公開済み）なので、
+        気付ける唯一の場所がアップロード前のここになる。
+        """
+        playlists_config = config.playlists.items
+        if not playlists_config:
+            return
+        theme = state.theme or ""
+        planning = state.planning
+        explicit = planning.playlists if planning is not None else None
+        activity = None
+        if explicit is None:
+            activity = planning.activities if planning is not None else None
+            if activity is None:
+                activity = config.content.title.activity_for_theme(theme)
+        resolved = resolve_playlist_keys(
+            playlists_config,
+            theme,
+            activity=activity or "",
+            explicit=explicit,
+        )
+        issue = check_playlist_assignment(playlists_config, resolved, theme=theme, explicit=explicit)
+        if issue:
+            raise ValidationError(f"❌ プレイリスト未割り当て: {issue}")
 
     def check(self, collection_dir: Path) -> None:
         """アップロード前メタデータ品質チェック (fail-loud)。
@@ -154,6 +188,10 @@ class PreflightChecker:
         msg = check_chapter_variation_suffix(ts_lines)
         if msg:
             raise ValidationError(f"❌ {msg}: 1 パターン = 1 chapter で再生成してください。")
+
+        # プレイリスト割り当て（#4330）。アップロード完了後に気付いても手戻りが
+        # 大きいので、数 GB を送る前のこの位置で fail-loud する。
+        self._check_playlist_assignment(state, config)
 
         scene_phrases = state.scene_phrases or {}
 

--- a/src/youtube_automation/domains/uploads/playlist_resolution.py
+++ b/src/youtube_automation/domains/uploads/playlist_resolution.py
@@ -1,0 +1,142 @@
+"""プレイリスト割り当ての解決ロジック（API 非依存の純関数）。
+
+``PlaylistManager`` と upload preflight の双方がここを共有する。preflight は
+YouTube clients を持たないため、解決は必ず副作用の無い純関数として切り出す。
+
+解決の優先順位 (#4330):
+
+1. ``workflow-state.json::planning.playlists`` の明示指定があればそれを採用する。
+   これが canonical。``[]`` は「auto_add 以外へは意図的に追加しない」の明示。
+2. 明示指定が無い場合のみ、``auto_add_activities`` / ``auto_add_themes`` の
+   レガシー照合へフォールバックする。
+
+theme slug の部分一致（``auto_add_themes``）は、新しいテーマを作るたびに
+キーワードが未登録となり、黙って ``auto_add`` プレイリストだけに入る事故を
+構造的に生む。``check_playlist_assignment`` はその状態を issue として検出し、
+呼び出し側が fail-loud できるようにする。
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+
+from youtube_automation.core.errors import ValidationError
+
+__all__ = [
+    "categorizing_playlist_keys",
+    "check_playlist_assignment",
+    "resolve_playlist_keys",
+    "validate_playlist_keys",
+]
+
+
+def categorizing_playlist_keys(playlists_config: Mapping[str, Mapping[str, object]]) -> list[str]:
+    """``auto_add`` ではない（＝テーマ分類用の）プレイリスト key を config 順で返す。"""
+    return [key for key, pl in playlists_config.items() if not pl.get("auto_add")]
+
+
+def _auto_add_keys(playlists_config: Mapping[str, Mapping[str, object]]) -> list[str]:
+    return [key for key, pl in playlists_config.items() if pl.get("auto_add")]
+
+
+def validate_playlist_keys(
+    playlists_config: Mapping[str, Mapping[str, object]],
+    keys: Sequence[str],
+    *,
+    source: str,
+) -> None:
+    """未知の playlist key を fail-loud で弾く。
+
+    typo や config から消えた key を黙って無視すると「指定したのに入らない」
+    という最も気付きにくい失敗になるため、必ず例外にする。
+    """
+    unknown = [key for key in keys if key not in playlists_config]
+    if not unknown:
+        return
+    known = ", ".join(playlists_config) or "(なし)"
+    raise ValidationError(
+        f"❌ {source} に未知のプレイリスト key: {unknown}\n  config/channel/playlists.json に定義済みの key: {known}"
+    )
+
+
+def resolve_playlist_keys(
+    playlists_config: Mapping[str, Mapping[str, object]],
+    theme: str,
+    *,
+    activity: str,
+    explicit: Sequence[str] | None,
+) -> list[str]:
+    """所属すべきプレイリスト key を config の定義順で返す。
+
+    Args:
+        playlists_config: ``config.playlists.items``
+        theme: コレクションの theme slug
+        activity: activity 文字列（``planning.activities`` または
+            ``activity_for_theme`` の解決結果）。``explicit`` 指定時は未使用。
+        explicit: ``planning.playlists`` の明示指定。``None`` は未決定、
+            ``[]`` は「auto_add のみで良い」の明示。
+
+    Raises:
+        ValidationError: ``explicit`` に未知の key が含まれる場合。
+    """
+    if explicit is not None:
+        validate_playlist_keys(playlists_config, explicit, source="workflow-state.json::planning.playlists")
+        selected = set(explicit)
+        # config の定義順を保つ（``all`` を先頭に置く運用が挿入位置に依存するため）。
+        return [key for key in playlists_config if key in selected or playlists_config[key].get("auto_add")]
+
+    theme_lower = theme.lower()
+    # 中黒は従来形式、カンマは channel-new の生成形式として下流 config に存在する。
+    activities = [a.strip() for a in activity.replace("·", ",").split(",")]
+    matched: list[str] = []
+
+    for key, pl in playlists_config.items():
+        if pl.get("auto_add"):
+            matched.append(key)
+            continue
+
+        activity_rules = pl.get("auto_add_activities") or []
+        if any(a in activity_rules for a in activities):
+            matched.append(key)
+            continue
+
+        theme_rules = pl.get("auto_add_themes") or []
+        if any(theme_kw in theme_lower for theme_kw in theme_rules):
+            matched.append(key)
+
+    return matched
+
+
+def check_playlist_assignment(
+    playlists_config: Mapping[str, Mapping[str, object]],
+    resolved: Sequence[str],
+    *,
+    theme: str,
+    explicit: Sequence[str] | None,
+) -> str | None:
+    """分類プレイリストへ 1 つも割り当たっていなければ issue 文字列を返す。
+
+    チャンネルが分類プレイリスト（``auto_add`` 以外）を 1 つも定義していない
+    場合は対象外。``explicit`` が空配列で与えられている場合は operator が
+    「auto_add のみ」を明示したものとして許容する。
+    """
+    categorizing = categorizing_playlist_keys(playlists_config)
+    if not categorizing:
+        return None
+    if explicit is not None:
+        # 明示的な空配列 = operator が意図して auto_add のみを選んだ。
+        return None
+    if any(key in categorizing for key in resolved):
+        return None
+
+    auto_only = ", ".join(_auto_add_keys(playlists_config)) or "(なし)"
+    return (
+        f"theme={theme!r} がどの分類プレイリストにも割り当たっていません"
+        f"（auto_add の {auto_only} のみ）。\n"
+        f"    auto_add_themes のキーワード照合は新テーマで必ず漏れます。"
+        f"割り当て先を明示してください:\n"
+        f"      uv run yt-workflow-state set-planning playlists "
+        f"'[\"{categorizing[0]}\"]'\n"
+        f"    分類しないことが意図なら空配列を明示してください: "
+        f"set-planning playlists '[]'"
+    )

--- a/src/youtube_automation/domains/uploads/playlist_resolution.py
+++ b/src/youtube_automation/domains/uploads/playlist_resolution.py
@@ -3,7 +3,7 @@
 ``PlaylistManager`` と upload preflight の双方がここを共有する。preflight は
 YouTube clients を持たないため、解決は必ず副作用の無い純関数として切り出す。
 
-解決の優先順位 (#4330):
+解決の優先順位 (#4346):
 
 1. ``workflow-state.json::planning.playlists`` の明示指定があればそれを採用する。
    これが canonical。``[]`` は「auto_add 以外へは意図的に追加しない」の明示。
@@ -123,20 +123,32 @@ def check_playlist_assignment(
     categorizing = categorizing_playlist_keys(playlists_config)
     if not categorizing:
         return None
-    if explicit is not None:
-        # 明示的な空配列 = operator が意図して auto_add のみを選んだ。
+    if explicit == []:
+        # 明示的な空配列だけが、operator が意図して auto_add のみを選んだ状態。
         return None
-    if any(key in categorizing for key in resolved):
-        return None
+    resolved_categorizing = [key for key in resolved if key in categorizing]
+    if not resolved_categorizing:
+        auto_only = ", ".join(_auto_add_keys(playlists_config)) or "(なし)"
+        return (
+            f"theme={theme!r} がどの分類プレイリストにも割り当たっていません"
+            f"（auto_add の {auto_only} のみ）。\n"
+            f"    auto_add_themes のキーワード照合は新テーマで必ず漏れます。"
+            f"割り当て先を明示してください:\n"
+            f"      uv run yt-workflow-state set-planning playlists "
+            f"'[\"{categorizing[0]}\"]'\n"
+            f"    分類しないことが意図なら空配列を明示してください: "
+            f"set-planning playlists '[]'"
+        )
 
-    auto_only = ", ".join(_auto_add_keys(playlists_config)) or "(なし)"
-    return (
-        f"theme={theme!r} がどの分類プレイリストにも割り当たっていません"
-        f"（auto_add の {auto_only} のみ）。\n"
-        f"    auto_add_themes のキーワード照合は新テーマで必ず漏れます。"
-        f"割り当て先を明示してください:\n"
-        f"      uv run yt-workflow-state set-planning playlists "
-        f"'[\"{categorizing[0]}\"]'\n"
-        f"    分類しないことが意図なら空配列を明示してください: "
-        f"set-planning playlists '[]'"
-    )
+    missing_playlist_ids = [
+        key
+        for key in resolved_categorizing
+        if not isinstance(playlists_config[key].get("playlist_id"), str)
+        or not playlists_config[key]["playlist_id"].strip()
+    ]
+    if missing_playlist_ids:
+        return (
+            f"分類プレイリストの playlist_id 未設定: {', '.join(missing_playlist_ids)}。"
+            "アップロード前に `uv run yt-playlist-manager --init` を実行してください"
+        )
+    return None

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -8,6 +8,10 @@ from youtube_automation.configuration import channel_dir, load_config, reset
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.errors import ValidationError, WorkflowStateError, YouTubeAPIError
 from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
+from youtube_automation.domains.uploads.playlist_resolution import (
+    check_playlist_assignment,
+    resolve_playlist_keys,
+)
 from youtube_automation.infrastructure.filesystem import (
     list_directory,
     path_exists,
@@ -123,37 +127,30 @@ class PlaylistManager:
 
     # ─── プレイリスト解決 ──────────────────────────────
 
-    def resolve_playlists(self, theme: str, activity: str | None = None) -> list[str]:
+    def resolve_playlists(
+        self,
+        theme: str,
+        activity: str | None = None,
+        explicit: list[str] | None = None,
+    ) -> list[str]:
         """テーマから所属すべきプレイリストキーのリストを返す.
 
-        `activity` 明示指定があればそれを優先し、`None` の場合のみ
-        `activity_for_theme(theme)` で解決する。明示 override は
-        `content.json` 未登録テーマに対する安全弁として使う（#80）。
+        `explicit`（`workflow-state.json::planning.playlists`）があればそれが
+        canonical で、activity / theme 照合は一切行わない（#4330）。
+
+        `explicit` が `None` のときのみレガシー照合へフォールバックする。
+        その場合、`activity` 明示指定があればそれを優先し、`None` の場合のみ
+        `activity_for_theme(theme)` で解決する（#80）。
         """
         playlists_config = self.config.playlists.items
-        if activity is None:
+        if explicit is None and activity is None:
             activity = self.config.content.title.activity_for_theme(theme)
-        theme_lower = theme.lower()
-        matched = []
-
-        for key, pl in playlists_config.items():
-            if pl.get("auto_add"):
-                matched.append(key)
-                continue
-
-            # 中黒は従来形式、カンマは channel-new の生成形式として下流 config に存在する。
-            activities = [a.strip() for a in activity.replace("·", ",").split(",")]
-            if any(a in pl.get("auto_add_activities", []) for a in activities):
-                matched.append(key)
-                continue
-
-            # theme キーワードベースのマッチング
-            for theme_kw in pl.get("auto_add_themes", []):
-                if theme_kw in theme_lower:
-                    matched.append(key)
-                    break
-
-        return matched
+        return resolve_playlist_keys(
+            playlists_config,
+            theme,
+            activity=activity or "",
+            explicit=explicit,
+        )
 
     # ─── プレイリスト作成 ──────────────────────────────
 
@@ -222,6 +219,19 @@ class PlaylistManager:
             return None
         return explicit if isinstance(explicit, str) and explicit else None
 
+    @staticmethod
+    def _planning_playlists(collection_path: Path) -> list[str] | None:
+        """collection_path/workflow-state.json から planning.playlists を読む (#4330).
+
+        `None` は未指定（レガシー照合へフォールバック）、`[]` は「auto_add のみ」
+        の明示。schema 違反（配列でない・空文字を含む）は fail-loud で伝播させる —
+        ここで握りつぶすと「指定したのに入らない」に戻ってしまう。
+        """
+        ws_path = CollectionPaths(collection_path).workflow_state_path
+        state = read_workflow_state_or_none(ws_path)
+        planning = state.planning if state is not None else None
+        return planning.playlists if planning is not None else None
+
     def _list_playlist_video_ids(self, playlist_id: str) -> set[str]:
         """プレイリスト内の動画IDセットを取得（重複防止用）"""
         youtube = self._youtube_service()
@@ -256,17 +266,17 @@ class PlaylistManager:
         """単一動画を該当プレイリストに追加
 
         `collection_path` が与えられた場合、`workflow-state.json` の
-        `planning.activities` があればそれを activity override として
-        `resolve_playlists` に渡す。`content.json` の `theme_scenes` に
-        未登録の新テーマでも、明示的に activity を与えることで正しく
-        プレイリスト判定できる（#80）。
+        `planning.playlists` を最優先で使う（#4330）。未指定のときのみ
+        `planning.activities` を activity override として `resolve_playlists`
+        に渡す（#80）。
 
         Returns:
             追加先のプレイリストキーリスト
         """
-        activity_override = self._planning_activities(collection_path) if collection_path else None
+        explicit = self._planning_playlists(collection_path) if collection_path else None
+        activity_override = self._planning_activities(collection_path) if collection_path and explicit is None else None
         playlists_config = self.config.playlists.items
-        target_keys = self.resolve_playlists(theme, activity=activity_override)
+        target_keys = self.resolve_playlists(theme, activity=activity_override, explicit=explicit)
         assigned = []
 
         for key in target_keys:
@@ -349,15 +359,19 @@ class PlaylistManager:
             planning = steps.get("planning") if isinstance(steps, dict) else None
             title = planning.get("final_title", col_path.name) if isinstance(planning, dict) else col_path.name
 
-            activity_override = self._planning_activities(col_path)
+            explicit = self._planning_playlists(col_path)
+            activity_override = self._planning_activities(col_path) if explicit is None else None
 
             if dry_run:
-                target_keys = self.resolve_playlists(theme, activity=activity_override)
+                target_keys = self.resolve_playlists(theme, activity=activity_override, explicit=explicit)
                 playlists_config = self.config.playlists.items
                 print(f"\n  {title}")
                 print(f"    theme: {theme} | video_id: {video_id}")
                 for key in target_keys:
                     print(f"    -> {playlists_config[key]['title']}")
+                issue = check_playlist_assignment(playlists_config, target_keys, theme=theme, explicit=explicit)
+                if issue:
+                    print(f"    ⚠️  {issue}")
                 results[col_path.name] = target_keys
             else:
                 logger.info(f"\n  {title} ({video_id})")

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -136,7 +136,7 @@ class PlaylistManager:
         """テーマから所属すべきプレイリストキーのリストを返す.
 
         `explicit`（`workflow-state.json::planning.playlists`）があればそれが
-        canonical で、activity / theme 照合は一切行わない（#4330）。
+        canonical で、activity / theme 照合は一切行わない（#4346）。
 
         `explicit` が `None` のときのみレガシー照合へフォールバックする。
         その場合、`activity` 明示指定があればそれを優先し、`None` の場合のみ
@@ -221,7 +221,7 @@ class PlaylistManager:
 
     @staticmethod
     def _planning_playlists(collection_path: Path) -> list[str] | None:
-        """collection_path/workflow-state.json から planning.playlists を読む (#4330).
+        """collection_path/workflow-state.json から planning.playlists を読む (#4346).
 
         `None` は未指定（レガシー照合へフォールバック）、`[]` は「auto_add のみ」
         の明示。schema 違反（配列でない・空文字を含む）は fail-loud で伝播させる —
@@ -266,7 +266,7 @@ class PlaylistManager:
         """単一動画を該当プレイリストに追加
 
         `collection_path` が与えられた場合、`workflow-state.json` の
-        `planning.playlists` を最優先で使う（#4330）。未指定のときのみ
+        `planning.playlists` を最優先で使う（#4346）。未指定のときのみ
         `planning.activities` を activity override として `resolve_playlists`
         に渡す（#80）。
 

--- a/tests/commands/collections/test_init_collection.py
+++ b/tests/commands/collections/test_init_collection.py
@@ -27,7 +27,7 @@ def _run(monkeypatch, argv: list[str]):
 
 @pytest.fixture
 def categorizing_playlists():
-    """分類プレイリスト（auto_add 以外）を持つチャンネル config に差し替える (#4330)."""
+    """分類プレイリスト（auto_add 以外）を持つチャンネル config に差し替える (#4346)."""
     path = Path(channel_dir()) / "config" / "channel" / "playlists.json"
     original = path.read_text(encoding="utf-8")
     path.write_text(
@@ -177,7 +177,7 @@ class TestScaffold:
 
 
 class TestPlaylistAssignment:
-    """#4330: 割り当て先を init 段階で明示させる。
+    """#4346: 割り当て先を init 段階で明示させる。
 
     theme slug のキーワード照合に任せると、新テーマを作るたびに未登録で漏れ、
     黙って auto_add プレイリストだけに入る。
@@ -234,6 +234,15 @@ class TestPlaylistAssignment:
             _run(monkeypatch, ["Init Scaffold", "init-scaffold", "--playlist", "typo"])
         assert exc.value.code == 1
         assert "typo" in capsys.readouterr().err
+
+    def test_auto_add_key_requires_no_playlist_instead(self, monkeypatch, capsys, categorizing_playlists):
+        with pytest.raises(SystemExit) as exc:
+            _run(monkeypatch, ["Init Scaffold", "init-scaffold", "--playlist", "all"])
+
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "分類プレイリスト" in err
+        assert "--no-playlist" in err
 
     def test_conflicting_flags_fail_loud(self, monkeypatch, capsys, categorizing_playlists):
         with pytest.raises(SystemExit) as exc:

--- a/tests/commands/collections/test_init_collection.py
+++ b/tests/commands/collections/test_init_collection.py
@@ -16,13 +16,36 @@ sys.path.insert(0, str(REPO_ROOT))
 import pytest
 
 from youtube_automation.commands.collections.init_collection import main
-from youtube_automation.configuration import channel_dir, load_config
+from youtube_automation.configuration import channel_dir, load_config, reset
 from youtube_automation.infrastructure.media.collection_paths import REQUIRED_SUBDIRS
 
 
 def _run(monkeypatch, argv: list[str]):
     monkeypatch.setattr(sys, "argv", ["yt-init-collection", *argv])
     return main()
+
+
+@pytest.fixture
+def categorizing_playlists():
+    """分類プレイリスト（auto_add 以外）を持つチャンネル config に差し替える (#4330)."""
+    path = Path(channel_dir()) / "config" / "channel" / "playlists.json"
+    original = path.read_text(encoding="utf-8")
+    path.write_text(
+        json.dumps(
+            {
+                "playlists": {
+                    "all": {"title": "All", "auto_add": True, "playlist_id": "PL_ALL"},
+                    "rain": {"title": "Rain", "auto_add_themes": ["rain"], "playlist_id": "PL_RAIN"},
+                    "rooms": {"title": "Rooms", "auto_add_themes": ["room"], "playlist_id": "PL_ROOMS"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    reset()
+    yield
+    path.write_text(original, encoding="utf-8")
+    reset()
 
 
 def _created_collection() -> Path:
@@ -127,6 +150,18 @@ class TestScaffold:
 
             shutil.rmtree(collection)
 
+    def test_no_playlist_key_written_when_channel_has_no_categorizing_playlist(self, monkeypatch):
+        """分類プレイリストが無いチャンネルでは planning.playlists を書かない（後方互換）."""
+        _run(monkeypatch, ["Init Scaffold", "init-scaffold"])
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert "playlists" not in state["planning"]
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
     def test_minimax_music_engine_is_persisted_in_workflow_state(self, monkeypatch):
         _run(monkeypatch, ["MiniMax Scaffold", "minimax-scaffold", "--music-engine", "minimax"])
         planning = Path(channel_dir()) / "collections" / "planning"
@@ -139,3 +174,72 @@ class TestScaffold:
             import shutil
 
             shutil.rmtree(collection)
+
+
+class TestPlaylistAssignment:
+    """#4330: 割り当て先を init 段階で明示させる。
+
+    theme slug のキーワード照合に任せると、新テーマを作るたびに未登録で漏れ、
+    黙って auto_add プレイリストだけに入る。
+    """
+
+    def test_playlist_keys_are_persisted(self, monkeypatch, categorizing_playlists):
+        _run(monkeypatch, ["Init Scaffold", "init-scaffold", "--playlist", "rain"])
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["planning"]["playlists"] == ["rain"]
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_repeated_flag_accumulates_in_config_order(self, monkeypatch, categorizing_playlists):
+        _run(
+            monkeypatch,
+            ["Init Scaffold", "init-scaffold", "--playlist", "rooms", "--playlist", "rain"],
+        )
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["planning"]["playlists"] == ["rain", "rooms"]
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_no_playlist_records_explicit_empty(self, monkeypatch, categorizing_playlists):
+        """空配列は「未決定」と区別され、preflight を通過できる明示指定になる."""
+        _run(monkeypatch, ["Init Scaffold", "init-scaffold", "--no-playlist"])
+        collection = _created_collection()
+        try:
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["planning"]["playlists"] == []
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_missing_flag_fails_loud_with_candidates(self, monkeypatch, capsys, categorizing_playlists):
+        with pytest.raises(SystemExit) as exc:
+            _run(monkeypatch, ["Init Scaffold", "init-scaffold"])
+        assert exc.value.code == 1
+        err = capsys.readouterr().err
+        assert "--playlist" in err
+        assert "rain" in err and "rooms" in err
+        assert "--no-playlist" in err
+
+    def test_unknown_key_fails_loud(self, monkeypatch, capsys, categorizing_playlists):
+        with pytest.raises(SystemExit) as exc:
+            _run(monkeypatch, ["Init Scaffold", "init-scaffold", "--playlist", "typo"])
+        assert exc.value.code == 1
+        assert "typo" in capsys.readouterr().err
+
+    def test_conflicting_flags_fail_loud(self, monkeypatch, capsys, categorizing_playlists):
+        with pytest.raises(SystemExit) as exc:
+            _run(
+                monkeypatch,
+                ["Init Scaffold", "init-scaffold", "--playlist", "rain", "--no-playlist"],
+            )
+        assert exc.value.code == 1
+        assert "同時に指定できません" in capsys.readouterr().err

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -624,7 +624,7 @@ def test_workflow_state_error_is_an_automation_error() -> None:
 
 
 class TestPlanningPlaylists:
-    """#4330: planning.playlists は「未決定」と「auto_add のみ」を区別する。"""
+    """#4346: planning.playlists は「未決定」と「auto_add のみ」を区別する。"""
 
     def _planning(self, tmp_path: Path, payload: object) -> object:
         state_path = tmp_path / "workflow-state.json"
@@ -642,7 +642,7 @@ class TestPlanningPlaylists:
     def test_keys_are_returned_in_order(self, tmp_path: Path) -> None:
         assert self._planning(tmp_path, {"playlists": ["a", "b"]}).playlists == ["a", "b"]
 
-    @pytest.mark.parametrize("payload", ["rain", {"key": "rain"}, [1], [""]])
+    @pytest.mark.parametrize("payload", [None, "rain", {"key": "rain"}, [1], [""]])
     def test_invalid_shape_fails_loud(self, tmp_path: Path, payload: object) -> None:
         planning = self._planning(tmp_path, {"playlists": payload})
         with pytest.raises(WorkflowStateError, match="planning.playlists"):

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -621,3 +621,36 @@ def test_update_serializes_processes_without_losing_changes(tmp_path: Path) -> N
 
 def test_workflow_state_error_is_an_automation_error() -> None:
     assert issubclass(WorkflowStateError, AutomationError)
+
+
+class TestPlanningPlaylists:
+    """#4330: planning.playlists は「未決定」と「auto_add のみ」を区別する。"""
+
+    def _planning(self, tmp_path: Path, payload: object) -> object:
+        state_path = tmp_path / "workflow-state.json"
+        _write(state_path, {"planning": payload})
+        state = read(state_path)
+        assert state.planning is not None
+        return state.planning
+
+    def test_missing_key_reads_as_none(self, tmp_path: Path) -> None:
+        assert self._planning(tmp_path, {"music": {"engine": "suno"}}).playlists is None
+
+    def test_empty_array_is_preserved(self, tmp_path: Path) -> None:
+        assert self._planning(tmp_path, {"playlists": []}).playlists == []
+
+    def test_keys_are_returned_in_order(self, tmp_path: Path) -> None:
+        assert self._planning(tmp_path, {"playlists": ["a", "b"]}).playlists == ["a", "b"]
+
+    @pytest.mark.parametrize("payload", ["rain", {"key": "rain"}, [1], [""]])
+    def test_invalid_shape_fails_loud(self, tmp_path: Path, payload: object) -> None:
+        planning = self._planning(tmp_path, {"playlists": payload})
+        with pytest.raises(WorkflowStateError, match="planning.playlists"):
+            _ = planning.playlists
+
+    def test_set_known_validates_shape(self, tmp_path: Path) -> None:
+        planning = self._planning(tmp_path, {})
+        planning.set_known("playlists", ["rain"])
+        assert planning.playlists == ["rain"]
+        with pytest.raises(WorkflowStateError, match="planning.playlists"):
+            planning.set_known("playlists", "rain")

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -151,6 +151,8 @@ def _title_preflight_config() -> SimpleNamespace:
             ),
         ),
         localizations=SimpleNamespace(supported_languages=["ja", "en", "de"]),
+        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4330)
+        playlists=SimpleNamespace(items={}),
     )
 
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -151,7 +151,7 @@ def _title_preflight_config() -> SimpleNamespace:
             ),
         ),
         localizations=SimpleNamespace(supported_languages=["ja", "en", "de"]),
-        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4330)
+        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4346)
         playlists=SimpleNamespace(items={}),
     )
 

--- a/tests/domains/uploads/test_playlist_manager.py
+++ b/tests/domains/uploads/test_playlist_manager.py
@@ -19,7 +19,7 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from youtube_automation.core.errors import ValidationError, YouTubeAPIError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, YouTubeAPIError
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 # ---------------------------------------------------------------------------
@@ -271,6 +271,63 @@ class TestAssignVideo:
         manager.assign_video("VID_X", "ocean waves", dry_run=True, collection_path=tmp_path)
 
         mock_config.content.title.activity_for_theme.assert_called_once_with("ocean waves")
+
+    def test_collection_path_planning_playlists_is_canonical(self, manager, mock_config, tmp_path):
+        """#4330: planning.playlists があれば theme / activity 照合は行わない."""
+        ws = tmp_path / "workflow-state.json"
+        ws.write_text(
+            json.dumps({"theme": "ocean waves", "planning": {"playlists": ["battle"]}}),
+            encoding="utf-8",
+        )
+        mock_config.content.title.activity_for_theme.reset_mock()
+
+        result = manager.assign_video("VID_X", "ocean waves", dry_run=True, collection_path=tmp_path)
+
+        mock_config.content.title.activity_for_theme.assert_not_called()
+        # 'ocean' は relaxation の auto_add_themes に hit するが、明示指定が勝つ。
+        assert "relaxation" not in result
+        assert set(result) == {"all", "battle"}
+
+    def test_planning_playlists_beats_planning_activities(self, manager, mock_config, tmp_path):
+        """playlists と activities が両方あれば playlists が優先される."""
+        ws = tmp_path / "workflow-state.json"
+        ws.write_text(
+            json.dumps({"planning": {"activities": "Gaming", "playlists": ["relaxation"]}}),
+            encoding="utf-8",
+        )
+
+        result = manager.assign_video("VID_X", "unknown-theme", dry_run=True, collection_path=tmp_path)
+
+        assert "battle" not in result
+        assert set(result) == {"all", "relaxation"}
+
+    def test_planning_playlists_empty_means_auto_add_only(self, manager, tmp_path):
+        """空配列は「auto_add のみ」の明示指定として尊重される."""
+        ws = tmp_path / "workflow-state.json"
+        ws.write_text(
+            json.dumps({"theme": "ocean waves", "planning": {"playlists": []}}),
+            encoding="utf-8",
+        )
+
+        result = manager.assign_video("VID_X", "ocean waves", dry_run=True, collection_path=tmp_path)
+
+        assert result == ["all"]
+
+    def test_planning_playlists_unknown_key_fails_loud(self, manager, tmp_path):
+        """未知 key を黙って無視すると『指定したのに入らない』に戻るため例外にする."""
+        ws = tmp_path / "workflow-state.json"
+        ws.write_text(json.dumps({"planning": {"playlists": ["typo"]}}), encoding="utf-8")
+
+        with pytest.raises(ValidationError, match="typo"):
+            manager.assign_video("VID_X", "ocean waves", dry_run=True, collection_path=tmp_path)
+
+    def test_planning_playlists_wrong_type_fails_loud(self, manager, tmp_path):
+        """schema 違反は WorkflowStateError として伝播させる."""
+        ws = tmp_path / "workflow-state.json"
+        ws.write_text(json.dumps({"planning": {"playlists": "battle"}}), encoding="utf-8")
+
+        with pytest.raises(WorkflowStateError, match="planning.playlists"):
+            manager.assign_video("VID_X", "ocean waves", dry_run=True, collection_path=tmp_path)
 
     def test_no_collection_path_uses_title_resolver(self, manager, mock_config):
         """collection_path 未指定なら従来どおりの経路（後方互換）."""

--- a/tests/domains/uploads/test_playlist_manager.py
+++ b/tests/domains/uploads/test_playlist_manager.py
@@ -273,7 +273,7 @@ class TestAssignVideo:
         mock_config.content.title.activity_for_theme.assert_called_once_with("ocean waves")
 
     def test_collection_path_planning_playlists_is_canonical(self, manager, mock_config, tmp_path):
-        """#4330: planning.playlists があれば theme / activity 照合は行わない."""
+        """#4346: planning.playlists があれば theme / activity 照合は行わない."""
         ws = tmp_path / "workflow-state.json"
         ws.write_text(
             json.dumps({"theme": "ocean waves", "planning": {"playlists": ["battle"]}}),

--- a/tests/domains/uploads/test_playlist_resolution.py
+++ b/tests/domains/uploads/test_playlist_resolution.py
@@ -1,4 +1,4 @@
-"""プレイリスト解決の純関数テスト (#4330).
+"""プレイリスト解決の純関数テスト (#4346).
 
 theme slug の部分一致だけに依存していた頃の事故（新テーマを作るたびに
 auto_add_themes が未登録で、黙って auto_add プレイリストだけに入る）が
@@ -100,3 +100,21 @@ class TestCheckPlaylistAssignment:
 
     def test_explicit_empty_is_an_accepted_operator_decision(self):
         assert check_playlist_assignment(PLAYLISTS, ["all"], theme="anything", explicit=[]) is None
+
+    def test_explicit_auto_add_key_does_not_claim_a_categorizing_assignment(self):
+        issue = check_playlist_assignment(PLAYLISTS, ["all"], theme="anything", explicit=["all"])
+
+        assert issue is not None
+        assert "分類プレイリスト" in issue
+
+    def test_flags_categorizing_playlist_without_youtube_id(self):
+        playlists = {
+            **PLAYLISTS,
+            "rain": {"title": "Rain", "auto_add_themes": ["rain"]},
+        }
+
+        issue = check_playlist_assignment(playlists, ["all", "rain"], theme="rain", explicit=["rain"])
+
+        assert issue is not None
+        assert "playlist_id 未設定" in issue
+        assert "rain" in issue

--- a/tests/domains/uploads/test_playlist_resolution.py
+++ b/tests/domains/uploads/test_playlist_resolution.py
@@ -1,0 +1,102 @@
+"""プレイリスト解決の純関数テスト (#4330).
+
+theme slug の部分一致だけに依存していた頃の事故（新テーマを作るたびに
+auto_add_themes が未登録で、黙って auto_add プレイリストだけに入る）が
+再発しないことを固定する。
+"""
+
+import pytest
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.uploads.playlist_resolution import (
+    categorizing_playlist_keys,
+    check_playlist_assignment,
+    resolve_playlist_keys,
+    validate_playlist_keys,
+)
+
+PLAYLISTS = {
+    "all": {"title": "All", "auto_add": True, "playlist_id": "PL_ALL"},
+    "rain": {"title": "Rain", "auto_add_themes": ["rain", "neon"], "playlist_id": "PL_RAIN"},
+    "rooms": {"title": "Rooms", "auto_add_activities": ["Focus"], "playlist_id": "PL_ROOMS"},
+}
+AUTO_ADD_ONLY = {"all": {"title": "All", "auto_add": True, "playlist_id": "PL_ALL"}}
+
+
+class TestCategorizingPlaylistKeys:
+    def test_excludes_auto_add(self):
+        assert categorizing_playlist_keys(PLAYLISTS) == ["rain", "rooms"]
+
+    def test_empty_when_only_auto_add(self):
+        assert categorizing_playlist_keys(AUTO_ADD_ONLY) == []
+
+
+class TestValidatePlaylistKeys:
+    def test_accepts_known_keys(self):
+        validate_playlist_keys(PLAYLISTS, ["rain", "all"], source="--playlist")
+
+    def test_rejects_unknown_key(self):
+        with pytest.raises(ValidationError) as exc:
+            validate_playlist_keys(PLAYLISTS, ["rain", "typo"], source="--playlist")
+        assert "typo" in str(exc.value)
+        assert "--playlist" in str(exc.value)
+
+
+class TestResolveExplicit:
+    def test_explicit_wins_over_keyword_match(self):
+        """明示指定があれば theme キーワードは一切参照しない."""
+        result = resolve_playlist_keys(PLAYLISTS, "rain-city", activity="Focus", explicit=["rooms"])
+        assert result == ["all", "rooms"]
+
+    def test_auto_add_always_included(self):
+        result = resolve_playlist_keys(PLAYLISTS, "anything", activity="", explicit=["rain"])
+        assert "all" in result
+
+    def test_empty_explicit_means_auto_add_only(self):
+        result = resolve_playlist_keys(PLAYLISTS, "rain-city", activity="Focus", explicit=[])
+        assert result == ["all"]
+
+    def test_result_follows_config_order(self):
+        result = resolve_playlist_keys(PLAYLISTS, "x", activity="", explicit=["rooms", "rain"])
+        assert result == ["all", "rain", "rooms"]
+
+    def test_unknown_explicit_key_fails_loud(self):
+        with pytest.raises(ValidationError):
+            resolve_playlist_keys(PLAYLISTS, "x", activity="", explicit=["nope"])
+
+
+class TestResolveLegacyFallback:
+    def test_theme_keyword_still_matches(self):
+        result = resolve_playlist_keys(PLAYLISTS, "Neon Rain Crossing", activity="Study", explicit=None)
+        assert result == ["all", "rain"]
+
+    def test_activity_still_matches(self):
+        result = resolve_playlist_keys(PLAYLISTS, "unknown", activity="Focus", explicit=None)
+        assert result == ["all", "rooms"]
+
+    @pytest.mark.parametrize("separator", ["·", ","])
+    def test_activity_separators(self, separator):
+        activity = separator.join(["Study", "Focus"])
+        assert "rooms" in resolve_playlist_keys(PLAYLISTS, "unknown", activity=activity, explicit=None)
+
+    def test_new_theme_falls_through_to_auto_add_only(self):
+        """回帰の再現: carriage-six / the-long-way-home はどのキーワードにも当たらない."""
+        for theme in ("carriage-six", "the-long-way-home"):
+            assert resolve_playlist_keys(PLAYLISTS, theme, activity="Study", explicit=None) == ["all"]
+
+
+class TestCheckPlaylistAssignment:
+    def test_flags_auto_add_only_result(self):
+        issue = check_playlist_assignment(PLAYLISTS, ["all"], theme="carriage-six", explicit=None)
+        assert issue is not None
+        assert "carriage-six" in issue
+        assert "set-planning playlists" in issue
+
+    def test_silent_when_categorizing_playlist_matched(self):
+        assert check_playlist_assignment(PLAYLISTS, ["all", "rain"], theme="rain-city", explicit=None) is None
+
+    def test_silent_when_channel_has_no_categorizing_playlist(self):
+        assert check_playlist_assignment(AUTO_ADD_ONLY, ["all"], theme="anything", explicit=None) is None
+
+    def test_explicit_empty_is_an_accepted_operator_decision(self):
+        assert check_playlist_assignment(PLAYLISTS, ["all"], theme="anything", explicit=[]) is None

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -212,7 +212,7 @@ def _make_preflight_config(supported_languages: list[str]) -> SimpleNamespace:
             ),
         ),
         localizations=SimpleNamespace(supported_languages=supported_languages),
-        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4330)
+        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4346)
         playlists=SimpleNamespace(items={}),
     )
 
@@ -1710,7 +1710,7 @@ def test_dedup_fails_open_for_invalid_video_response_container(tmp_path, respons
 
 
 # ---------------------------------------------------------------------------
-# Issue #4330: preflight プレイリスト割り当てゲート
+# PR #4346: preflight プレイリスト割り当てゲート
 # ---------------------------------------------------------------------------
 
 
@@ -1773,6 +1773,34 @@ class TestPreflightPlaylistAssignment:
         )
 
         checker.check(col_dir)
+
+    def test_should_fail_when_explicit_playlists_only_names_auto_add(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, {"playlists": ["all"]}, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(_CATEGORIZING_PLAYLISTS),
+        )
+
+        with pytest.raises(ValidationError, match="プレイリスト未割り当て"):
+            checker.check(col_dir)
+
+    def test_should_fail_when_categorizing_playlist_has_no_youtube_id(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        playlists = {
+            "all": {"title": "All", "auto_add": True, "playlist_id": "PL_ALL"},
+            "rain": {"title": "Rain", "auto_add_themes": ["rain"]},
+        }
+        col_dir = _write_playlist_collection(tmp_path, {"playlists": ["rain"]}, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(playlists),
+        )
+
+        with pytest.raises(ValidationError, match="playlist_id 未設定.*rain"):
+            checker.check(col_dir)
 
     def test_should_pass_when_legacy_keyword_still_matches(self, tmp_path):
         """既存コレクション（キーワードが当たる）は明示指定なしでも通る（後方互換）."""

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -212,6 +212,8 @@ def _make_preflight_config(supported_languages: list[str]) -> SimpleNamespace:
             ),
         ),
         localizations=SimpleNamespace(supported_languages=supported_languages),
+        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4330)
+        playlists=SimpleNamespace(items={}),
     )
 
 
@@ -1705,3 +1707,92 @@ def test_dedup_fails_open_for_invalid_video_response_container(tmp_path, respons
     uploader.youtube.videos.return_value.list.return_value.execute.return_value = response
 
     assert uploader.find_existing_video_by_title("Rainy Jazz") is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #4330: preflight プレイリスト割り当てゲート
+# ---------------------------------------------------------------------------
+
+
+_CATEGORIZING_PLAYLISTS = {
+    "all": {"title": "All", "auto_add": True, "playlist_id": "PL_ALL"},
+    "rain": {"title": "Rain", "auto_add_themes": ["rain"], "playlist_id": "PL_RAIN"},
+}
+
+
+def _make_playlist_config(playlists: dict) -> SimpleNamespace:
+    cfg = _make_preflight_config(["ja", "en"])
+    cfg.playlists = SimpleNamespace(items=playlists)
+    cfg.content.title.activity_for_theme = lambda _theme: "Study"
+    return cfg
+
+
+def _write_playlist_collection(tmp_path: Path, planning: dict | None, theme: str) -> Path:
+    col_dir = _write_preflight_collection(tmp_path, ["en", "ja"])
+    state = {"theme": theme, "scene_phrases": {lang: {"title": f"title-{lang}"} for lang in ("en", "ja")}}
+    if planning is not None:
+        state["planning"] = planning
+    (col_dir / "workflow-state.json").write_text(json.dumps(state), encoding="utf-8")
+    return col_dir
+
+
+class TestPreflightPlaylistAssignment:
+    """新テーマが黙って auto_add プレイリストだけに入る状態を、数 GB を送る前に弾く."""
+
+    def test_should_fail_when_theme_matches_no_categorizing_playlist(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, None, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(_CATEGORIZING_PLAYLISTS),
+        )
+
+        with pytest.raises(ValidationError, match="プレイリスト未割り当て"):
+            checker.check(col_dir)
+
+    def test_should_pass_with_explicit_planning_playlists(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, {"playlists": ["rain"]}, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(_CATEGORIZING_PLAYLISTS),
+        )
+
+        checker.check(col_dir)
+
+    def test_should_pass_with_explicit_empty_playlists(self, tmp_path):
+        """空配列 = operator が「auto_add のみ」を明示した状態は通過させる."""
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, {"playlists": []}, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(_CATEGORIZING_PLAYLISTS),
+        )
+
+        checker.check(col_dir)
+
+    def test_should_pass_when_legacy_keyword_still_matches(self, tmp_path):
+        """既存コレクション（キーワードが当たる）は明示指定なしでも通る（後方互換）."""
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, None, "rain-on-the-bar-window")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config(_CATEGORIZING_PLAYLISTS),
+        )
+
+        checker.check(col_dir)
+
+    def test_should_pass_when_channel_has_no_categorizing_playlist(self, tmp_path):
+        from youtube_automation.domains.uploads.youtube import PreflightChecker
+
+        col_dir = _write_playlist_collection(tmp_path, None, "carriage-six")
+        checker = PreflightChecker(
+            tmp_path,
+            config_loader=lambda: _make_playlist_config({"all": {"auto_add": True, "playlist_id": "PL_ALL"}}),
+        )
+
+        checker.check(col_dir)


### PR DESCRIPTION
## 問題

`config/channel/playlists.json` の `auto_add_themes` は theme slug に対する**部分一致**で割り当てを決めている。新しいテーマを作るたびにキーワードが未登録で漏れ、そのコレクションは `auto_add` のプレイリストだけに入る。

実際に運用中のチャンネルで直近 2 本連続で発生した:

| theme | 起きたこと | 手動対応 |
|---|---|---|
| `carriage-six` | `'train'` が slug に含まれず分類プレイリストに入らなかった | `'carriage'` を追加して再割り当て |
| `the-long-way-home` | どのキーワードにも当たらなかった | `'long-way'` を追加して再割り当て |

結果としてキーワード配列は「そのテーマ専用の 1 語」が積み上がり、ルールとして意味をなさなくなっていた。

**気付けない理由**が構造的で、これが本質:

- `resolve_playlists()` の戻り値は `auto_add` プレイリストが必ず入るので空にならない
- `PlaylistAssignment.assign()` は `if assigned:` でログを出すだけ → 成功に見える
- 割り当てはアップロード後に走るので、気付いた時には動画は公開済み

## 変更

割り当ての正本を `workflow-state.json::planning.playlists` に移す。

- **`yt-init-collection --playlist KEY`**（複数指定可）で init 段階に決める。分類プレイリスト（`auto_add` 以外）を定義しているチャンネルでは必須。分類しないことが意図なら `--no-playlist` で空配列を明示する
- **解決順序**: 明示指定があれば theme / activity 照合は一切行わない。未指定のときだけ従来の `auto_add_activities` / `auto_add_themes` へフォールバックするので、既存チャンネル・既存コレクションの挙動は変わらない
- **fail-loud**: 分類プレイリストに 1 つも割り当たらない状態を**アップロード preflight**が弾く。数 GB を送る前に止まり、復旧コマンド（`yt-workflow-state set-planning playlists`）を提示する
- **未知の key は `ValidationError`**。黙って無視すると「指定したのに入らない」という最も気付きにくい失敗になる
- `[]`（明示的な空）と key 欠落（未決定）を区別する。前者は operator の判断として通し、後者だけを止める

解決ロジックは API 非依存の純関数として `domains/uploads/playlist_resolution.py` に切り出し、`PlaylistManager` と preflight が共有する（preflight は YouTube clients を持たないため）。

## 互換性

- 分類プレイリストを持たないチャンネル（`playlists.json` が `auto_add` のみ、または未定義）は**完全に無変更**。`planning.playlists` キーも書かれない
- 既存コレクションはキーワードが当たる限り従来どおり通る。当たらないものは preflight で止まり、`yt-workflow-state --collection <dir> set-planning playlists '["key"]'` で解消できる
- **BREAKING**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須になる。`wf-new` skill の手順も更新済み

## テスト

- `tests/domains/uploads/test_playlist_resolution.py`（新規 18 件）— 純関数の解決順序・fail-loud・`carriage-six` / `the-long-way-home` の回帰再現
- `tests/domains/uploads/test_playlist_manager.py` — 明示指定が activity / keyword に勝つこと、空配列、未知 key、schema 違反
- `tests/domains/uploads/test_youtube_auto_uploader.py` — preflight ゲートの通過・停止条件 5 件
- `tests/commands/collections/test_init_collection.py` — `--playlist` / `--no-playlist` / 未知 key / 未指定 / フラグ競合
- `tests/domains/collections/test_workflow_state.py` — `planning.playlists` の schema 検証

全体: `uv run pytest` で 7910 passed。`tests/repo/test_actions_parallel_workflows.py` の 4 件はローカル環境起因で、この変更前の clean tree でも同じく失敗する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Maintainer review follow-up

最新 `main` へ再配置し、追加レビューで次を補強しました。

- `auto_add` のみの明示指定を分類済みと誤認しない
- 分類先の `playlist_id` 未設定を fail-loud にする
- `planning.playlists: null` を黙って legacy fallback へ流さない
- BREAKING CLI の pilot / phase2 手順例を `--playlist` / `--no-playlist` と整合
- 無関係な issue `#4330` への参照を PR `#4346` へ訂正

検証結果: 全体 9856 passed / 3 skipped、関連 342 passed。Ruff check / format、Any 型ゲート、skill lint、repository contracts、wheel build / sync はすべて成功しています。