### PR TITLE
fix(suno-helper): 形式モーダル検出を旧DOMにも対応する (#4353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。
+- `fix(suno-helper)`: ダウンロード形式モーダルを意味的なボタン構造で検証しつつ、現行 `role="dialog"` DOM と旧 `modal-class modal-overlay` DOM の両方で検出できるようにする（#4353）。
 
 - `feat(hybrid)`: 月次 `openai/codex-action` canary workflowとtyped Discord結果通知を追加し、Codex escape経路の死亡を無人検知できるようにする（#4060）。
 

--- a/extensions/suno-helper/lib/download.ts
+++ b/extensions/suno-helper/lib/download.ts
@@ -9,7 +9,8 @@ const CLIP_ROW_SELECTOR =
   '[data-testid="clip-row"], .clip-row, article, [role="group"]';
 const CONTEXT_MENU_SELECTOR = 'div[data-context-menu="true"]';
 const DOWNLOAD_MENU_ITEM_TEXT = /download\s*all/i;
-const DIALOG_SELECTOR = '[role="dialog"]';
+const FORMAT_MODAL_CANDIDATE_SELECTOR =
+  '[role="dialog"], div.modal-class.modal-overlay';
 const BUTTON_SELECTOR = "button";
 const DOWNLOAD_CONFIRM_LABEL = "Download";
 const FORMAT_OPTION_LABELS = ["M4A", "MP3", "WAV"] as const;
@@ -52,31 +53,31 @@ function findButtonByExactLabel(
   return null;
 }
 
-function isVisibleDialog(dialog: HTMLElement): boolean {
-  if (dialog.hidden || dialog.getAttribute("aria-hidden") === "true") {
+function isVisibleModal(modal: HTMLElement): boolean {
+  if (modal.hidden || modal.getAttribute("aria-hidden") === "true") {
     return false;
   }
-  const style = getComputedStyle(dialog);
+  const style = getComputedStyle(modal);
   return style.display !== "none" && style.visibility !== "hidden";
 }
 
 function resolveFormatModal(): HTMLElement | null {
-  const matchingDialogs = Array.from(
-    document.querySelectorAll<HTMLElement>(DIALOG_SELECTOR)
+  const matchingModals = Array.from(
+    document.querySelectorAll<HTMLElement>(FORMAT_MODAL_CANDIDATE_SELECTOR)
   ).filter(
-    (dialog) =>
-      isVisibleDialog(dialog) &&
+    (modal) =>
+      isVisibleModal(modal) &&
       FORMAT_OPTION_LABELS.every((label) =>
-        findButtonByExactLabel(dialog, label)
+        findButtonByExactLabel(modal, label)
       ) &&
-      findButtonByExactLabel(dialog, DOWNLOAD_CONFIRM_LABEL)
+      findButtonByExactLabel(modal, DOWNLOAD_CONFIRM_LABEL)
   );
-  if (matchingDialogs.length > 1) {
+  if (matchingModals.length > 1) {
     throw new Error(
       "ダウンロード形式モーダルが複数見つかりました。Suno の UI 変更の可能性があります。"
     );
   }
-  return matchingDialogs[0] ?? null;
+  return matchingModals[0] ?? null;
 }
 
 async function waitForFormatModal(
@@ -92,7 +93,7 @@ async function waitForFormatModal(
     await sleep(pollMs);
   }
   throw new Error(
-    `Download 確認ボタンと M4A / MP3 / WAV を持つ可視ダイアログが見つかりませんでした (${timeoutMs}ms)。` +
+    `Download 確認ボタンと M4A / MP3 / WAV を持つ可視モーダルが見つかりませんでした (${timeoutMs}ms)。` +
       "Suno の UI 変更の可能性があります。"
   );
 }

--- a/extensions/suno-helper/tests/download.test.ts
+++ b/extensions/suno-helper/tests/download.test.ts
@@ -16,6 +16,7 @@ interface FormatModalFixtureOptions {
   confirm?: boolean;
   formats?: readonly string[];
   hidden?: boolean;
+  legacy?: boolean;
   mp3Disabled?: boolean;
   testId?: string;
 }
@@ -34,7 +35,10 @@ function formatModalFixture(options: FormatModalFixtureOptions = {}): string {
     options.confirm === false
       ? ""
       : '<button class="hxc-btn-variant-primary">Download</button>';
-  return `<div role="dialog" data-open data-base-ui-focusable data-testid="${
+  const modalContract = options.legacy
+    ? 'class="modal-class modal-overlay"'
+    : 'role="dialog" data-open data-base-ui-focusable';
+  return `<div ${modalContract} data-testid="${
     options.testId ?? "format-modal"
   }"${options.hidden ? " hidden" : ""}>${formatButtons}${confirm}</div>`;
 }
@@ -282,6 +286,45 @@ describe("triggerDownloadAll", () => {
     await triggerDownloadAll("mp3");
 
     expect(clicked).toEqual(["more", "download-all", "mp3", "confirm"]);
+  });
+
+  it("DOM fixture: 旧 class 形式モーダルでも MP3 → Download を操作する", async () => {
+    vi.useFakeTimers();
+    const clicked: string[] = [];
+    vi.stubGlobal("PointerEvent", MouseEvent);
+    document.body.innerHTML = `
+      <div class="clip-browser-list-scroller">
+        <article>
+          <img src="clip.jpg" alt="" />
+          <div class="multi-select-button"><button aria-label="Deselect clip">Selected</button></div>
+          <button aria-label="More options">...</button>
+        </article>
+      </div>
+      <div data-context-menu="true">
+        <button aria-label="Download all">Download all</button>
+      </div>
+      ${formatModalFixture({ legacy: true })}
+    `;
+    const formatModal = document.querySelector<HTMLElement>(
+      '[data-testid="format-modal"]'
+    )!;
+    const mp3 = Array.from(
+      formatModal.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
+    ).find((button) => button.textContent?.trim() === "MP3")!;
+    const confirm = formatModal.querySelector<HTMLButtonElement>(
+      "button.hxc-btn-variant-primary"
+    )!;
+    mp3.addEventListener("click", () => clicked.push("mp3"));
+    confirm.addEventListener("click", () => {
+      clicked.push("confirm");
+      formatModal.remove();
+    });
+
+    const result = triggerDownloadAll("mp3");
+    await vi.advanceTimersByTimeAsync(20_000);
+
+    await expect(result).resolves.toBeUndefined();
+    expect(clicked).toEqual(["mp3", "confirm"]);
   });
 
   it("DOM fixture: Download 確定後に 10 秒超で閉じる形式選択モーダルを待てる", async () => {


### PR DESCRIPTION
## Summary

- 形式モーダル候補を現行 `role="dialog"` と旧 `modal-class modal-overlay` の両方から収集
- M4A / MP3 / WAV と Download 確定ボタンを持つ可視モーダルだけを採用し、無関係・非表示・曖昧な候補は既存どおり fail-loud
- 旧 DOM の失敗再現を追加し、現行 DOM と downloaded 通知までの既存回帰契約を維持

## Verification

- `pnpm check`
- `pnpm compile`
- Vitest: 1,462 passed
- Playwright: 18 passed
- WXT production build
- Fallow audit

Closes #4353