### PR TITLE
fix(skills): 統合済み設定の移行先を補完する (#4333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
+
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。
 

--- a/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
+++ b/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
@@ -18,19 +18,19 @@ from youtube_automation.core.errors import ConfigError
 
 @dataclass(frozen=True, slots=True)
 class SkillConfigMigration:
-    """One old config filename and its namespaced destination."""
+    """One old config filename and its consolidated destination."""
 
     target_skill: str
-    section: str
+    section: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class MigrationAction:
-    """One source file moved into one destination section."""
+    """One source file moved into a destination root or section."""
 
     source: Path
     destination: Path
-    section: str
+    section: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,8 +45,13 @@ class MigrationPlan:
 # 統合先 skill と名前空間 loader key が成立した段から移行を有効化する。
 # apply は利用者の明示実行だけで行い、旧 loader key は互換入口として維持する。
 SKILL_CONFIG_MIGRATIONS: Final[Mapping[str, SkillConfigMigration]] = {
+    "benchmark": SkillConfigMigration("channel-research", "benchmark"),
+    "collection-ideate": SkillConfigMigration("wf-new", None),
     "community-post": SkillConfigMigration("publish", "community"),
     "live-clean": SkillConfigMigration("publish", "clean"),
+    "loop-video": SkillConfigMigration("thumbnail", "loop"),
+    "lyria": SkillConfigMigration("music", "generate"),
+    "masterup": SkillConfigMigration("music", "master"),
     "suno": SkillConfigMigration("music", "prompt"),
     "suno-lyric": SkillConfigMigration("music", "lyric"),
     "metadata-audit": SkillConfigMigration("audit", "metadata"),
@@ -111,6 +116,12 @@ def build_migration_plan(
         if destination not in destinations:
             destinations[destination] = _load_mapping(destination) if destination.is_file() else {}
         destination_data = destinations[destination]
+        if migration.section is None:
+            if destination_data and destination_data != source_data:
+                raise ConfigError(f"移行先に既存内容があります: {destination} (既存内容を上書きしません)")
+            destinations[destination] = source_data
+            actions.append(MigrationAction(source, destination, migration.section))
+            continue
         existing = destination_data.get(migration.section)
         if migration.section in destination_data and existing != source_data:
             raise ConfigError(
@@ -182,7 +193,8 @@ def apply_migration_plan(plan: MigrationPlan) -> None:
 def _print_plan(channel_dir: Path, plan: MigrationPlan, *, dry_run: bool) -> None:
     prefix = "[dry-run] " if dry_run else ""
     for action in plan.actions:
-        print(f"{prefix}{action.source.name} -> {action.destination.name}::{action.section}")
+        section_suffix = f"::{action.section}" if action.section is not None else ""
+        print(f"{prefix}{action.source.name} -> {action.destination.name}{section_suffix}")
     if dry_run:
         for destination, data in plan.destinations.items():
             before = destination.read_text(encoding="utf-8").splitlines(keepends=True) if destination.is_file() else []

--- a/tests/commands/system/test_skills_migrate_config.py
+++ b/tests/commands/system/test_skills_migrate_config.py
@@ -161,6 +161,26 @@ def test_migrate_config_refuses_to_overwrite_different_existing_section(
     assert destination.read_bytes() == destination_before
 
 
+def test_migrate_config_refuses_to_overwrite_different_existing_root(
+    channel_dir: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        migrate_config,
+        "SKILL_CONFIG_MIGRATIONS",
+        {"collection-ideate": migrate_config.SkillConfigMigration("wf-new", None)},
+    )
+    source = _write_config(channel_dir, "collection-ideate", {"freshness_days": 7})
+    destination = _write_config(channel_dir, "wf-new", {"freshness_days": 3})
+    source_before = source.read_bytes()
+    destination_before = destination.read_bytes()
+
+    assert main(["migrate-config", "--channel-dir", str(channel_dir)]) == 1
+
+    assert "移行先に既存内容があります" in capsys.readouterr().err
+    assert source.read_bytes() == source_before
+    assert destination.read_bytes() == destination_before
+
+
 def test_production_cli_exposes_suno_to_music_prompt_migration(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
@@ -172,3 +192,29 @@ def test_production_cli_exposes_suno_to_music_prompt_migration(
     assert "suno.yaml -> music.yaml::prompt" in capsys.readouterr().out
     assert source.is_file()
     assert not (channel_dir / "config" / "skills" / "music.yaml").exists()
+
+
+def test_production_cli_migrates_consolidated_skill_configs_without_orphans(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    channel_dir = tmp_path / "channel"
+    (channel_dir / "config" / "skills").mkdir(parents=True)
+    sources = {
+        "collection-ideate": {"freshness_days": 7},
+        "loop-video": {"enabled": False},
+        "masterup": {"audio": {"target_duration_min": 60}},
+        "lyria": {"model": "lyria-3"},
+        "benchmark": {"scan_recent": 150},
+    }
+    for name, data in sources.items():
+        _write_config(channel_dir, name, data)
+
+    assert main(["migrate-config", "--channel-dir", str(channel_dir)]) == 0
+
+    assert _read_config(channel_dir, "wf-new") == sources["collection-ideate"]
+    assert _read_config(channel_dir, "thumbnail")["loop"] == sources["loop-video"]
+    assert _read_config(channel_dir, "music")["master"] == sources["masterup"]
+    assert _read_config(channel_dir, "music")["generate"] == sources["lyria"]
+    assert _read_config(channel_dir, "channel-research")["benchmark"] == sources["benchmark"]
+    assert all(not (channel_dir / "config" / "skills" / f"{name}.yaml").exists() for name in sources)
+    assert "孤児 skill-config" not in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- 欠落していた5種の skill config 移行先を追加
- section を持たない `wf-new` の root config 移行に対応
- 既存移行先との衝突を fail-safe に拒否する回帰テストを追加

## Verification

- 全テスト: 9,808 passed / 3 skipped
- Ruff / format
- skill catalog

Closes #4333