### PR TITLE
fix(automation-update): workspace の gitignore 同期を除外する (#4331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
+- `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/system/skills_sync/__init__.py
+++ b/src/youtube_automation/commands/system/skills_sync/__init__.py
@@ -40,9 +40,14 @@ from __future__ import annotations
 import argparse
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import Iterable
+from typing import Final, Iterable
 
 import youtube_automation
+from youtube_automation.configuration import find_workspace_root
+
+WORKSPACE_GITIGNORE_SKIP_MESSAGE: Final[str] = (
+    "workspace レイアウトのため適用対象外です。workspace 用 .gitignore を維持してください。"
+)
 
 # asset ごとの kind / wheel resource 名・開発時 fallback・デフォルト target を集約。
 # (pyproject.toml の force-include で source_subdir 配下が resource_name/ に同梱される)
@@ -183,6 +188,13 @@ def _resolve_file_target(asset: str, spec: dict[str, str], target: Path) -> Path
     if asset == "auth-template" and target.exists() and target.is_dir():
         return target / spec["default_target"]
     return target
+
+
+def _is_workspace_gitignore_target(asset: str, target: Path) -> bool:
+    if asset != "channel-gitignore":
+        return False
+    workspace_root = find_workspace_root(target.parent)
+    return workspace_root is not None and target == workspace_root / ".gitignore"
 
 
 def _guard_target_with_all(args: argparse.Namespace) -> None:

--- a/src/youtube_automation/commands/system/skills_sync/_diff.py
+++ b/src/youtube_automation/commands/system/skills_sync/_diff.py
@@ -9,9 +9,11 @@ from pathlib import Path
 
 from youtube_automation.commands.system.skills_sync import (
     _ASSET_SPECS,
+    WORKSPACE_GITIGNORE_SKIP_MESSAGE,
     _asset_root,
     _distribution_entries,
     _guard_target_with_all,
+    _is_workspace_gitignore_target,
     _resolve_file_target,
 )
 from youtube_automation.commands.system.skills_sync._ops import _has_diff, _prunable_orphan_names
@@ -58,6 +60,9 @@ def _diff_all(args: argparse.Namespace) -> int:
 
 def _diff_file_asset(asset: str, spec: dict[str, str], root: Path, target: Path) -> int:
     target = _resolve_file_target(asset, spec, target)
+    if _is_workspace_gitignore_target(asset, target):
+        print(WORKSPACE_GITIGNORE_SKIP_MESSAGE)
+        return 0
     src = root / spec["source_filename"]
     if not target.exists():
         print(f"target が存在しません: {target}", file=sys.stderr)

--- a/src/youtube_automation/commands/system/skills_sync/_sync.py
+++ b/src/youtube_automation/commands/system/skills_sync/_sync.py
@@ -9,8 +9,10 @@ from pathlib import Path
 from youtube_automation.commands.system.skills_sync import (
     _ASSET_SPECS,
     _DEV_ONLY_SKILL_NAMES,
+    WORKSPACE_GITIGNORE_SKIP_MESSAGE,
     _asset_root,
     _guard_target_with_all,
+    _is_workspace_gitignore_target,
     _list_entries,
     _resolve_file_target,
 )
@@ -132,6 +134,13 @@ def _sync_file_asset(
     src = root / spec["source_filename"]
     target = _resolve_file_target(args.asset, spec, target)
     _ensure_target_parent(target)
+
+    if _is_workspace_gitignore_target(args.asset, target):
+        print(f"  {'skipped':>8}: {target.name}")
+        print(f"  {WORKSPACE_GITIGNORE_SKIP_MESSAGE}")
+        print()
+        print("完了: 1 件処理 — {'skipped': 1}")
+        return 0
 
     if args.asset == "channel-gitignore" and (target.exists() or target.is_symlink()):
         print(f"  {'skipped':>8}: {target.name}")

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -171,6 +171,22 @@ def test_cmd_sync_never_overwrites_existing_channel_gitignore_even_with_force(
     assert "migrate-state-git" in capsys.readouterr().out
 
 
+def test_cmd_sync_should_not_create_channel_gitignore_at_workspace_root(
+    fake_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "channels" / "ambient" / "config" / "channel").mkdir(parents=True)
+    monkeypatch.chdir(workspace)
+
+    parser = build_parser()
+    args = parser.parse_args(["sync", "--asset", "channel-gitignore", "--force"])
+    skills_sync._resolve_default_target(args)
+    assert args.func(args) == 0
+
+    assert not (workspace / ".gitignore").exists()
+    assert "workspace レイアウトのため適用対象外" in capsys.readouterr().out
+
+
 def test_migrate_state_git_requires_explicit_channel_dir() -> None:
     parser = build_parser()
     with pytest.raises(SystemExit) as exc_info:
@@ -1008,6 +1024,28 @@ def test_cmd_diff_claude_md_does_not_emit_prune_hint(
     assert rc == 0
     out = capsys.readouterr().out
     assert "--prune" not in out
+
+
+def test_cmd_diff_should_ignore_channel_gitignore_difference_at_workspace_root(
+    fake_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    workspace = tmp_path / "workspace"
+    (workspace / "channels" / "ambient" / "config" / "channel").mkdir(parents=True)
+    gitignore = workspace / ".gitignore"
+    gitignore.write_text(
+        ".claude/settings.local.json\nchannels/*/auth/client_secrets.json\nchannels/*/auth/token*.json\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(workspace)
+
+    parser = build_parser()
+    args = parser.parse_args(["diff", "--asset", "channel-gitignore"])
+    skills_sync._resolve_default_target(args)
+    assert args.func(args) == 0
+
+    output = capsys.readouterr().out
+    assert "workspace レイアウトのため適用対象外" in output
+    assert "内容が異なる" not in output
 
 
 # ---------- cmd_sync --prune ----------


### PR DESCRIPTION
## Summary

- workspace root の `channel-gitignore` asset を sync 対象外に変更
- diff 判定も同じ契約へ揃え、`--force-sync` で既存 OAuth secret ignore を消さない
- sync 回帰テストを追加

## Verification

- 全テスト: 9,808 passed / 3 skipped
- Ruff / format / catalog / Any型 gate

Closes #4331