### PR TITLE
fix(hybrid): state Git移行をworkspace対応する (#4332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
 - `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。
+- `fix(hybrid)`: `yt-skills migrate-state-git` が workspace root の集約 `.gitignore` を利用し、既追跡の制御面 JSON を移行済みとして検査できるようにする（#4332）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/system/skills_sync/_state_git.py
+++ b/src/youtube_automation/commands/system/skills_sync/_state_git.py
@@ -25,8 +25,8 @@ def _print_plan(context: StateGitContext) -> None:
             difflib.unified_diff(
                 before,
                 after,
-                fromfile=f"{context.gitignore.relative_to(context.channel_dir)} (before)",
-                tofile=f"{context.gitignore.relative_to(context.channel_dir)} (after)",
+                fromfile=f"{context.gitignore.relative_to(context.repository)} (before)",
+                tofile=f"{context.gitignore.relative_to(context.repository)} (after)",
             )
         ),
         end="",

--- a/src/youtube_automation/infrastructure/vcs/state_git.py
+++ b/src/youtube_automation/infrastructure/vcs/state_git.py
@@ -61,6 +61,17 @@ def state_gitignore_block() -> str:
     return template[marker_at:].rstrip() + "\n"
 
 
+def _workspace_state_gitignore_block() -> str:
+    channel_lines = state_gitignore_block().splitlines()
+    workspace_lines = [channel_lines[0], "!channels/", "!channels/*/"]
+    workspace_lines.extend(f"!channels/*/{line.removeprefix('!')}" for line in channel_lines[1:])
+    return "\n".join(workspace_lines) + "\n"
+
+
+def _uses_workspace_gitignore(context: StateGitContext) -> bool:
+    return context.channel_dir != context.repository and context.gitignore == context.repository / ".gitignore"
+
+
 def _run_git(repository: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", *args],
@@ -172,8 +183,15 @@ def build_pull_context(channel_dir: Path) -> StateGitContext:
     repository = Path(top_level.stdout.strip()).resolve()
     if not channel.is_relative_to(repository):
         raise ConfigError(f"channel directory が Git repository 外です: {channel}")
-    gitignore = channel / ".gitignore"
-    _regular_file(gitignore, label="channel .gitignore")
+    channel_gitignore = channel / ".gitignore"
+    if channel_gitignore.exists() or channel_gitignore.is_symlink():
+        _regular_file(channel_gitignore, label="channel .gitignore")
+        gitignore = channel_gitignore
+    elif channel.parent.name == "channels" and channel.parent.parent == repository:
+        gitignore = repository / ".gitignore"
+        _regular_file(gitignore, label="workspace .gitignore")
+    else:
+        _regular_file(channel_gitignore, label="channel .gitignore")
     return StateGitContext(channel, repository, gitignore, ())
 
 
@@ -255,7 +273,7 @@ def _ignored_policy_paths(context: StateGitContext) -> tuple[str, ...]:
 
 def check_state_git(context: StateGitContext) -> tuple[str, ...]:
     diagnostics: list[str] = []
-    if STATE_GITIGNORE_MARKER not in _read_gitignore(context):
+    if not _uses_workspace_gitignore(context) and STATE_GITIGNORE_MARKER not in _read_gitignore(context):
         diagnostics.append(f"Git管理ポリシーがありません: {_repo_relative(context, context.gitignore)}")
     for relative in _ignored_policy_paths(context):
         diagnostics.append(f"制御面JSONがignoreされています: {relative}")
@@ -281,7 +299,7 @@ def check_state_git(context: StateGitContext) -> tuple[str, ...]:
 
 def planned_gitignore(context: StateGitContext) -> str:
     current = _read_gitignore(context)
-    block = state_gitignore_block()
+    block = _workspace_state_gitignore_block() if _uses_workspace_gitignore(context) else state_gitignore_block()
     if current.endswith(block):
         return current
     if block in current:

--- a/tests/commands/system/test_state_git_migration.py
+++ b/tests/commands/system/test_state_git_migration.py
@@ -49,6 +49,16 @@ def _write_control_files(channel: Path) -> tuple[Path, ...]:
     return state, tracking, post_publish, pinned
 
 
+def _init_workspace(path: Path, *, gitignore: str = "channels/*/collections/**/*.mp3\n") -> tuple[Path, Path]:
+    workspace = _init_repo(path, gitignore=gitignore)
+    channel = workspace / "channels" / "ambient"
+    (channel / "config" / "channel").mkdir(parents=True)
+    (channel / "config" / "channel" / "meta.json").write_text('{"channel": {"name": "ambient"}}\n', encoding="utf-8")
+    assert _git(workspace, "add", "-f", "channels/ambient/config/channel/meta.json").returncode == 0
+    assert _git(workspace, "commit", "-qm", "add channel").returncode == 0
+    return workspace, channel
+
+
 def test_dry_run_lists_only_channel_control_files_without_mutation(tmp_path: Path, capsys) -> None:
     channel = _init_repo(tmp_path / "channel")
     files = _write_control_files(channel)
@@ -82,6 +92,63 @@ def test_apply_stages_policy_and_control_files_then_check_passes_after_commit(tm
 
     assert _git(channel, "commit", "-qm", "manage state").returncode == 0
     assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 0
+
+
+def test_workspace_check_passes_with_root_gitignore_when_control_files_are_tracked(
+    tmp_path: Path,
+) -> None:
+    workspace, channel = _init_workspace(tmp_path / "workspace")
+    files = _write_control_files(channel)
+    assert _git(workspace, "add", *(path.relative_to(workspace).as_posix() for path in files)).returncode == 0
+    assert _git(workspace, "commit", "-qm", "manage state").returncode == 0
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 0
+
+
+def test_workspace_dry_run_targets_root_gitignore_without_mutation(tmp_path: Path, capsys) -> None:
+    workspace, channel = _init_workspace(tmp_path / "workspace")
+    _write_control_files(channel)
+    before = (workspace / ".gitignore").read_bytes()
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 0
+
+    assert ".gitignore (before)" in capsys.readouterr().out
+    assert (workspace / ".gitignore").read_bytes() == before
+
+
+def test_workspace_apply_stages_root_policy_and_channel_control_files(tmp_path: Path) -> None:
+    workspace, channel = _init_workspace(tmp_path / "workspace")
+    files = _write_control_files(channel)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+
+    assert STATE_GITIGNORE_MARKER in (workspace / ".gitignore").read_text(encoding="utf-8")
+    staged = set(_git(workspace, "diff", "--cached", "--name-only").stdout.splitlines())
+    assert staged == {".gitignore", *(path.relative_to(workspace).as_posix() for path in files)}
+    assert _git(workspace, "commit", "-qm", "migrate state").returncode == 0
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 0
+
+
+def test_workspace_apply_unignores_control_files_from_root_policy(tmp_path: Path) -> None:
+    workspace, channel = _init_workspace(tmp_path / "workspace", gitignore="*.json\n")
+    files = _write_control_files(channel)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel)]) == 0
+
+    staged = set(_git(workspace, "diff", "--cached", "--name-only").stdout.splitlines())
+    assert staged == {".gitignore", *(path.relative_to(workspace).as_posix() for path in files)}
+
+
+def test_workspace_rejects_symlinked_root_gitignore(tmp_path: Path, capsys) -> None:
+    workspace, channel = _init_workspace(tmp_path / "workspace")
+    outside = tmp_path / "outside-ignore"
+    outside.write_text("*.json\n", encoding="utf-8")
+    (workspace / ".gitignore").unlink()
+    (workspace / ".gitignore").symlink_to(outside)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--check"]) == 1
+
+    assert "symlink" in capsys.readouterr().err
 
 
 def test_apply_is_idempotent_while_generated_changes_are_staged(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- workspace root の集約 `.gitignore` を検出して state Git migration に使用
- 既追跡 state の check と root policy の dry-run / apply に対応
- workspace layout の回帰テストを追加

## Verification

- 全テスト: 9,811 passed
- 品質・packaging gate

Closes #4332