### PR TITLE
fix(masterup): 不完全なSuno生成の明示続行を可能にする (#4336)

### DIFF
--- a/.claude/skills/music/references/master.md
+++ b/.claude/skills/music/references/master.md
@@ -195,7 +195,7 @@ print(f'pattern_count={pattern_count} expected={expected} actual={actual}')
 
 判定:
 - **`actual == 0`**: `/music --generate` 未実行として「`/music --generate` を実行してダウンロードを完了してください」を案内して停止
-- **`0 < actual < expected`**: 部分ダウンロードとして扱う。`assets.music_downloaded` が `true` であっても揃っているとはみなさない。不足曲数（`expected - actual`）を提示し、「`/music --generate` を再実行して不足分を DL するか、Suno UI から手動で不足曲をダウンロードして `02-Individual-music/` に配置してください」を案内して停止
+- **`0 < actual < expected`**: 部分ダウンロードとして扱う。`assets.music_downloaded` が `true` であっても揃っているとはみなさない。不足曲数（`expected - actual`）を提示し、「`/music --generate` を再実行して不足分を DL するか、Suno UI から手動で不足曲をダウンロードして `02-Individual-music/` に配置してください」を案内して既定では停止する。ユーザーが欠落込みの続行を明示指示した場合だけ、Step 4.5 の `--allow-incomplete-download` 手順へ進む
 - 定期実行の extension state が `checkpoint` / `manual-intervention` / `running` の場合も、実ファイル数・`planning.music.suno_playlist_url`・`assets.music_downloaded` が揃うまでは停止する。extension state の `completed` は補助情報であり、この実ファイル突合を代替しない
 - **`actual >= expected`**: チェック OK として Step 1.6 へ進む
 
@@ -217,8 +217,8 @@ fallback path（Step 2-3 で DL する場合）は従来どおり Step 2 の Web
 判定:
 - **unknown（どの entry にも一致しない曲）**: 別コレクション由来の混入。playlist から除外するまで Step 5 に進まない
 - **missing（playlist に存在しない entry）**: 生成漏れ。`/music --generate` で追補生成するまで Step 5 に進まない
-- **underfilled（clip 数が期待未満の entry）**: 生成が途中で止まった疑い。既定は 2 clip/entry（`--expected-clips-per-entry` で調整、`0` で無効化）
-- 非 0 終了時はレポートをそのままユーザーへ提示して停止する。**ユーザーが混入込みでの続行を明示指示した場合のみ**、混入内容と影響（世界観不整合・メタデータずれ）を報告した上で続行できる
+- **underfilled（clip 数が期待未満の entry）**: 生成が途中で止まった疑い。既定は 2 clip/entry（`--expected-clips-per-entry` で調整、`0` で無効化）。既定では停止し、Step 1.5 で欠落込みの続行が明示承認済みの場合だけ Step 4.5 の `--allow-incomplete-download` 手順へ進める
+- 非 0 終了時はレポートをそのままユーザーへ提示して既定では停止する。unknown は、ユーザーが混入込みでの続行を明示指示した場合のみ、混入内容と影響（世界観不整合・メタデータずれ）を報告した上で続行できる。underfilled だけの非 0 は前項の明示承認時のみ例外とし、clip が 0 件の missing entry は引き続き停止する
 
 > **背景**: playlist には「最新セットの生成が未完のまま、前後コレクションの曲が混入する」事故が繰り返し起きている（実例: 深夜コレクションに昼テーマ 2 ペアが混入 + 深夜 2 entry 未生成のまま master 化）。曲名は `/music --generate` が Song Title 欄へ注入する `entry.title ?? entry.name` で一意なため、機械突合で確実に検出できる。silent な続行は禁止。
 
@@ -283,6 +283,17 @@ uv run yt-suno-select-tracks <collection-path>
    - 尺フィルタで落ちた clip だけ除外し、残った clip は `01a-...` / `01b-...` のまま `uv run yt-generate-master` に渡す
 
 `lyrics` が `[Instrumental]` / `[Extended Outro]` などタグだけの場合は歌詞なしとして扱う。選別ログは `pair_selection.selection_log_path`（既定 `01-master/.selection.log`）に残す。
+
+**2 clip 未満の prompt を含む場合の例外続行**:
+
+既定では prompt ごとに 2 clip が必要であり、不足分の追補生成を優先する。各 prompt に少なくとも 1 clip は存在するものの、Suno の一部生成失敗などで追補せず続行することをユーザーが明示承認した場合だけ、不足 prompt と `実数/2`、instrumental の収録曲数が減る影響、vocal の代替候補がない影響を提示し、次の順で実行する。
+
+```bash
+uv run yt-suno-select-tracks --dry-run <collection-path> --allow-incomplete-download
+uv run yt-suno-select-tracks <collection-path> --allow-incomplete-download
+```
+
+このフラグが無効化するのは初期の 2 clip 完了検査だけである。`pair_selection.min_song_sec` / `max_song_sec` の尺フィルタ、命名・duration probe、尺フィルタ後に候補 0 件となる prompt の停止は維持する。dry-run で `[dropped_under_min]` が出た場合は、通常どおり本実行前に別途続行確認を取る。
 
 **max_song_sec 超過だけで全落ちした場合の復旧**:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。
 - `fix(hybrid)`: `yt-skills migrate-state-git` が workspace root の集約 `.gitignore` を利用し、既追跡の制御面 JSON を移行済みとして検査できるようにする（#4332）。
 - `fix(skills)`: 統廃合で削除した 42 skill を `yt-skills sync --prune` の既知削除対象へ登録し、未知の自作 skill を保護したまま旧配布ディレクトリを明示承認付きで削除できるようにする（#4334）。
+- `fix(masterup)`: `yt-suno-select-tracks` に 2 clip 未満の prompt を明示承認後も尺フィルタ付きで処理できる `--allow-incomplete-download` を追加する（#4336）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/suno/suno_select_tracks.py
+++ b/src/youtube_automation/commands/suno/suno_select_tracks.py
@@ -35,6 +35,11 @@ def main() -> int:
         action="store_true",
         help="全候補が max_song_sec 超過した prompt は最短候補を警告付きで例外採用する",
     )
+    parser.add_argument(
+        "--allow-incomplete-download",
+        action="store_true",
+        help="2 clip 未満の prompt を許可する（尺フィルタ後に候補 0 件なら停止）",
+    )
     args = parser.parse_args()
 
     try:
@@ -45,6 +50,7 @@ def main() -> int:
             cfg,
             dry_run=args.dry_run,
             allow_best_effort_over_max=args.allow_best_effort_over_max,
+            allow_incomplete_download=args.allow_incomplete_download,
         )
     except (ValidationError, OSError, json.JSONDecodeError) as exc:
         print(f"ERROR: {exc}", file=sys.stderr)

--- a/src/youtube_automation/domains/suno/selection.py
+++ b/src/youtube_automation/domains/suno/selection.py
@@ -867,6 +867,7 @@ def select_suno_tracks(
     *,
     dry_run: bool = False,
     allow_best_effort_over_max: bool = False,
+    allow_incomplete_download: bool = False,
 ) -> SelectionResult:
     parsed_cfg = parse_selection_config(cfg, collection_dir)
     if parsed_cfg.pair.mode == "never":
@@ -877,7 +878,8 @@ def select_suno_tracks(
         candidates = collect_candidates(collection_dir, prompts)
     except AmbiguousSunoNameError as exc:
         raise ValidationError(str(exc)) from exc
-    _validate_download_complete(prompts, candidates)
+    if not allow_incomplete_download:
+        _validate_download_complete(prompts, candidates)
     plan = _plan_suno_selection(
         collection_dir=collection_dir,
         prompts=prompts,

--- a/tests/commands/suno/test_suno_select_tracks.py
+++ b/tests/commands/suno/test_suno_select_tracks.py
@@ -827,6 +827,45 @@ def test_missing_initial_second_clip_fails_before_duration_filter(tmp_path, monk
     assert not (collection / "01-master" / ".selection.log").exists()
 
 
+def test_should_keep_single_clip_when_incomplete_download_is_allowed(tmp_path, monkeypatch):
+    collection = _make_collection(
+        tmp_path,
+        [{"name": "夜明け — Dawn Groove", "lyrics": ""}],
+    )
+    source = _write_audio(collection, "01a-Dawn Groove.mp3")
+    monkeypatch.setattr(suno_track_selection, "probe_duration", lambda _: 120.0)
+
+    result = suno_track_selection.select_suno_tracks(
+        collection,
+        _cfg(),
+        dry_run=True,
+        allow_incomplete_download=True,
+    )
+
+    assert result.kept == [source]
+    assert result.dropped == []
+    assert source.exists()
+
+
+def test_should_enforce_duration_filter_when_incomplete_download_is_allowed(tmp_path, monkeypatch):
+    collection = _make_collection(
+        tmp_path,
+        [{"name": "夜明け — Dawn Groove", "lyrics": ""}],
+    )
+    source = _write_audio(collection, "01a-Dawn Groove.mp3")
+    monkeypatch.setattr(suno_track_selection, "probe_duration", lambda _: 20.0)
+
+    with pytest.raises(ValidationError, match="採用候補が 0 件"):
+        suno_track_selection.select_suno_tracks(
+            collection,
+            _cfg(),
+            allow_incomplete_download=True,
+        )
+
+    assert source.exists()
+    assert not (collection / "01-master" / ".selection.log").exists()
+
+
 def test_invalid_audio_filename_fails_loud(tmp_path, monkeypatch):
     collection = _make_collection(
         tmp_path,
@@ -966,6 +1005,25 @@ def test_main_passes_best_effort_over_max_flag(tmp_path, monkeypatch, capsys):
 
     assert suno_select_tracks.main() == 0
     assert "exceptions_over_limit=1" in capsys.readouterr().out
+
+
+def test_main_should_pass_allow_incomplete_download_flag(tmp_path, monkeypatch, capsys):
+    collection = _make_collection(
+        tmp_path,
+        [{"name": "夜明け — Dawn Groove", "lyrics": ""}],
+    )
+    source = _write_audio(collection, "01a-Dawn Groove.mp3")
+    monkeypatch.setattr(suno_track_selection, "probe_duration", lambda _: 120.0)
+    monkeypatch.setattr(suno_select_tracks, "load_skill_config", lambda _: _cfg())
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["yt-suno-select-tracks", "--dry-run", str(collection), "--allow-incomplete-download"],
+    )
+
+    assert suno_select_tracks.main() == 0
+    assert source.exists()
+    assert "kept=1" in capsys.readouterr().out
 
 
 def test_main_returns_1_and_stderr_on_validation_error(tmp_path, monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- `yt-suno-select-tracks --allow-incomplete-download` を追加
- entry あたり2 clip未満でも、明示指定時だけ選別を続行
- 尺・命名・probe の既存検証は維持し、skill手順と回帰テストを更新

## Verification

- 全テスト: 9,809 passed / 3 skipped
- 関連 lint / quality gates

Closes #4336