### PR TITLE
fix(skills): 旧videoスキルをprune対象にする (#4337)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(hybrid)`: `yt-skills migrate-state-git` が workspace root の集約 `.gitignore` を利用し、既追跡の制御面 JSON を移行済みとして検査できるようにする（#4332）。
 - `fix(skills)`: 統廃合で削除した 42 skill を `yt-skills sync --prune` の既知削除対象へ登録し、未知の自作 skill を保護したまま旧配布ディレクトリを明示承認付きで削除できるようにする（#4334）。
 - `fix(masterup)`: `yt-suno-select-tracks` に 2 clip 未満の prompt を明示承認後も尺フィルタ付きで処理できる `--allow-incomplete-download` を追加する（#4336）。
+- `fix(skills)`: `/video` 統合後も下流に残る旧 `/video-description` / `/videoup` を既知の prune 対象として検出し、古い `descriptions.md` 生成契約を明示削除できるようにする（#4337）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/tests/commands/system/test_skills_sync.py
+++ b/tests/commands/system/test_skills_sync.py
@@ -1242,6 +1242,36 @@ def test_cmd_sync_prune_removes_known_removed_skill_when_yes(fake_repo: Path, tm
     assert not orphan.exists()
 
 
+def test_cmd_sync_prune_replaces_legacy_video_skills_with_video_owner(
+    fake_repo: Path,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    bundled_video = fake_repo / ".claude" / "skills" / "video"
+    bundled_video.mkdir()
+    (bundled_video / "SKILL.md").write_text("# video owner\n", encoding="utf-8")
+    target = tmp_path / "out" / ".claude" / "skills"
+    _seed_bundled_target(target)
+    legacy_skills = (target / "video-description", target / "videoup")
+    for legacy_skill in legacy_skills:
+        legacy_skill.mkdir()
+        (legacy_skill / "SKILL.md").write_text("# legacy\n", encoding="utf-8")
+
+    parser = build_parser()
+    diff_args = parser.parse_args(["diff", "--asset", "skills", "--target", str(target)])
+    assert diff_args.func(diff_args) == 0
+    diff_output = capsys.readouterr().out
+    assert "upstream 管理の既知の旧 skill (prune 候補)" in diff_output
+    assert all(f"  - {legacy_skill.name}" in diff_output for legacy_skill in legacy_skills)
+
+    args = parser.parse_args(["sync", "--asset", "skills", "--target", str(target), "--force", "--prune", "--yes"])
+    rc = args.func(args)
+
+    assert rc == 0
+    assert (target / "video" / "SKILL.md").read_text(encoding="utf-8") == "# video owner\n"
+    assert all(not legacy_skill.exists() for legacy_skill in legacy_skills)
+
+
 def test_cmd_sync_prune_preserves_user_skill(fake_repo: Path, tmp_path: Path) -> None:
     """同梱外の未知 skill はユーザー作成の可能性があるため prune しない。"""
     target = tmp_path / "out" / ".claude" / "skills"


### PR DESCRIPTION
## Summary

- 旧 `/video-description` と `/videoup` を既知 prune 対象へ追加
- 正準 `/video` を残したまま、食い違う旧 SKILL.md を削除可能にする
- prune 回帰テストを追加

## Verification

- 全品質ゲート green

Closes #4337