### PR TITLE
fix(upload): 目標尺外アップロードの明示許可を追加する (#4338)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(skills)`: 統廃合で削除した 42 skill を `yt-skills sync --prune` の既知削除対象へ登録し、未知の自作 skill を保護したまま旧配布ディレクトリを明示承認付きで削除できるようにする（#4334）。
 - `fix(masterup)`: `yt-suno-select-tracks` に 2 clip 未満の prompt を明示承認後も尺フィルタ付きで処理できる `--allow-incomplete-download` を追加する（#4336）。
 - `fix(skills)`: `/video` 統合後も下流に残る旧 `/video-description` / `/videoup` を既知の prune 対象として検出し、古い `descriptions.md` 生成契約を明示削除できるようにする（#4337）。
+- `fix(upload)`: `yt-upload-collection` に `--allow-duration-outside-target` を追加し、operator の明示判断で目標尺外動画の preflight を通過できるようにする（#4338）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/uploads/collection_uploader.py
+++ b/src/youtube_automation/commands/uploads/collection_uploader.py
@@ -24,6 +24,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--daemon", "-d", action="store_true")
     parser.add_argument("--collection", "-c")
     parser.add_argument("--config")
+    parser.add_argument(
+        "--allow-duration-outside-target",
+        action="store_true",
+        help="operator 判断で config/channel/audio.json の目標尺外を明示許可する",
+    )
     return parser
 
 
@@ -31,6 +36,7 @@ def run(args: argparse.Namespace) -> None:
     uploader = CollectionUploader(
         config_path=args.config,
         youtube_clients=create_authenticated_youtube_clients(),
+        allow_duration_outside_target=getattr(args, "allow_duration_outside_target", False),
     )
     if args.daemon:
         uploader.run_automated_schedule()

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -23,6 +23,7 @@ from youtube_automation.domains.uploads._collection_uploader_constants import (
 )
 from youtube_automation.domains.uploads._complete_collection_executor import CompleteCollectionExecutor
 from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssignment
+from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
@@ -72,6 +73,7 @@ class CollectionUploader:
         published_dates: PublishedDatesScheduler | None = None,
         playlist_assignment: PlaylistAssignment | None = None,
         complete_collection_executor: CompleteCollectionExecutor | None = None,
+        allow_duration_outside_target: bool = False,
     ):
         if collections_root is None:
             collections_root = channel_dir() / "collections"
@@ -81,7 +83,14 @@ class CollectionUploader:
 
         self.collections_root = Path(collections_root)
         self.config_path = Path(config_path)
-        self.uploader = YouTubeAutoUploader(str(collections_root), youtube_clients)
+        self.uploader = YouTubeAutoUploader(
+            str(collections_root),
+            youtube_clients,
+            preflight_checker=PreflightChecker(
+                self.collections_root,
+                allow_duration_outside_target=allow_duration_outside_target,
+            ),
+        )
         self.config = self._load_config()
         self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
         self.youtube_service = None

--- a/tests/commands/uploads/test_upload_cli_error_boundary.py
+++ b/tests/commands/uploads/test_upload_cli_error_boundary.py
@@ -159,10 +159,39 @@ def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expecte
 
     assert collection_uploader.main(argv) == 0
 
-    factory.assert_called_once_with(config_path="/config.json", youtube_clients=clients)
+    factory.assert_called_once_with(
+        config_path="/config.json",
+        youtube_clients=clients,
+        allow_duration_outside_target=False,
+    )
     uploader.find_collection.assert_called_once_with("slug")
     assert uploader.ensure_upload_preflight.called is preflight
     getattr(uploader, expected_action).assert_called_once_with(target)
+
+
+def test_collection_cli_forwards_duration_override_to_uploader(monkeypatch):
+    from youtube_automation.commands.uploads import collection_uploader
+
+    # Given: 対象 collection が見つからない副作用なしの uploader
+    uploader = SimpleNamespace(find_collection=MagicMock(return_value=None))
+    factory = MagicMock(return_value=uploader)
+    clients = object()
+    monkeypatch.setattr(collection_uploader, "CollectionUploader", factory)
+    monkeypatch.setattr(
+        collection_uploader,
+        "create_authenticated_youtube_clients",
+        MagicMock(return_value=clients),
+    )
+
+    # When: operator が目標尺外を明示許可する
+    assert collection_uploader.main(["--allow-duration-outside-target"]) == 0
+
+    # Then: CLI の opt-in が domain constructor へ伝わる
+    factory.assert_called_once_with(
+        config_path=None,
+        youtube_clients=clients,
+        allow_duration_outside_target=True,
+    )
 
 
 def test_collection_cli_daemon_skips_collection_lookup(monkeypatch):

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -375,6 +375,20 @@ def test_collection_uploader_accepts_injected_tracking_store(tmp_path: Path) -> 
     assert uploader.tracking_store is store
 
 
+def test_collection_uploader_forwards_duration_override_to_preflight_checker(tmp_path: Path) -> None:
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    # Given/When: operator の目標尺外 opt-in 付きで uploader を構築する
+    uploader = CollectionUploader(
+        collections_root=str(tmp_path / "collections"),
+        config_path=str(tmp_path / "schedule_config.json"),
+        allow_duration_outside_target=True,
+    )
+
+    # Then: 実アップロード前に使う checker が同じ opt-in を保持する
+    assert uploader.uploader.preflight_checker.allow_duration_outside_target is True
+
+
 def test_collection_uploader_accepts_injected_published_dates(tmp_path: Path) -> None:
     from youtube_automation.domains.uploads.collection import CollectionUploader
 


### PR DESCRIPTION
## Summary

- `yt-upload-collection --allow-duration-outside-target` を追加
- 明示許可を upload preflight まで伝播
- 既定では従来どおり目標尺外を拒否する回帰契約を維持

## Verification

- 関連118 tests
- 全体9,807 tests + timeout対象の単独再実行
- lint / format / catalog

Closes #4338