### PR TITLE
fix(video-upload): 空のlocalizationsで生成済み翻訳を消さない (#4339)

### DIFF
--- a/.claude/skills/publish/references/upload.md
+++ b/.claude/skills/publish/references/upload.md
@@ -123,7 +123,10 @@ $ARGUMENTS
 2. **live 移動** — `collections/planning/` → `collections/live/`
 3. **公開後処理** — フラグなし chain では upload 完了後も manifest 順の `community → pinned` を続行する。各段の承認と成果物ベースの再開契約に委ね、ここで個別処理を再実装しない。`/publish --upload` の単独 mode では後段を暗黙実行せず、`/publish --community`、`/publish --pinned`、`/audit --metadata` は必要に応じて独立実行する
 
-メタデータは共通readerで検証した `descriptions.json` の title / description / tags / localizations だけを使用する。HTMLや旧Markdownはparseせず、pair欠損・schema/quality不正時はfallbackせず停止する。
+メタデータの title / description / tags は共通readerで検証した `descriptions.json` の値を使用する。
+`localizations` が非空なら同文書の値を最終翻訳として使用し、空 object なら `workflow-state.json` の
+`scene_phrases` から metadata generator が生成した翻訳を維持する。HTMLや旧Markdownはparseせず、
+pair欠損・schema/quality不正時はfallbackせず停止する。
 
 承認済みタイトルを 100 codepoint 以下へ短縮する必要が生じた場合は、旧版と短縮案を codepoint 数付き diff として提示し、ユーザーの再承認を得るまで `descriptions.json` pair の更新や upload を行わない。`--plan` は primary title だけでなく保存済み全 locale title を検証し、超過 locale を言語・文字数・実タイトル付きで fail-loud にする。
 

--- a/.claude/skills/video/references/video-description-documents.md
+++ b/.claude/skills/video/references/video-description-documents.md
@@ -19,5 +19,9 @@ uv run yt-document-migrate <candidate.json> \
 HTML 再生成照合、JSON/HTML 再読込が成功した後だけ Markdown を削除し、workflow-state owner 経由で
 `assets.description = true` にする。失敗時は旧 Markdown、pair、state を rollback する。
 
+localizations が非空なら、その値を upload 時の最終翻訳として使う。localizations が空 object の場合は
+「文書側に最終翻訳なし」と扱い、workflow-state.json の scene_phrases から metadata generator が生成した
+翻訳を維持する。空 object で生成済み翻訳を消してはならない。
+
 localization の必須値、title 上限、quality status / 各 check のいずれかが不正なら公開しない。
 公開済み pair の片方欠損・改変も state / preflight / upload を成功扱いにしない。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(masterup)`: `yt-suno-select-tracks` に 2 clip 未満の prompt を明示承認後も尺フィルタ付きで処理できる `--allow-incomplete-download` を追加する（#4336）。
 - `fix(skills)`: `/video` 統合後も下流に残る旧 `/video-description` / `/videoup` を既知の prune 対象として検出し、古い `descriptions.md` 生成契約を明示削除できるようにする（#4337）。
 - `fix(upload)`: `yt-upload-collection` に `--allow-duration-outside-target` を追加し、operator の明示判断で目標尺外動画の preflight を通過できるようにする（#4338）。
+- `fix(video-upload)`: `descriptions.json::localizations` が空でも `scene_phrases` から生成済みの翻訳を維持し、ja/de 等がアップロード時に消える問題を修正する（#4339）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_strategy.py
@@ -115,7 +115,10 @@ class CompleteCollectionStrategy:
             if prebuilt["tags"]:
                 metadata["tags"] = prebuilt["tags"]
 
-            metadata["localizations"] = prebuilt["localizations"]
+            # 空 object は「文書側に最終翻訳なし」を表すため、scene_phrases から
+            # metadata generator が組み立てた翻訳を消さない。非空なら承認済み文書を優先する。
+            if prebuilt["localizations"]:
+                metadata["localizations"] = prebuilt["localizations"]
 
         if publish_at:
             metadata["publish_at"] = publish_at

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -1114,6 +1114,50 @@ class TestUploadCompleteCollectionDedup:
         assert result["video_id"] == "VID_NEW"
         assert result["upload_source"] == "new_upload"
 
+    @pytest.mark.parametrize(
+        ("document_localizations", "expected_localizations"),
+        [
+            ({}, {"ja": {"title": "生成済みタイトル", "description": "生成済み概要"}}),
+            (
+                {"de": {"title": "Freigegebener Titel", "description": "Freigegebene Beschreibung"}},
+                {"de": {"title": "Freigegebener Titel", "description": "Freigegebene Beschreibung"}},
+            ),
+        ],
+    )
+    def test_prebuilt_localizations_override_generated_only_when_nonempty(
+        self,
+        tmp_path,
+        document_localizations,
+        expected_localizations,
+    ):
+        """空の文書値は生成済み翻訳を維持し、非空の文書値だけを最終値にする。"""
+        # Given
+        uploader, col_dir, mock_gen = self._setup(tmp_path)
+        generated_localizations = {"ja": {"title": "生成済みタイトル", "description": "生成済み概要"}}
+        mock_gen.generate_complete_collection_metadata.return_value = {
+            **_make_metadata("Generated Title"),
+            "localizations": generated_localizations,
+        }
+        documentation = col_dir / "20-documentation"
+        documentation.mkdir()
+        write_video_description_pair(
+            documentation,
+            title="Approved Title",
+            description="Approved description",
+            localizations=document_localizations,
+        )
+
+        with (
+            patch.object(uploader.dedup_search, "find_existing_video_by_title", return_value=None),
+            patch.object(uploader, "upload_video", return_value="VID_NEW") as mock_upload_video,
+        ):
+            # When
+            uploader._upload_complete_collection(col_dir, mock_gen, publish_at=None)
+
+        # Then
+        metadata = mock_upload_video.call_args.args[1]
+        assert metadata["localizations"] == expected_localizations
+
     def test_workflow_state_master_video_wins_over_preview(self, tmp_path):
         uploader, col_dir, mock_gen = self._setup(tmp_path)
         preview = col_dir / "01-master" / "A-Preview.mp4"


### PR DESCRIPTION
## Summary

- `descriptions.json.localizations` が空なら生成済み翻訳を維持
- 非空の場合だけ文書側 localizations で上書き
- publish / video description 手順と回帰テストを更新

## Verification

- 関連・回帰 tests
- 全体9,807 passed / 3 skipped、並列timeout 1件は単独再実行pass
- lint / format / Any型 gate

Closes #4339