### PR TITLE
fix(wf-new): 多言語タイトル長を保存前に検証する (#4340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `fix(skills)`: `/video` 統合後も下流に残る旧 `/video-description` / `/videoup` を既知の prune 対象として検出し、古い `descriptions.md` 生成契約を明示削除できるようにする（#4337）。
 - `fix(upload)`: `yt-upload-collection` に `--allow-duration-outside-target` を追加し、operator の明示判断で目標尺外動画の preflight を通過できるようにする（#4338）。
 - `fix(video-upload)`: `descriptions.json::localizations` が空でも `scene_phrases` から生成済みの翻訳を維持し、ja/de 等がアップロード時に消える問題を修正する（#4339）。
+- `fix(wf-new)`: `scene_phrases` の保存前に予定尺込みの多言語タイトルを組み立て、YouTube の 100 codepoint 上限超過を全言語まとめて拒否する（#4340）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/media/populate_scene_phrases.py
+++ b/src/youtube_automation/commands/media/populate_scene_phrases.py
@@ -31,6 +31,7 @@ from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.errors import AutomationError, ConfigError, ValidationError
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
+from youtube_automation.domains.metadata import format_scene_title_violations, validate_scene_phrases
 from youtube_automation.domains.uploads.preflight import requires_scene_phrases
 
 logger = logging.getLogger(__name__)
@@ -177,6 +178,26 @@ def _build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _validate_scene_title_lengths(scene_phrases: dict[str, str], config, *, scene_emoji: str) -> None:
+    target_duration_min = config.audio.target_duration_min
+    duration_seconds = target_duration_min * 60 if target_duration_min is not None else None
+    try:
+        violations = validate_scene_phrases(
+            scene_phrases,
+            config,
+            duration_seconds,
+            scene_emoji=scene_emoji,
+        )
+    except ValueError as exc:
+        raise ValidationError(str(exc)) from exc
+    if violations:
+        raise ValidationError(
+            f"localizations の {len(violations)} 言語で予定タイトルが 100 codepoint を超過:\n"
+            f"{format_scene_title_violations(violations)}\n"
+            "→ scene_phrases を短縮してから再実行してください"
+        )
+
+
 def main(argv: list[str] | None = None) -> int:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
     args = _build_arg_parser().parse_args(argv)
@@ -187,7 +208,8 @@ def main(argv: list[str] | None = None) -> int:
         ws_path = col_path / "workflow-state.json"
         if not ws_path.exists():
             raise ConfigError(f"{ws_path} が存在しません")
-        state = read_workflow_state(ws_path).to_dict()
+        workflow_state = read_workflow_state(ws_path)
+        state = workflow_state.to_dict()
 
         supported = list(config.localizations.supported_languages)
         if not requires_scene_phrases(supported):
@@ -222,6 +244,9 @@ def main(argv: list[str] | None = None) -> int:
 
         translations = translate_phrase(en_phrase, supported, translations_json=translations_json)
         scene_phrases: dict[str, str] = {SOURCE_LANG: en_phrase, **translations}
+        planning = workflow_state.planning
+        scene_emoji = planning.scene_emoji if planning is not None else ""
+        _validate_scene_title_lengths(scene_phrases, config, scene_emoji=scene_emoji or "")
 
         if args.dry_run:
             print(json.dumps(scene_phrases, ensure_ascii=False, indent=2))

--- a/src/youtube_automation/domains/metadata/localizations.py
+++ b/src/youtube_automation/domains/metadata/localizations.py
@@ -172,7 +172,7 @@ class SceneTitleViolation:
 def validate_scene_phrases(
     scene_phrases: Dict[str, str],
     config,
-    duration_seconds: int | float,
+    duration_seconds: int | float | None,
     scene_emoji: str = "",
 ) -> List[SceneTitleViolation]:
     """scene_phrases を localizations の全言語で試算し、100 codepoint 超過を一括検出する.
@@ -185,7 +185,7 @@ def validate_scene_phrases(
     Args:
         scene_phrases: {"en": ..., "ja": ..., ...} コレクション別の感情フレーズ翻訳
         config: `load_config()` の戻り値
-        duration_seconds: primary title と共有する実マスター秒数
+        duration_seconds: primary title と共有する実マスター秒数。生成前検証では予定秒数。
 
     Returns:
         違反のリスト。空なら全言語 100 codepoint 以内.
@@ -240,9 +240,15 @@ def _validate_and_format_scene_titles(
             raise ValueError(f"localizations.json: language '{lang}' に title_template が無い")
         activities = lang_data.get("activities", best_for_line)
         scene = scene_phrases[lang]
+        title_placeholders = _referenced_placeholders(title_tpl)
+        if "duration_display" in title_placeholders and duration_seconds is None:
+            raise ValueError(
+                "localizations の title_template に {duration_display} があるため、"
+                "config/channel/audio.json の audio.target_duration_min が必要です"
+            )
         duration_display = (
             format_localized_duration_display(duration_seconds, lang)
-            if "duration_display" in _referenced_placeholders(title_tpl)
+            if "duration_display" in title_placeholders and duration_seconds is not None
             else ""
         )
         title = format_title_template(

--- a/tests/commands/media/test_populate_scene_phrases.py
+++ b/tests/commands/media/test_populate_scene_phrases.py
@@ -76,6 +76,8 @@ def _setup_channel(
     workflow_state: dict | None = None,
     collection_stage: str = "planning",
     collection_name: str = "20260322-tc-city-collection",
+    title_template: str = "{scene_phrase}",
+    target_duration_min: float | None = None,
 ) -> Path:
     ch = tmp_path / "channel"
     for filename, data in _sections_with_theme_scenes().items():
@@ -87,12 +89,12 @@ def _setup_channel(
                 "default_language": "en",
                 "supported_languages": supported_languages,
                 "languages": {
-                    lang: {"title_template": "{scene_phrase}", "activities": "x"}
-                    for lang in supported_languages
-                    if lang != "en"
+                    lang: {"title_template": title_template, "activities": "x"} for lang in supported_languages
                 },
             },
         )
+    if target_duration_min is not None:
+        _write_json(ch / "config" / "channel" / "audio.json", {"audio": {"target_duration_min": target_duration_min}})
     if workflow_state is not None:
         _write_json(
             ch / "collections" / collection_stage / collection_name / "workflow-state.json",
@@ -308,6 +310,77 @@ class TestMainCLI:
         assert ws["scene_phrases"]["ja"] == "深夜のネオン街"
         assert ws["scene_phrases"]["ko"] == "심야 네온"
         assert ws["future_section"] == {"keep": True}
+
+    def test_rejects_localized_titles_over_limit_before_writing(self, tmp_path, monkeypatch, capsys):
+        collection_name = "20260322-tc-city-collection"
+        en_phrase = "back at your desk after time away, quiet morning light, settling in again"
+        de_phrase = "zurück am Schreibtisch nach längerer Pause, stilles Morgenlicht, wieder ankommen"
+        ch = _setup_channel(
+            tmp_path,
+            supported_languages=["en", "de"],
+            workflow_state={"theme": "city"},
+            collection_name=collection_name,
+            title_template="{scene_phrase} | lo-fi work playlist [{duration_display}]",
+            target_duration_min=180,
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        rc = populate_scene_phrases.main(
+            [collection_name, "--en", en_phrase, "--translations-json", json.dumps({"de": de_phrase})]
+        )
+
+        assert rc == 1
+        error = capsys.readouterr().err
+        assert "[en] 105 codepoints" in error
+        assert "[de] 110 codepoints" in error
+        state = json.loads(
+            (ch / "collections" / "planning" / collection_name / "workflow-state.json").read_text(encoding="utf-8")
+        )
+        assert "scene_phrases" not in state
+
+    def test_writes_when_localized_planned_titles_fit_limit(self, tmp_path, monkeypatch):
+        collection_name = "20260322-tc-city-collection"
+        ch = _setup_channel(
+            tmp_path,
+            supported_languages=["en", "de"],
+            workflow_state={"theme": "city"},
+            collection_name=collection_name,
+            title_template="{scene_phrase} | lo-fi work playlist [{duration_display}]",
+            target_duration_min=180,
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        rc = populate_scene_phrases.main(
+            [collection_name, "--en", "quiet desk", "--translations-json", json.dumps({"de": "ruhiger Schreibtisch"})]
+        )
+
+        assert rc == 0
+        state = json.loads(
+            (ch / "collections" / "planning" / collection_name / "workflow-state.json").read_text(encoding="utf-8")
+        )
+        assert state["scene_phrases"] == {"en": "quiet desk", "de": "ruhiger Schreibtisch"}
+
+    def test_rejects_duration_template_without_planned_duration(self, tmp_path, monkeypatch, capsys):
+        collection_name = "20260322-tc-city-collection"
+        ch = _setup_channel(
+            tmp_path,
+            supported_languages=["en", "de"],
+            workflow_state={"theme": "city"},
+            collection_name=collection_name,
+            title_template="{scene_phrase} [{duration_display}]",
+        )
+        monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+        rc = populate_scene_phrases.main(
+            [collection_name, "--en", "quiet desk", "--translations-json", json.dumps({"de": "ruhiger Schreibtisch"})]
+        )
+
+        assert rc == 1
+        assert "audio.target_duration_min" in capsys.readouterr().err
+        state = json.loads(
+            (ch / "collections" / "planning" / collection_name / "workflow-state.json").read_text(encoding="utf-8")
+        )
+        assert "scene_phrases" not in state
 
     def test_writes_translated_phrases_from_file(self, tmp_path, monkeypatch):
         ch = _setup_channel(


### PR DESCRIPTION
## Summary

- scene_phrases 保存前に予定尺込みの全言語タイトルを検証
- YouTube上限100 codepoint超過時は書き込み前に停止
- 多言語 title template の回帰テストを追加

## Verification

- 関連 tests / lint / build / wheel smoke
- 全体並列で変更外collection server timeout、該当3件は直列再実行pass

Closes #4340