### PR TITLE
fix(analytics): 自チャンネルの再生数をengagedViewsへ移行する (#4352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(dashboard)`: 総再生時間を分単位の整数から、3 桁区切りを含む「時間+分」の複合表記へ変更する（#4345）。
 - `fix(dashboard)`: 期間変更・手動更新後の最新 snapshot が遅延中の旧リクエストに上書きされないようにし、概況・期間・更新時刻・選択中の詳細を同じ収集結果へ同期する（#4348）。
 - `fix(dashboard)`: チャンネル比較の期間再生数見出しに、全チャンネルの対象期間を月日で表示する（#4350）。
+- `fix(analytics)`: 自チャンネルの Targeted Query で従来基準の `engagedViews` を取得し、既存の `views` キーへ写像する（#4352）。
 
 - `fix(collection-serve)`: Suno の安全モードで長時間生成した後も playlist 追加を継続できるよう、collection server の既定 idle timeout を 60 分から 4 時間へ延長する（#4335）。
 - `fix(uploads)`: プレイリスト割り当ての正本を `workflow-state.json::planning.playlists` に移し、theme slug の部分一致（`auto_add_themes`）だけに依存する構造をやめる。`yt-init-collection --playlist` / `--no-playlist` で init 段階に決め、分類プレイリストへ 1 つも割り当たらない状態はアップロード preflight が fail-loud で弾く（#4346）。**breaking**: 分類プレイリストを定義しているチャンネルでは `yt-init-collection` に `--playlist` か `--no-playlist` が必須。

--- a/src/youtube_automation/commands/channel/channel_status.py
+++ b/src/youtube_automation/commands/channel/channel_status.py
@@ -12,6 +12,10 @@ from datetime import datetime, timedelta
 
 from youtube_automation.configuration import channel_dir, load_config
 from youtube_automation.core.errors import AutomationError, YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 from youtube_automation.domains.analytics.service import YouTubeAnalyticsCollector
 from youtube_automation.infrastructure import cost_tracker
 from youtube_automation.infrastructure.analytics_adapter import AnalyticsAdapter, YouTubeDataAdapter
@@ -155,10 +159,10 @@ def get_channel_latest_status():
                     ids=f"channel=={collector.channel_id}",
                     startDate=start_date,
                     endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration",
+                    metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration",
                     dimensions="video",
                     filters=f"video=={','.join(video_ids)}",
-                    sort="-views",
+                    sort=TARGETED_QUERY_VIEWS_SORT,
                 )
                 for row in response.get("rows", []):
                     stats_map[row[0]] = {

--- a/src/youtube_automation/domains/analytics/collection/strategic_analytics.py
+++ b/src/youtube_automation/domains/analytics/collection/strategic_analytics.py
@@ -12,6 +12,10 @@ from typing import TYPE_CHECKING, Dict, List
 
 from youtube_automation.core.adapters.observability import section
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -102,9 +106,9 @@ class StrategicAnalyticsMixin:
                     ids=f"channel=={self.channel_id}",
                     startDate=start_date,
                     endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                    metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
                     dimensions="video",
-                    sort="-views",
+                    sort=TARGETED_QUERY_VIEWS_SORT,
                     maxResults=batch_size,
                     startIndex=len(top_videos_data) + 1,
                 )
@@ -314,9 +318,9 @@ class StrategicAnalyticsMixin:
                     ids=f"channel=={self.channel_id}",
                     startDate=start_date,
                     endDate=end_date,
-                    metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                    metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
                     dimensions="video",
-                    sort="-views",
+                    sort=TARGETED_QUERY_VIEWS_SORT,
                     maxResults=batch_size,
                     startIndex=len(videos_data) + 1,
                 )

--- a/src/youtube_automation/domains/analytics/mixins/audience_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/audience_analytics.py
@@ -9,6 +9,10 @@ import logging
 from typing import TYPE_CHECKING, Dict
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -29,9 +33,9 @@ class AudienceAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration",
                 dimensions="subscribedStatus",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
             )
             response = request
 
@@ -75,9 +79,9 @@ class AudienceAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration",
                 dimensions="deviceType",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
             )
             response = request
 
@@ -125,9 +129,9 @@ class AudienceAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,subscribersGained",
                 dimensions="country",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
                 maxResults=max_countries,
             )
             response = request

--- a/src/youtube_automation/domains/analytics/mixins/channel_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/channel_analytics.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Dict
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import TARGETED_QUERY_VIEWS_METRIC
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -63,7 +64,7 @@ class ChannelAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,likes,dislikes,comments,shares,averageViewPercentage,cardImpressions,cardClicks,cardClickRate",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,likes,dislikes,comments,shares,averageViewPercentage,cardImpressions,cardClicks,cardClickRate",
                 dimensions="day",
             )
             response = request

--- a/src/youtube_automation/domains/analytics/mixins/ctr_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/ctr_analytics.py
@@ -4,7 +4,7 @@ YouTubeAnalyticsCollector の CTR 特化分析メソッド群。
 
 `videoThumbnailImpressions` / `videoThumbnailImpressionsClickRate` は
 YouTube Analytics API (channel_reports) の仕様上 `dimensions=video` と組み合わせ不可。
-そのため動画別クエリからはこれらメトリクスを除外し、views/likes/comments/watch_time のみ取得する。
+そのため動画別クエリからはこれらメトリクスを除外し、engagedViews/likes/comments/watch_time のみ取得する。
 (チャンネル全体サマリーは公式ドキュメントでは Traffic Source / Device Type / OS Report で
 取得可能とされているが、実 API では 400 が返るチャンネルが多く、Google 公式の Looker Studio
 Connector でも同症状が報告されている未解決問題のため、本 Mixin では収集しない)
@@ -21,6 +21,10 @@ import logging
 from typing import TYPE_CHECKING, Dict, List
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -51,7 +55,7 @@ class CTRAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,likes,comments,shares,subscribersGained",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},likes,comments,shares,subscribersGained",
             )
             overall_response = request
 
@@ -63,7 +67,7 @@ class CTRAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched",
                 dimensions="day",
             )
             traffic_response = request
@@ -91,14 +95,14 @@ class CTRAnalyticsMixin:
             return {"error": str(e)}
 
     def _fetch_video_ctr(self, start_date: str, end_date: str) -> Dict:
-        """動画別パフォーマンスデータを取得する（トップ30本、views 降順）"""
+        """動画別パフォーマンスデータを取得する（トップ30本、engagedViews 降順）"""
         request = self.analytics_service.query(
             ids=f"channel=={self.channel_id}",
             startDate=start_date,
             endDate=end_date,
-            metrics="views,likes,comments,estimatedMinutesWatched",
+            metrics=f"{TARGETED_QUERY_VIEWS_METRIC},likes,comments,estimatedMinutesWatched",
             dimensions="video",
-            sort="-views",
+            sort=TARGETED_QUERY_VIEWS_SORT,
             maxResults=30,
         )
         return request

--- a/src/youtube_automation/domains/analytics/mixins/retention_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/retention_analytics.py
@@ -9,6 +9,10 @@ import logging
 from typing import TYPE_CHECKING, Dict, List
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -107,9 +111,9 @@ class RetentionAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views",
+                metrics=TARGETED_QUERY_VIEWS_METRIC,
                 dimensions="video",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
                 maxResults=top_n,
             )
             response = request

--- a/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/revenue_analytics.py
@@ -6,14 +6,17 @@ import logging
 from typing import TYPE_CHECKING
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import TARGETED_QUERY_VIEWS_METRIC
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
 
 logger = logging.getLogger(__name__)
 
-_DAILY_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
-_VIDEO_REVENUE_METRICS = "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+_DAILY_REVENUE_METRICS = (
+    f"{TARGETED_QUERY_VIEWS_METRIC},estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+)
+_VIDEO_REVENUE_METRICS = f"{TARGETED_QUERY_VIEWS_METRIC},estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
 _VIDEO_REVENUE_MAX_RESULTS = 200
 
 

--- a/src/youtube_automation/domains/analytics/mixins/traffic_source_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/traffic_source_analytics.py
@@ -9,6 +9,10 @@ import logging
 from typing import TYPE_CHECKING, Dict, List
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -38,9 +42,9 @@ class TrafficSourceMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration",
                 dimensions="insightTrafficSourceType",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
             )
             response = request
 
@@ -89,10 +93,10 @@ class TrafficSourceMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched",
                 dimensions="insightTrafficSourceDetail",
                 filters=f"insightTrafficSourceType=={source_type}",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
                 maxResults=25,
             )
             response = request

--- a/src/youtube_automation/domains/analytics/mixins/video_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/video_analytics.py
@@ -9,6 +9,10 @@ import logging
 from typing import TYPE_CHECKING, Dict, List
 
 from youtube_automation.core.errors import YouTubeAPIError
+from youtube_automation.domains.analytics.query_contract import (
+    TARGETED_QUERY_VIEWS_METRIC,
+    TARGETED_QUERY_VIEWS_SORT,
+)
 
 if TYPE_CHECKING:
     from youtube_automation.domains.analytics.ports import AnalyticsBase  # noqa: F401
@@ -39,9 +43,9 @@ class VideoAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
                 dimensions="video",
-                sort="-views",
+                sort=TARGETED_QUERY_VIEWS_SORT,
                 maxResults=10,
             )
             response = request
@@ -101,7 +105,7 @@ class VideoAnalyticsMixin:
                 ids=f"channel=={self.channel_id}",
                 startDate=start_date,
                 endDate=end_date,
-                metrics="views,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
+                metrics=f"{TARGETED_QUERY_VIEWS_METRIC},estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained",
                 filters=f"video=={video_id}",
             )
             response = request

--- a/src/youtube_automation/domains/analytics/mixins/video_daily_analytics.py
+++ b/src/youtube_automation/domains/analytics/mixins/video_daily_analytics.py
@@ -6,14 +6,15 @@ import logging
 from typing import Dict, List, Optional
 
 from youtube_automation.core.adapters.observability import section
+from youtube_automation.domains.analytics.query_contract import TARGETED_QUERY_VIEWS_METRIC
 
 logger = logging.getLogger(__name__)
 
 
 class VideoDailyAnalyticsMixin:
-    """動画 × 日次粒度で views を取得する
+    """動画 × 日次粒度で engagedViews を取得して内部 views として返す。
 
-    動画×日次では `videoThumbnailImpressions*` が API 仕様上取得不可のため views のみ。
+    動画×日次では `videoThumbnailImpressions*` が API 仕様上取得不可のため engagedViews のみ。
     impressions/CTR は `ChannelDailyAnalyticsMixin.get_channel_daily_impressions` で代替する。
     """
 
@@ -24,7 +25,7 @@ class VideoDailyAnalyticsMixin:
         video_ids: Optional[List[str]] = None,
     ) -> List[Dict]:
         """
-        dimensions='video,day' で日次 views を取得する。
+        dimensions='video,day' で日次 engagedViews を取得する。
 
         Args:
             start_date: YYYY-MM-DD
@@ -51,7 +52,7 @@ class VideoDailyAnalyticsMixin:
             filtered=bool(video_ids),
         ):
             request = self.analytics_service.query(
-                metrics="views",
+                metrics=TARGETED_QUERY_VIEWS_METRIC,
                 **query_kwargs,
             )
             response = request

--- a/src/youtube_automation/domains/analytics/query_contract.py
+++ b/src/youtube_automation/domains/analytics/query_contract.py
@@ -1,0 +1,4 @@
+"""YouTube Analytics API Targeted Query のメトリクス契約。"""
+
+TARGETED_QUERY_VIEWS_METRIC = "engagedViews"
+TARGETED_QUERY_VIEWS_SORT = f"-{TARGETED_QUERY_VIEWS_METRIC}"

--- a/tests/commands/channel/test_channel_status.py
+++ b/tests/commands/channel/test_channel_status.py
@@ -147,17 +147,25 @@ def test_get_status_falls_back_to_uploads_when_collection_playlists_are_empty(mo
             }
         ]
     }
-    collector.analytics_service.query.return_value = {"rows": []}
+    collector.analytics_service.query.return_value = {"rows": [["video-fallback", 321, 42.5, 100]]}
     monkeypatch.setattr(channel_status, "YouTubeAnalyticsCollector", MagicMock(return_value=collector))
 
     result = channel_status.get_channel_latest_status()
 
+    query = collector.analytics_service.query.call_args.kwargs
+    assert query["metrics"] == "engagedViews,estimatedMinutesWatched,averageViewDuration"
+    assert query["sort"] == "-engagedViews"
     assert result["recent_collections"] == [
         {
             "collection_name": "Fallback upload",
             "published_at": "2026-07-30",
             "video_id": "video-fallback",
             "url": "https://youtu.be/video-fallback",
+            "stats": {
+                "views": 321,
+                "watch_time_min": 42.5,
+                "avg_view_duration_sec": 100,
+            },
         }
     ]
     collector.youtube_service.list_playlist_items_for_display.assert_called_once_with("UU_REF", max_results=10)

--- a/tests/domains/analytics/collection/test_strategic_analytics_parallel.py
+++ b/tests/domains/analytics/collection/test_strategic_analytics_parallel.py
@@ -190,6 +190,12 @@ class TestSubscriberConversionRanking:
 
         result = collector.get_combined_analytics("2026-01-01", "2026-04-01")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == (
+            "engagedViews,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained"
+        )
+        assert query["sort"] == "-engagedViews"
+        assert result["top_videos"][0]["views"] == 200
         assert result["top_videos"][0]["subscriber_conversion_rate"] == 3.0
 
     def test_top_video_analytics_adds_conversion_rate(self, collector: _StubCollector) -> None:
@@ -198,6 +204,11 @@ class TestSubscriberConversionRanking:
 
         result = collector.get_top_video_analytics("2026-01-01", "2026-04-01")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == (
+            "engagedViews,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained"
+        )
+        assert query["sort"] == "-engagedViews"
         assert result[0]["subscriber_conversion_rate"] == 3.0
 
 

--- a/tests/domains/analytics/mixins/test_audience_analytics.py
+++ b/tests/domains/analytics/mixins/test_audience_analytics.py
@@ -45,6 +45,9 @@ class TestGetDeviceAnalytics:
 
         result = collector.get_device_analytics("2026-01-01", "2026-04-01")
 
+        query = request.call_args.kwargs
+        assert query["metrics"] == "engagedViews,estimatedMinutesWatched,averageViewDuration"
+        assert query["sort"] == "-engagedViews"
         assert result["devices"]["MOBILE"]["views"] == 1
         request.assert_called_once()
 
@@ -103,6 +106,9 @@ class TestGetCountryAnalytics:
 
         result = collector.get_country_analytics("2026-01-01", "2026-04-01")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == ("engagedViews,estimatedMinutesWatched,averageViewDuration,subscribersGained")
+        assert query["sort"] == "-engagedViews"
         assert result["total_views"] == 350
         assert result["countries"]["JP"]["subscribers_gained"] == 3
         assert result["countries"]["US"]["view_share_percent"] == pytest.approx(57.1, abs=0.1)
@@ -139,7 +145,8 @@ class TestGetSubscribedStatusAnalytics:
         }
         query_kwargs = collector.analytics_service.query.call_args.kwargs
         assert query_kwargs["dimensions"] == "subscribedStatus"
-        assert query_kwargs["metrics"] == "views,estimatedMinutesWatched,averageViewDuration"
+        assert query_kwargs["metrics"] == "engagedViews,estimatedMinutesWatched,averageViewDuration"
+        assert query_kwargs["sort"] == "-engagedViews"
 
     def test_consumes_adapter_response(self, collector):
         request = collector.analytics_service.query

--- a/tests/domains/analytics/mixins/test_channel_analytics.py
+++ b/tests/domains/analytics/mixins/test_channel_analytics.py
@@ -118,6 +118,10 @@ def test_channel_analytics_maps_daily_rows_and_summary_with_optional_columns() -
 
     result = collector.get_channel_analytics("2026-07-01", "2026-07-02")
 
+    assert collector.analytics_service.query.call_args.kwargs["metrics"] == (
+        "engagedViews,estimatedMinutesWatched,averageViewDuration,subscribersGained,subscribersLost,"
+        "likes,dislikes,comments,shares,averageViewPercentage,cardImpressions,cardClicks,cardClickRate"
+    )
     assert result["daily_metrics"][0]["avg_view_percentage"] == 0
     assert result["daily_metrics"][1]["card_click_rate"] == 2.5
     assert result["summary"] == {

--- a/tests/domains/analytics/mixins/test_ctr_analytics.py
+++ b/tests/domains/analytics/mixins/test_ctr_analytics.py
@@ -36,7 +36,8 @@ def test_fetch_video_ctr_excludes_thumbnail_impressions_metrics():
     last_call_kwargs = mock_service.query.call_args.kwargs
     assert "videoThumbnailImpressions" not in last_call_kwargs["metrics"]
     assert last_call_kwargs["dimensions"] == "video"
-    assert "views" in last_call_kwargs["metrics"]
+    assert last_call_kwargs["metrics"] == "engagedViews,likes,comments,estimatedMinutesWatched"
+    assert last_call_kwargs["sort"] == "-engagedViews"
 
 
 def test_process_video_ctr_parses_five_column_rows():
@@ -89,8 +90,17 @@ def test_get_ctr_analysis_returns_without_impressions_summary():
     collector = DummyCollector(mock_service)
     result = collector.get_ctr_analysis("2026-04-01", "2026-04-30")
 
+    calls = mock_service.query.call_args_list
+    assert [call.kwargs["metrics"] for call in calls] == [
+        "engagedViews,likes,comments,shares,subscribersGained",
+        "engagedViews,likes,comments,estimatedMinutesWatched",
+        "engagedViews,estimatedMinutesWatched",
+    ]
+    assert calls[1].kwargs["sort"] == "-engagedViews"
     assert "error" not in result
     assert "impressions_summary" not in result
+    assert result["overall_engagement"]["total_views"] == 10000
+    assert result["daily_traffic"][0]["views"] == 300
     assert result["video_performance"][0]["video_id"] == "vid_A"
 
 

--- a/tests/domains/analytics/mixins/test_retention.py
+++ b/tests/domains/analytics/mixins/test_retention.py
@@ -74,6 +74,9 @@ class TestGetRetentionSummary:
 
         result = collector.get_retention_summary("2026-01-01", "2026-04-01", top_n=2)
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == "engagedViews"
+        assert query["sort"] == "-engagedViews"
         assert result == []
         collector.youtube_service.list_videos.assert_not_called()
 

--- a/tests/domains/analytics/mixins/test_revenue_analytics.py
+++ b/tests/domains/analytics/mixins/test_revenue_analytics.py
@@ -54,10 +54,10 @@ def test_collects_daily_and_video_revenue_metrics():
         "rpm": 6.2,
     }
     assert service.query.call_args_list[0].kwargs["metrics"] == (
-        "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+        "engagedViews,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
     )
     assert service.query.call_args_list[1].kwargs["metrics"] == (
-        "views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
+        "engagedViews,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm"
     )
     assert service.query.call_args_list[1].kwargs["maxResults"] == 200
 

--- a/tests/domains/analytics/mixins/test_traffic_source.py
+++ b/tests/domains/analytics/mixins/test_traffic_source.py
@@ -40,6 +40,9 @@ class TestGetTrafficSourceAnalytics:
 
         result = collector.get_traffic_source_analytics("2026-01-01", "2026-04-01")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == "engagedViews,estimatedMinutesWatched,averageViewDuration"
+        assert query["sort"] == "-engagedViews"
         assert result["total_views"] == 600
         assert result["sources"]["YT_SEARCH"]["views"] == 300
         assert result["sources"]["YT_SEARCH"]["view_share_percent"] == 50.0
@@ -79,6 +82,9 @@ class TestGetTrafficSourceDetail:
 
         result = collector.get_traffic_source_detail("2026-01-01", "2026-04-01", "YT_SEARCH")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == "engagedViews,estimatedMinutesWatched"
+        assert query["sort"] == "-engagedViews"
         assert len(result) == 2
         assert result[0]["detail"] == "lofi music"
         assert result[0]["views"] == 100

--- a/tests/domains/analytics/mixins/test_video_analytics.py
+++ b/tests/domains/analytics/mixins/test_video_analytics.py
@@ -68,6 +68,11 @@ class TestGetVideoAnalytics:
 
         result = collector.get_video_analytics("2026-01-01", "2026-04-01")
 
+        query = collector.analytics_service.query.call_args.kwargs
+        assert query["metrics"] == (
+            "engagedViews,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained"
+        )
+        assert query["sort"] == "-engagedViews"
         assert len(result) == 1
         video = result[0]
         assert video["video_id"] == "VID_001"
@@ -131,6 +136,9 @@ class TestGetVideoAnalyticsById:
 
         result = collector.get_video_analytics_by_id("VID_001", "2026-01-01", "2026-04-01")
 
+        assert collector.analytics_service.query.call_args.kwargs["metrics"] == (
+            "engagedViews,estimatedMinutesWatched,averageViewDuration,likes,dislikes,comments,shares,subscribersGained"
+        )
         assert result["views"] == 100
         assert result["likes"] == 10
         assert result["comments"] == 3

--- a/tests/domains/analytics/mixins/test_video_daily_analytics.py
+++ b/tests/domains/analytics/mixins/test_video_daily_analytics.py
@@ -35,7 +35,7 @@ def test_get_video_daily_analytics_parses_views_only_rows():
     assert result[2]["video_id"] == "vid_B"
 
 
-def test_get_video_daily_analytics_query_uses_views_metric_only():
+def test_get_video_daily_analytics_query_uses_engaged_views_metric_only():
     """クエリ送信時に videoThumbnailImpressions* が含まれないことを検証。"""
     mock_service = MagicMock()
     mock_service.query.return_value = {"rows": []}
@@ -44,7 +44,7 @@ def test_get_video_daily_analytics_query_uses_views_metric_only():
 
     # reports().query(...) の最後の呼び出しを取得
     last_call_kwargs = mock_service.query.call_args.kwargs
-    assert last_call_kwargs["metrics"] == "views"
+    assert last_call_kwargs["metrics"] == "engagedViews"
     assert "videoThumbnailImpressions" not in last_call_kwargs["metrics"]
 
 

--- a/tests/test_analytics_cli_integration.py
+++ b/tests/test_analytics_cli_integration.py
@@ -49,14 +49,14 @@ class _AnalyticsReports:
                     {"rows": [["VIDEO_1", 100, 2.5, 80, 4.0, 5.0]]},
                     error=self.video_revenue_error,
                 )
-            if metrics.startswith("views,estimatedMinutesWatched"):
+            if metrics.startswith("engagedViews,estimatedMinutesWatched"):
                 return _Request({"rows": [["VIDEO_1", 100, 500, 120, 5, 0, 1, 2, 4]]})
             return _Request({"rows": [["VIDEO_1", 100, 5, 1, 500]]})
         if dimensions == "insightTrafficSourceType":
             return _Request({"rows": [["YT_SEARCH", 100, 500, 120]]})
         if dimensions == "deviceType":
             return _Request({"rows": [["MOBILE", 100, 500, 120]]})
-        if dimensions == "day" and metrics.startswith("views,estimatedMinutesWatched,averageViewDuration"):
+        if dimensions == "day" and metrics.startswith("engagedViews,estimatedMinutesWatched,averageViewDuration"):
             return _Request({"rows": [["2026-04-01", 100, 500, 120, 4, 0, 5, 0, 1, 2, 50, 0, 0, 0]]})
         if dimensions == "day" and "estimatedRevenue" in metrics:
             return _Request(
@@ -228,11 +228,14 @@ def test_yt_analytics_collects_and_saves_subscribed_status_via_cli(cli_dependenc
     assert payload["video_analytics"]["VIDEO_1"]["estimated_revenue"] == 2.5
     revenue_queries = [query for query in reports.queries if "estimatedRevenue" in query["metrics"]]
     assert next(query for query in revenue_queries if query["dimensions"] == "day")["metrics"] == (
-        "views,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
+        "engagedViews,estimatedRevenue,monetizedPlaybacks,adImpressions,cpm,playbackBasedCpm"
     )
     video_revenue_query = next(query for query in revenue_queries if query["dimensions"] == "video")
-    assert video_revenue_query["metrics"] == ("views,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm")
+    assert video_revenue_query["metrics"] == ("engagedViews,estimatedRevenue,monetizedPlaybacks,cpm,playbackBasedCpm")
     assert video_revenue_query["maxResults"] == 200
+    views_queries = [query for query in reports.queries if "engagedViews" in query["metrics"].split(",")]
+    assert views_queries
+    assert all("views" not in query["metrics"].split(",") for query in views_queries)
     assert any(query.get("dimensions") == "subscribedStatus" for query in reports.queries)
 
 


### PR DESCRIPTION
## 概要

自チャンネル向け YouTube Analytics Targeted Query を `engagedViews`（並び替えは `-engagedViews`）へ移行し、API 境界で既存の内部 `views` キーへ写像します。Public Data API の `viewCount`、`playlistViews`、Reporting API Reach 経路は変更しません。

## 検証

- 公式 YouTube Analytics Metrics / Revision History を確認
- 関連 Targeted Query tests: 713 passed
- Python full suite: 9806 passed, 3 skipped
- Ruff / format / Any / CHANGELOG gates
- uv build

Closes #4352