### PR TITLE
feat(documents): 候補レビューの比較体験を改善する (#4377)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(documents)`: review View で候補名・preview・固定 QA・確定操作を一意に関連付け、画像・音声・動画・テキストを mobile と keyboard でも比較しやすくする（#4377）。
 - `feat(documents)`: schema 文書 View で要点・主要指標を先に表示し、長い根拠や未知の追加データを欠落させず native details へ段階表示する（#4376）。
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
 - `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。

--- a/src/youtube_automation/domains/documents/resources/review.html
+++ b/src/youtube_automation/domains/documents/resources/review.html
@@ -6,14 +6,29 @@
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src file:; media-src file:; style-src 'unsafe-inline'; script-src 'none'; base-uri 'none'; form-action $FORM_ACTION; frame-ancestors 'none'">
   <title>$TITLE</title>
   <style>$CSS
-  form { margin-top: 1rem; }
+  .document-header { margin-bottom: .5rem; }
+  .document-header p { color: #52617a; }
+  .review-grid { display: grid; gap: 1.25rem; }
+  .review-candidate { display: grid; gap: 1.25rem; }
+  .review-candidate-header h2 { margin: .25rem 0 0; }
+  .review-preview { min-width: 0; }
+  .review-qa { border-top: 1px solid #e1e6ef; padding-top: 1.25rem; }
+  .review-qa h3 { margin: 0 0 .75rem; font-size: 1rem; }
+  .review-action { display: flex; align-items: center; justify-content: space-between; gap: 1rem; border-top: 1px solid #e1e6ef; padding-top: 1.25rem; }
+  .review-action p, .review-action form { margin: 0; }
   button { background: #0066cc; border: 0; border-radius: .4rem; color: white; cursor: pointer; padding: .7rem 1rem; }
+  button:focus-visible { outline: 3px solid #1557b0; outline-offset: 3px; }
   img, audio, video { display: block; max-height: 70vh; max-width: 100%; }
   .review-images { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr)); }
   .review-images figure { margin: 0; }
   .review-images figcaption { color: #52617a; font-weight: 650; margin-bottom: .5rem; }
   .review-images .review-320 { height: auto; max-width: 100%; width: 320px; }
+  @media (max-width: 40rem) {
+    .review-action { align-items: stretch; flex-direction: column; }
+    .review-action button { width: 100%; }
+    .review-images { grid-template-columns: 1fr; }
+  }
   </style>
 </head>
-<body><main><header class="document-header"><h1>$TITLE</h1><p>表示と候補選択だけを行います。成果物やworkflow stateは変更しません。</p></header>$CONTENT</main></body>
+<body><main><header class="document-header"><p class="eyebrow">候補レビュー</p><h1>$TITLE</h1><p>候補を比較し、選択する候補だけを確定します。</p></header><div class="review-grid">$CONTENT</div></main></body>
 </html>

--- a/src/youtube_automation/domains/documents/review_rendering.py
+++ b/src/youtube_automation/domains/documents/review_rendering.py
@@ -29,6 +29,7 @@ def render_review_html(
     action = endpoint or ""
     cards = "".join(
         _candidate_card(
+            index,
             candidate.id,
             candidate.label,
             candidate.details,
@@ -37,7 +38,7 @@ def render_review_html(
             action,
             compact_image=candidate.id in compact_image_ids,
         )
-        for candidate in manifest.candidates
+        for index, candidate in enumerate(manifest.candidates, start=1)
     )
     package = "youtube_automation.domains.documents.resources"
     template = Template(files(package).joinpath("review.html").read_text(encoding="utf-8"))
@@ -60,6 +61,7 @@ def render_review_html(
 
 
 def _candidate_card(
+    index: int,
     candidate_id: str,
     label: str,
     details: tuple[tuple[str, str], ...],
@@ -69,22 +71,33 @@ def _candidate_card(
     *,
     compact_image: bool,
 ) -> str:
+    title_id = f"candidate-{index}-title"
+    qa_id = f"candidate-{index}-qa"
     preview = _preview(media_path, label, compact_image=compact_image) if media_path is not None else ""
+    if preview:
+        preview = f'<div class="review-preview" aria-label="{escape(label, quote=True)} preview">{preview}</div>'
     comparison = ""
     if details:
         rows = "".join(f"<dt>{escape(key)}</dt><dd>{escape(value)}</dd>" for key, value in details)
-        comparison = f'<dl class="review-comparison">{rows}</dl>'
+        comparison = (
+            f'<section class="review-qa" aria-labelledby="{qa_id}"><h3 id="{qa_id}">確認項目</h3>'
+            f'<dl class="review-comparison">{rows}</dl></section>'
+        )
     form = ""
     if action:
         form = (
+            f'<div class="review-action"><p>この候補で確定します。</p>'
             f'<form method="post" action="{escape(action, quote=True)}">'
             f'<input type="hidden" name="artifact_digest" value="{manifest.artifact_digest}">'
-            f'<button type="submit" name="candidate_id" value="{escape(candidate_id, quote=True)}">'
-            "この候補を選ぶ</button></form>"
+            f'<button type="submit" name="candidate_id" value="{escape(candidate_id, quote=True)}" '
+            f'aria-label="{escape(label, quote=True)} を選ぶ">'
+            "この候補を選ぶ</button></form></div>"
         )
     return (
-        f'<section class="view-card" data-candidate-id="{escape(candidate_id, quote=True)}">'
-        f"<h2>{escape(label)}</h2>{comparison}{preview}{form}</section>"
+        f'<article class="view-card review-candidate" data-candidate-id="{escape(candidate_id, quote=True)}" '
+        f'aria-labelledby="{title_id}"><header class="review-candidate-header">'
+        f'<p class="eyebrow">候補 {index}</p><h2 id="{title_id}">{escape(label)}</h2></header>'
+        f"{preview}{comparison}{form}</article>"
     )
 
 

--- a/tests/domains/documents/test_review_rendering.py
+++ b/tests/domains/documents/test_review_rendering.py
@@ -88,3 +88,62 @@ def test_plan_review_card_shows_comparison_details_and_preview(tmp_path: Path) -
     assert "夜に集中したい人" in html
     assert "映像方針" in html
     assert preview.resolve().as_uri() in html
+
+
+def test_each_candidate_has_unique_accessible_label_preview_qa_and_action(tmp_path: Path) -> None:
+    preview = tmp_path / "preview.png"
+    preview.write_bytes(b"preview")
+    manifest = SelectionManifest.create(
+        artifact="thumbnail",
+        artifact_digest="a" * 64,
+        candidates=(
+            ReviewCandidate("candidate-a", "候補 A", "b" * 64, details=(("固定 QA", "pass"),)),
+            ReviewCandidate("candidate-b", "候補 B", "c" * 64, details=(("固定 QA", "warn"),)),
+        ),
+        now=datetime(2026, 8, 16, tzinfo=UTC),
+        lifetime=timedelta(minutes=5),
+    )
+    endpoint = f"http://127.0.0.1:43123/select/{manifest.token}"
+
+    html = render_review_html(
+        manifest,
+        endpoint=endpoint,
+        media={"candidate-a": preview, "candidate-b": preview},
+    )
+
+    assert 'class="review-grid"' in html
+    assert 'aria-labelledby="candidate-1-title"' in html
+    assert 'aria-labelledby="candidate-2-title"' in html
+    assert 'aria-label="候補 A を選ぶ"' in html
+    assert 'aria-label="候補 B を選ぶ"' in html
+    first = html.index('data-candidate-id="candidate-a"')
+    second = html.index('data-candidate-id="candidate-b"')
+    assert first < html.index("候補 A 原寸", first) < html.index("確認項目", first) < html.index("候補 A を選ぶ", first)
+    assert (
+        second
+        < html.index("候補 B 原寸", second)
+        < html.index("確認項目", second)
+        < html.index("候補 B を選ぶ", second)
+    )
+
+
+def test_video_and_text_candidates_keep_the_same_comparison_hierarchy(tmp_path: Path) -> None:
+    video = tmp_path / "candidate.mp4"
+    video.write_bytes(b"video")
+    manifest = SelectionManifest.create(
+        artifact="mixed",
+        artifact_digest="a" * 64,
+        candidates=(
+            ReviewCandidate("video", "映像候補", "b" * 64, details=(("固定 QA", "pass"),)),
+            ReviewCandidate("text", "テキスト候補", "c" * 64, details=(("本文", "静かな夜"),)),
+        ),
+        now=datetime(2026, 8, 16, tzinfo=UTC),
+        lifetime=timedelta(minutes=5),
+    )
+
+    html = render_review_html(manifest, endpoint=None, media={"video": video})
+
+    assert f'<video src="{video.resolve().as_uri()}" controls preload="metadata"></video>' in html
+    assert html.count("確認項目") == 2
+    assert "静かな夜" in html
+    assert "button:focus-visible" in html


### PR DESCRIPTION
Closes #4377

## 変更概要

- 各候補を候補番号・一意な heading / accessible name で関連付け
- preview → 固定 QA → 確定操作の比較階層を画像・音声・動画・テキストで統一
- mobile では確定操作を縦配置し、button の keyboard focus を明示
- 既存の media allowlist、artifact digest、candidate allowlist、loopback endpoint、CSP 契約を維持

## 検証

- `nix develop --command uv run pytest tests/domains/documents/test_review_rendering.py tests/domains/documents/test_review.py -q`（11 passed）
- `nix develop --command uv run ruff check .`
- `nix develop --command uv run ruff format --check .`
- `nix develop --command python .github/scripts/run-affected-tests.py`（9886 passed, 3 skipped）
- Chrome 1280×720 / 390×844: image/audio/video/text fixture、page overflow なし
- accessibility snapshot: 4候補すべて一意な button name、Tab focus 3px、computed contrast 最小 5.57:1
- `git diff --check`

## 参照

- `CLAUDE.md`
- `docs/architecture.md`
- `docs/development.md`
- GitHub issue #4377
