### PR TITLE
feat(wf-status): 制作状況Viewの一覧性を改善する (#4378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(wf-status)`: 制作状況 View で phase・要対応・成果物詳細の順に情報を整理し、停滞・警告・未生成を先頭表示して mobile と keyboard でも絞り込みやすくする（#4378）。
 - `feat(documents)`: review View で候補名・preview・固定 QA・確定操作を一意に関連付け、画像・音声・動画・テキストを mobile と keyboard でも比較しやすくする（#4377）。
 - `feat(documents)`: schema 文書 View で要点・主要指標を先に表示し、長い根拠や未知の追加データを欠落させず native details へ段階表示する（#4376）。
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。

--- a/src/youtube_automation/domains/documents/resources/workflow_status.css
+++ b/src/youtube_automation/domains/documents/resources/workflow_status.css
@@ -1,35 +1,81 @@
-:root { color-scheme: dark; font-family: ui-sans-serif, system-ui, sans-serif; background: #101417; color: #eef3f4; }
+:root {
+  color-scheme: light;
+  font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic", Meiryo, system-ui, sans-serif;
+  background: #f5f7fb;
+  color: #172033;
+  line-height: 1.55;
+}
 * { box-sizing: border-box; }
 body { margin: 0; }
-main { width: min(1180px, calc(100% - 2rem)); margin: 0 auto; padding: 3rem 0; }
-.page-header { border-bottom: 1px solid #334047; margin-bottom: 1.5rem; }
-.eyebrow, .status { color: #77d5bf; font-size: .75rem; font-weight: 700; letter-spacing: .12em; }
-h1 { font-size: clamp(2rem, 6vw, 4rem); margin: .2rem 0; }
-.filter-control { position: absolute; opacity: 0; pointer-events: none; }
+main { width: min(1180px, calc(100% - 2rem)); margin: 0 auto; padding: 2.5rem 0; }
+.page-header { border-bottom: 1px solid #dce2ec; margin-bottom: 1.5rem; }
+.page-header > p:last-child { color: #52617a; }
+.eyebrow, .status { color: #355f55; font-size: .8rem; font-weight: 700; }
+h1 { font-size: clamp(1.75rem, 5vw, 2.75rem); margin: .2rem 0; }
+.filter-control {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+}
 .filters { display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 1.25rem; }
-.filters label { border: 1px solid #52636c; border-radius: 999px; cursor: pointer; padding: .55rem 1rem; }
+.filters label { border: 1px solid #8794a8; border-radius: 999px; cursor: pointer; padding: .55rem 1rem; }
+.filter-selected { display: none; }
 #filter-all:checked ~ .filters label[for=filter-all],
 #filter-planning:checked ~ .filters label[for=filter-planning],
 #filter-live:checked ~ .filters label[for=filter-live],
-#filter-complete:checked ~ .filters label[for=filter-complete] { background: #77d5bf; border-color: #77d5bf; color: #101417; }
+#filter-complete:checked ~ .filters label[for=filter-complete] {
+  background: #d8eee8;
+  border-color: #357363;
+  color: #173f35;
+  font-weight: 700;
+}
+#filter-all:checked ~ .filters label[for=filter-all] .filter-selected,
+#filter-planning:checked ~ .filters label[for=filter-planning] .filter-selected,
+#filter-live:checked ~ .filters label[for=filter-live] .filter-selected,
+#filter-complete:checked ~ .filters label[for=filter-complete] .filter-selected { display: inline; }
+.filter-control:focus-visible ~ .filters { outline: 3px solid #1557b0; outline-offset: 3px; }
 #filter-planning:checked ~ .collection-grid [data-status]:not([data-status=planning]),
 #filter-live:checked ~ .collection-grid [data-status]:not([data-status=live]),
 #filter-complete:checked ~ .collection-grid [data-status]:not([data-status=complete]) { display: none; }
 .collection-grid { display: grid; gap: 1rem; }
-.collection-card { background: #182025; border: 1px solid #334047; border-radius: 1rem; padding: 1.25rem; }
+.collection-card {
+  background: #fff;
+  border: 1px solid #d3dae5;
+  border-radius: .75rem;
+  min-width: 0;
+  padding: 1.25rem;
+  box-shadow: 0 4px 16px rgb(31 45 70 / 6%);
+}
+.collection-card[data-attention=true] { border-left: .35rem solid #b5473c; }
 .collection-card h2 { margin: .2rem 0 1rem; }
+.attention {
+  background: #fff4f2;
+  border: 1px solid #f0bbb5;
+  border-radius: .5rem;
+  color: #76231c;
+  margin-bottom: 1rem;
+  padding: .85rem 1rem;
+}
+.attention h3 { margin: 0 0 .35rem; font-size: 1rem; }
+.attention ul { margin: 0; padding-left: 1.25rem; }
 .summary { display: grid; gap: .5rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
-.summary div { background: #11171a; border-radius: .5rem; padding: .75rem; }
-dt { color: #9eafb7; font-size: .75rem; text-transform: uppercase; }
+.summary div { background: #f7f9fc; border-radius: .5rem; padding: .75rem; }
+dt { color: #52617a; font-size: .75rem; font-weight: 700; text-transform: uppercase; }
 dd { margin: .25rem 0 0; overflow-wrap: anywhere; }
-table { border-collapse: collapse; margin-top: 1rem; width: 100%; }
+.table-scroll { max-width: 100%; overflow-x: auto; width: 100%; }
+table { border-collapse: collapse; margin-top: 1rem; min-width: 42rem; width: 100%; }
 caption { font-weight: 700; text-align: left; padding: .5rem 0; }
-th, td { border-top: 1px solid #334047; padding: .65rem; text-align: left; vertical-align: top; }
-.artifact { border-radius: 999px; display: inline-block; font-size: .75rem; padding: .2rem .55rem; }
-.artifact.complete { background: #174f41; }
-.artifact.missing { background: #4b4d50; }
-.artifact.inconsistent, .stale { background: #702c2c; }
-.stale { border-radius: .25rem; padding: .1rem .3rem; }
-.warnings { color: #ffb4a9; }
-.empty { border: 1px dashed #52636c; border-radius: 1rem; padding: 3rem; text-align: center; }
-@media (max-width: 640px) { th:nth-child(3), td:nth-child(3) { display: none; } }
+th, td { border-top: 1px solid #dce2ec; padding: .65rem; text-align: left; vertical-align: top; }
+th { color: #52617a; }
+.artifact { border-radius: 999px; display: inline-block; font-size: .75rem; font-weight: 700; padding: .2rem .55rem; }
+.artifact.complete { background: #d9f2e8; color: #135b47; }
+.artifact.missing { background: #fff0c7; color: #654b00; }
+.artifact.inconsistent { background: #fde2df; color: #84251d; }
+.empty { border: 1px dashed #8794a8; border-radius: .75rem; color: #52617a; padding: 3rem; text-align: center; }
+@media (max-width: 640px) {
+  main { width: min(100% - 1rem, 1180px); padding: 1.25rem 0; }
+  .collection-card { padding: 1rem; }
+}

--- a/src/youtube_automation/domains/documents/resources/workflow_status.html
+++ b/src/youtube_automation/domains/documents/resources/workflow_status.html
@@ -10,7 +10,7 @@
 <body>
   <main>
     <header class="page-header">
-      <p class="eyebrow">READ-ONLY SNAPSHOT</p>
+      <p class="eyebrow">読み取り専用 snapshot</p>
       <h1>制作状況</h1>
       <p>生成日時: $generated_at</p>
     </header>

--- a/src/youtube_automation/domains/documents/workflow_status_rendering.py
+++ b/src/youtube_automation/domains/documents/workflow_status_rendering.py
@@ -25,13 +25,15 @@ def render_workflow_status(snapshot: WorkflowStatusSnapshot) -> str:
         )
         + '<nav class="filters" aria-label="表示フィルター">'
         + "".join(
-            f'<label for="filter-{status}">{label}</label>'
+            f'<label for="filter-{status}"><span class="filter-selected" aria-hidden="true">'
+            f"選択中 · </span>{label}</label>"
             for status, label in zip(_FILTERS, ("すべて", "企画中", "公開工程", "完了"), strict=True)
         )
         + "</nav>"
     )
     if snapshot.collections:
-        collections = "".join(_render_collection(item) for item in snapshot.collections)
+        ordered = sorted(snapshot.collections, key=lambda item: not _needs_attention(item))
+        collections = "".join(_render_collection(item) for item in ordered)
     else:
         collections = '<p class="empty">コレクションはありません</p>'
     html = template.substitute(
@@ -45,10 +47,21 @@ def render_workflow_status(snapshot: WorkflowStatusSnapshot) -> str:
 
 
 def _render_collection(item: CollectionStatusView) -> str:
-    warnings = ""
-    if item.warnings:
-        warnings = (
-            '<ul class="warnings">' + "".join(f"<li>{escape(warning)}</li>" for warning in item.warnings) + "</ul>"
+    attention_items: list[str] = []
+    if item.stale:
+        attention_items.append(f"停滞: {escape(item.stalled_for)}（最終更新 {escape(item.updated_at)}）")
+    attention_items.extend(f"警告: {escape(warning)}" for warning in item.warnings)
+    attention_items.extend(
+        f"{escape(artifact.label)}: {_status_label(artifact.status)} — {escape(artifact.detail)}"
+        for artifact in item.artifacts
+        if artifact.status != "complete"
+    )
+    attention = ""
+    if attention_items:
+        attention = (
+            '<section class="attention" aria-label="要対応"><h3>要対応</h3><ul>'
+            + "".join(f"<li>{message}</li>" for message in attention_items)
+            + "</ul></section>"
         )
     artifacts = "".join(
         "<tr>"
@@ -58,19 +71,25 @@ def _render_collection(item: CollectionStatusView) -> str:
         "</tr>"
         for artifact in item.artifacts
     )
-    stale = '<span class="stale">停滞</span>' if item.stale else ""
     return (
-        f'<article class="collection-card" data-status="{item.status}">'
-        f'<header><p class="status">{_collection_label(item.status)}</p><h2>{escape(item.name)}</h2></header>'
+        f'<article class="collection-card" data-status="{item.status}" data-slug="{escape(item.slug, quote=True)}" '
+        f'data-attention="{str(bool(attention_items)).lower()}">'
+        f'<header><p class="status">{_collection_label(item.status)} · phase {escape(item.phase)}</p>'
+        f"<h2>{escape(item.name)}</h2></header>{attention}"
         '<dl class="summary">'
         f"<div><dt>phase</dt><dd>{escape(item.phase)}</dd></div>"
         f"<div><dt>blocker</dt><dd>{escape(item.blocker)}</dd></div>"
         f"<div><dt>next action</dt><dd>{escape(item.next_action)}</dd></div>"
-        f"<div><dt>更新</dt><dd>{escape(item.updated_at)} / {escape(item.stalled_for)} {stale}</dd></div>"
+        f"<div><dt>更新</dt><dd>{escape(item.updated_at)} / {escape(item.stalled_for)}</dd></div>"
         "</dl>"
-        "<table><caption>成果物</caption><thead><tr><th>項目</th><th>状態</th><th>根拠</th></tr></thead>"
-        f"<tbody>{artifacts}</tbody></table>{warnings}</article>"
+        '<div class="table-scroll"><table><caption>成果物の詳細</caption>'
+        "<thead><tr><th>項目</th><th>状態</th><th>根拠</th></tr></thead>"
+        f"<tbody>{artifacts}</tbody></table></div></article>"
     )
+
+
+def _needs_attention(item: CollectionStatusView) -> bool:
+    return item.stale or bool(item.warnings) or any(artifact.status != "complete" for artifact in item.artifacts)
 
 
 def _status_label(status: str) -> str:

--- a/tests/domains/documents/test_workflow_status_rendering.py
+++ b/tests/domains/documents/test_workflow_status_rendering.py
@@ -57,7 +57,56 @@ def test_renderer_provides_css_only_client_filters_for_all_statuses() -> None:
     for status in ("all", "planning", "live", "complete"):
         assert f'id="filter-{status}"' in html
     assert 'data-status="planning"' in html
+    assert '<span class="filter-selected" aria-hidden="true">選択中 · </span>' in html
+    assert ".filter-control:focus-visible" in html
     assert "#filter-planning:checked ~ .collection-grid [data-status]:not([data-status=planning])" in html
+
+
+def test_attention_collections_and_missing_artifacts_render_before_normal_details() -> None:
+    healthy = CollectionStatusView(
+        name="Healthy collection",
+        slug="healthy",
+        status="complete",
+        phase="complete",
+        blocker="なし",
+        next_action="なし",
+        updated_at="2026-08-16 11:00 UTC",
+        stalled_for="1時間",
+        stale=False,
+        warnings=(),
+        artifacts=(ArtifactStatusView(key="plan", label="企画", status="complete", detail="plan.json"),),
+    )
+    attention = CollectionStatusView(
+        name="Needs attention",
+        slug="attention",
+        status="planning",
+        phase="prepared",
+        blocker="master missing",
+        next_action="/music --master",
+        updated_at="2026-08-10 11:00 UTC",
+        stalled_for="6日",
+        stale=True,
+        warnings=("workflow state が古い",),
+        artifacts=(
+            ArtifactStatusView(key="master", label="Master", status="missing", detail="01-master/master.mp3"),
+            ArtifactStatusView(key="plan", label="企画", status="complete", detail="plan.json"),
+        ),
+    )
+    snapshot = WorkflowStatusSnapshot(
+        generated_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
+        collections=(healthy, attention),
+    )
+
+    html = render_workflow_status(snapshot)
+
+    assert html.index("Needs attention") < html.index("Healthy collection")
+    attention_start = html.index('data-slug="attention"')
+    healthy_start = html.index('data-slug="healthy"')
+    segment = html[attention_start:healthy_start]
+    assert segment.index("phase") < segment.index("要対応") < segment.index("成果物の詳細")
+    assert "停滞: 6日" in segment
+    assert "Master: 未生成" in segment
+    assert "workflow state が古い" in segment
 
 
 def test_empty_snapshot_renders_an_explicit_empty_state() -> None:


### PR DESCRIPTION
## 概要

制作状況 snapshot を、現在の phase / status、要対応、成果物詳細の順で読める一覧へ整えます。停滞・警告・未生成／不整合がある collection は先頭へ移し、色だけに依存しない CSS-only filter と mobile の局所 table scroll を追加しました。

Closes #4378

## 変更内容

- 要対応 collection を入力順を保ったまま先頭へまとめ、停滞時間・警告・不足成果物を明示
- phase / blocker / next action の概要後に成果物詳細を配置
- 選択中テキストと keyboard focus を備えた read-only CSS filter
- 日本語向け neutral theme、WCAG AA contrast、mobile の page overflow 防止
- HTML escape、CSP、no-script / no-form 契約を維持する renderer test を追加

## 検証

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加
- [x] renderer / command tests: 7 passed
- [x] affected suite: 9,887 passed, 3 skipped
- [x] `pytest tests/ --ignore=tests/integration -n auto`: 9,861 passed, 3 skipped
- [x] Ruff / format / `git diff --check`
- [x] Chrome 1280×720 / 390×844: page overflow なし、mobile table は局所 scroll
- [x] keyboard: Tab focus 3px、ArrowRight で planning 選択、`選択中` を文字表示
- [x] computed minimum text contrast: 5.85:1

## 関連

- Stack #4388
- Parent PR: #4387
- Epic: #4375
