### PR TITLE
refactor(localserver): collection serverの共通規約を抽出する (#4379)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(wf-status)`: 制作状況 View で phase・要対応・成果物詳細の順に情報を整理し、停滞・警告・未生成を先頭表示して mobile と keyboard でも絞り込みやすくする（#4378）。
 - `feat(documents)`: review View で候補名・preview・固定 QA・確定操作を一意に関連付け、画像・音声・動画・テキストを mobile と keyboard でも比較しやすくする（#4377）。
 - `feat(documents)`: schema 文書 View で要点・主要指標を先に表示し、長い根拠や未知の追加データを欠落させず native details へ段階表示する（#4376）。
+- `refactor(localserver)`: collection 探索・loopback CORS・PID / stop / startup-lock の規約を server 種別に依存しない共有モジュールへ抽出し、既存 collection server の外部挙動を維持する（#4379）。
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
 - `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。
 - `fix(hybrid)`: `yt-skills migrate-state-git` が workspace root の集約 `.gitignore` を利用し、既追跡の制御面 JSON を移行済みとして検査できるようにする（#4332）。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -248,6 +248,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `application.analytics.video_report` | 動画解析結果を audit report schema へ写像し、共通運用文書 migration による JSON+HTML 公開を調停 |
 | `.claude/skills/channel-research/references/channel-research-report.schema.json` | benchmark / market / viewer voice / thumbnail 調査の比較表・勝ちパターン・根拠・適用候補を共通定義し、skill writer と全 downstream reader の正本になる |
 | `infrastructure.filesystem` | provider-neutral な filesystem I/O と、複数 text file の fsync・rollback・公開後 verifier 付き transaction |
+| `infrastructure.localserver` | loopback server 共通の collection 探索、server-kind 別 PID / stop / startup-lock path と lifecycle record 読取、CORS origin policy |
 | `infrastructure.documents.publishing` | 構造化 JSON と同 basename の HTML を temp・fsync・再読込検証・replace で原子的に公開し、consumer 向けに schema 検証済み JSON+HTML 対応 pair を再読込する |
 | `commands.documents.migrate` | skill writer の未公開 candidate JSON と明示 yes/no を共通移行 workflow へ渡す `yt-document-migrate` adapter |
 | `commands.documents.render` | 固定 schema registry から選択して HTML を生成する `yt-document-render` adapter |

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -39,7 +39,6 @@ import threading
 import time
 import urllib.parse
 import uuid
-from dataclasses import dataclass
 from datetime import datetime
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -97,6 +96,58 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
     resolve_unpacked_extension_origin,
 )
 from youtube_automation.infrastructure.file_lock import file_lock
+from youtube_automation.infrastructure.localserver.collections import (
+    COLLECTION_DIR_SUFFIX as _COLLECTION_DIR_SUFFIX,
+)
+from youtube_automation.infrastructure.localserver.collections import (
+    find_collection_dirs,
+)
+from youtube_automation.infrastructure.localserver.collections import (
+    find_suno_collection_dirs as _find_suno_collection_dirs,
+)
+from youtube_automation.infrastructure.localserver.cors import (
+    EXTENSION_ORIGIN_SCHEME as _EXTENSION_ORIGIN_SCHEME,
+)
+from youtube_automation.infrastructure.localserver.cors import (
+    is_origin_allowed,
+)
+from youtube_automation.infrastructure.localserver.cors import (
+    is_read_origin_allowed as _is_read_origin_allowed,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    LifecycleRecord as _LifecycleRecord,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    consume_stop_request as _consume_stop_request,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    pid_file_path as _pid_file_path,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    pid_is_running,
+    process_exit_watcher,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    pid_is_running_windows as _shared_pid_is_running_windows,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    read_pid_file as _read_pid_file,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    remove_matching_record as _remove_matching_record,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    remove_owned_pid_file as _remove_owned_pid_file,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    startup_lock_path as _startup_lock_path,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    stop_request_path as _stop_request_path,
+)
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    write_pid_file as _write_pid_file,
+)
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
 from youtube_automation.infrastructure.media_store import R2MediaStore, R2MediaStoreConfig
 from youtube_automation.infrastructure.notifications.discord import create_discord_notification_sink
@@ -111,20 +162,6 @@ VERSION_ROUTE = "/version"
 SERVER_INFO_ROUTE = "/server-info"
 _LIFECYCLE_ROUTE_PREFIX = "/.well-known/yt-collection-serve-lifecycle/"
 MIN_EXTENSION_VERSION = "0.2.0"
-_EXTENSION_ORIGIN_SCHEME = "chrome-extension://"
-# overlay 化（#892/#895）で content script の fetch が page origin になったため、
-# helper 拡張がホストされる web origin をデフォルト許可する（#896/#1710）。完全一致のみ。
-_DEFAULT_ALLOWED_WEB_ORIGINS = frozenset(
-    {
-        "https://suno.com",
-        "https://www.suno.com",
-        "https://distrokid.com",
-        "https://www.distrokid.com",
-    }
-)
-# `collections/planning/` 配下で 1 コレクションを示すディレクトリ接尾辞。
-_COLLECTION_DIR_SUFFIX = "-collection"
-
 # DistroKid dir mode: リリース記録の出力先 JSON（`<root>/config/distrokid-releases.json`）（#934）。
 _DISTROKID_RELEASES_OUTPUT_RELPATH = Path("config") / "distrokid-releases.json"
 _DISTROKID_CAPTURE_ROOT_ENV = "DISTROKID_CAPTURE_ROOT"
@@ -168,13 +205,6 @@ class _IdleTimeout(RuntimeError):
     def __init__(self, seconds: float) -> None:
         self.seconds = seconds
         super().__init__(f"no HTTP requests received for {seconds:g} seconds")
-
-
-@dataclass(frozen=True)
-class _LifecycleRecord:
-    pid: int
-    token: str
-    configuration: str
 
 
 class _IdleTrackingHTTPServer(ThreadingHTTPServer):
@@ -377,19 +407,6 @@ def resolve_prompts_path(path: Path) -> Path:
     raise ConfigError(f"path does not exist: {path}")
 
 
-def find_collection_dirs(root: Path) -> list[Path]:
-    """`root` 直下の `*-collection` ディレクトリのみを名前昇順で返す（#816 dir mode）.
-
-    `collections/planning/` 配下には `01-master` 等の非コレクションや雑多なファイルが
-    混在しうるため、接尾辞 `-collection` を持つディレクトリだけをホワイトリスト採用する。
-    `root` が存在しない / ディレクトリでない場合は空リスト。
-    """
-    if not root.is_dir():
-        return []
-    dirs = (p for p in root.iterdir() if p.is_dir() and p.name.endswith(_COLLECTION_DIR_SUFFIX))
-    return sorted(dirs, key=lambda p: p.name)
-
-
 def _read_workflow_state_lenient(path: Path) -> dict:
     """配信一覧の fail-open 契約に合わせ、読めない state を空として扱う。"""
     try:
@@ -397,24 +414,6 @@ def _read_workflow_state_lenient(path: Path) -> dict:
     except WorkflowStateError:
         return {}
     return state.to_dict() if state is not None else {}
-
-
-def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
-    """planning の対応する live collection が完了済みなら True を返す（#2331）。
-
-    Suno の dir mode を ``collections/planning`` で配信する場合だけ sibling の
-    ``collections/live/<collection_id>/workflow-state.json`` を参照する。状態ファイルが
-    不在・破損・非 object の場合は fail-open とし、planning 側を従来どおり表示する。
-    """
-    if root.name != "planning" or root.parent.name != "collections":
-        return False
-    workflow_state = root.parent / "live" / collection_id / "workflow-state.json"
-    return _read_workflow_state_lenient(workflow_state).get("phase") == "complete"
-
-
-def _find_suno_collection_dirs(root: Path) -> list[Path]:
-    """Suno に提示可能な planning collection だけを返す（#2331）。"""
-    return [coll for coll in find_collection_dirs(root) if not _is_live_complete_collection(root, coll.name)]
 
 
 def _determine_status(
@@ -633,32 +632,6 @@ def _resolve_community_image(
     return resolved if resolved.is_file() and content_type is not None and content_type.startswith("image/") else None
 
 
-def is_origin_allowed(origin: str | None, allow_origin: str | None) -> bool:
-    """CORS 判定.
-
-    allow_origin=None なら `chrome-extension://` scheme と helper サイト web origin
-    （suno.com / distrokid.com、完全一致）を許可する（#896）。
-    allow_origin 指定時はその値との完全一致のみ許可する（lock 維持）。
-    """
-    if not origin:
-        return False
-    if allow_origin is not None:
-        return origin == allow_origin
-    if origin.startswith(_EXTENSION_ORIGIN_SCHEME):
-        return True
-    return origin in _DEFAULT_ALLOWED_WEB_ORIGINS
-
-
-def _is_read_origin_allowed(origin: str | None, allow_origin: str | None, _path: str) -> bool:
-    """Read-only GET/OPTIONS CORS 判定.
-
-    `--allow-origin` 指定時は read-only も exact lock に従う。Suno overlay から
-    必要な read API は background script が extension origin で取得する。YouTube の
-    page origin には localhost の下書きや画像を公開しない。
-    """
-    return is_origin_allowed(origin, allow_origin)
-
-
 def _is_locked_extension_request(
     raw_origin: str | None,
     declared_extension_origin: str | None,
@@ -704,20 +677,8 @@ def _lifecycle_root(path: Path) -> Path:
     return collection
 
 
-def _pid_file_path(root: Path, port: int) -> Path:
-    return root / f".collection-serve-{port}.pid"
-
-
-def _stop_request_path(root: Path, port: int) -> Path:
-    return root / f".collection-serve-{port}.stop"
-
-
 def _lifecycle_stop_path(record: _LifecycleRecord, attempt_token: str) -> str:
     return f"{_LIFECYCLE_ROUTE_PREFIX}{record.token}/stop/{attempt_token}"
-
-
-def _startup_lock_path(root: Path, port: int) -> Path:
-    return root / f".collection-serve-{port}"
 
 
 @contextlib.contextmanager
@@ -727,109 +688,23 @@ def _startup_lock(path: Path):
         yield
 
 
-def _read_pid_file(path: Path) -> _LifecycleRecord | None:
-    try:
-        payload = json.loads(path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        return None
-    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
-        raise ConfigError(f"PID file を読み取れません: {path}: {exc}") from exc
-    if not isinstance(payload, dict):
-        raise ConfigError(f"PID file が不正です: {path}")
-    pid = payload.get("pid")
-    token = payload.get("token")
-    configuration = payload.get("configuration")
-    if (
-        not isinstance(pid, int)
-        or isinstance(pid, bool)
-        or pid <= 0
-        or not isinstance(token, str)
-        or not token
-        or not isinstance(configuration, str)
-        or not configuration
-    ):
-        raise ConfigError(f"PID file が不正です: {path}")
-    return _LifecycleRecord(pid=pid, token=token, configuration=configuration)
+_pid_is_running_windows = _shared_pid_is_running_windows
 
 
 def _pid_is_running(pid: int) -> bool:
-    if sys.platform == "win32":
-        return _pid_is_running_windows(pid)
-    try:
-        os.kill(pid, 0)
-    except ProcessLookupError:
-        return False
-    except PermissionError:
-        return True
-    # kill(pid, 0) also succeeds for an exited child until its parent reaps it.
-    # A zombie has completed server/discovery cleanup and no longer executes.
-    try:
-        status = subprocess.run(
-            ["ps", "-o", "stat=", "-p", str(pid)],
-            capture_output=True,
-            check=False,
-            text=True,
-        )
-    except OSError:
-        return True
-    return not (status.returncode == 0 and status.stdout.lstrip().startswith("Z"))
-
-
-def _pid_is_running_windows(pid: int) -> bool:
-    """Windows は signal 0 での kill() 生存確認に対応しないため WinAPI で判定する。"""
-    import ctypes
-
-    PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
-    STILL_ACTIVE = 259
-    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
-    handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
-    if not handle:
-        return False
-    try:
-        exit_code = ctypes.c_ulong()
-        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
-            return False
-        return exit_code.value == STILL_ACTIVE
-    finally:
-        kernel32.CloseHandle(handle)
+    return pid_is_running(
+        pid,
+        platform=sys.platform,
+        os_module=os,
+        subprocess_module=subprocess,
+        windows_checker=_pid_is_running_windows,
+    )
 
 
 @contextlib.contextmanager
 def _process_exit_watcher(pid: int):
-    """元の process instance の終了を待つ callable を返す。"""
-    pidfd_open = getattr(os, "pidfd_open", None)
-    if callable(pidfd_open):
-        try:
-            descriptor = pidfd_open(pid)
-        except OSError:
-            pass
-        else:
-            try:
-                yield lambda timeout: bool(select.select([descriptor], [], [], timeout)[0])
-            finally:
-                os.close(descriptor)
-            return
-
-    if hasattr(select, "kqueue") and hasattr(select, "KQ_NOTE_EXIT"):
-        queue = select.kqueue()
-        try:
-            event = select.kevent(
-                pid,
-                filter=select.KQ_FILTER_PROC,
-                flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
-                fflags=select.KQ_NOTE_EXIT,
-            )
-            queue.control([event], 0, 0)
-        except OSError:
-            queue.close()
-        else:
-            try:
-                yield lambda timeout: bool(queue.control(None, 1, timeout))
-            finally:
-                queue.close()
-            return
-
-    yield None
+    with process_exit_watcher(pid, os_module=os, select_module=select) as wait_for_exit:
+        yield wait_for_exit
 
 
 def _server_process_id(port: int, record: _LifecycleRecord, expected_configuration: str | None = None) -> int | None:
@@ -872,34 +747,6 @@ def _request_server_stop(port: int, record: _LifecycleRecord, attempt_token: str
         connection.close()
 
 
-def _remove_owned_pid_file(path: Path, pid: int) -> None:
-    try:
-        record = _read_pid_file(path)
-        if record is not None and record.pid == pid:
-            path.unlink()
-    except FileNotFoundError:
-        return
-
-
-def _remove_matching_record(path: Path, expected: _LifecycleRecord) -> None:
-    try:
-        if _read_pid_file(path) == expected:
-            path.unlink()
-    except FileNotFoundError:
-        return
-
-
-def _consume_stop_request(path: Path, pid: int) -> bool:
-    try:
-        request = _read_pid_file(path)
-    except ConfigError:
-        return False
-    if request is None or request.pid != pid:
-        return False
-    path.unlink(missing_ok=True)
-    return True
-
-
 def _existing_server_pid(path: Path, port: int, expected_configuration: str) -> int | None:
     try:
         record = _read_pid_file(path)
@@ -922,33 +769,6 @@ def _existing_server_pid(path: Path, port: int, expected_configuration: str) -> 
     raise ConfigError(
         f"collection server PID {record.pid} is running, but its identity on port {port} could not be verified"
     )
-
-
-def _write_pid_file(path: Path, record: _LifecycleRecord) -> None:
-    temporary_path: Path | None = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            mode="w",
-            encoding="utf-8",
-            dir=path.parent,
-            prefix=f".{path.name}.",
-            delete=False,
-        ) as stream:
-            temporary_path = Path(stream.name)
-            json.dump(
-                {"pid": record.pid, "token": record.token, "configuration": record.configuration},
-                stream,
-            )
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        try:
-            os.link(temporary_path, path)
-        except FileExistsError as exc:
-            raise ConfigError(f"PID file already exists: {path}") from exc
-    finally:
-        if temporary_path is not None:
-            temporary_path.unlink(missing_ok=True)
 
 
 def _configuration_fingerprint(

--- a/src/youtube_automation/infrastructure/localserver/__init__.py
+++ b/src/youtube_automation/infrastructure/localserver/__init__.py
@@ -1,0 +1,1 @@
+"""Shared loopback local-server discovery, CORS, and lifecycle primitives."""

--- a/src/youtube_automation/infrastructure/localserver/collections.py
+++ b/src/youtube_automation/infrastructure/localserver/collections.py
@@ -1,0 +1,42 @@
+"""Collection directory discovery shared by loopback local servers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
+
+COLLECTION_DIR_SUFFIX = "-collection"
+
+
+def find_collection_dirs(root: Path) -> list[Path]:
+    """Return direct ``*-collection`` children in deterministic name order."""
+    if not root.is_dir():
+        return []
+    directories = (path for path in root.iterdir() if path.is_dir() and path.name.endswith(COLLECTION_DIR_SUFFIX))
+    return sorted(directories, key=lambda path: path.name)
+
+
+def find_suno_collection_dirs(root: Path) -> list[Path]:
+    """Return planning collections that do not have a completed live sibling."""
+    return [
+        collection
+        for collection in find_collection_dirs(root)
+        if not _is_live_complete_collection(root, collection.name)
+    ]
+
+
+def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
+    if root.name != "planning" or root.parent.name != "collections":
+        return False
+    state = _read_workflow_state_lenient(root.parent / "live" / collection_id / "workflow-state.json")
+    return state.get("phase") == "complete"
+
+
+def _read_workflow_state_lenient(path: Path) -> dict[str, object]:
+    try:
+        state = read_workflow_state_or_none(path)
+    except WorkflowStateError:
+        return {}
+    return state.to_dict() if state is not None else {}

--- a/src/youtube_automation/infrastructure/localserver/cors.py
+++ b/src/youtube_automation/infrastructure/localserver/cors.py
@@ -1,0 +1,29 @@
+"""Origin policy shared by loopback local servers."""
+
+from __future__ import annotations
+
+EXTENSION_ORIGIN_SCHEME = "chrome-extension://"
+DEFAULT_ALLOWED_WEB_ORIGINS = frozenset(
+    {
+        "https://suno.com",
+        "https://www.suno.com",
+        "https://distrokid.com",
+        "https://www.distrokid.com",
+    }
+)
+
+
+def is_origin_allowed(origin: str | None, allow_origin: str | None) -> bool:
+    """Apply the default helper-site policy or an exact explicit origin lock."""
+    if not origin:
+        return False
+    if allow_origin is not None:
+        return origin == allow_origin
+    if origin.startswith(EXTENSION_ORIGIN_SCHEME):
+        return True
+    return origin in DEFAULT_ALLOWED_WEB_ORIGINS
+
+
+def is_read_origin_allowed(origin: str | None, allow_origin: str | None, _path: str) -> bool:
+    """Apply the same exact-lock policy to read-only endpoints."""
+    return is_origin_allowed(origin, allow_origin)

--- a/src/youtube_automation/infrastructure/localserver/lifecycle.py
+++ b/src/youtube_automation/infrastructure/localserver/lifecycle.py
@@ -1,0 +1,224 @@
+"""Filesystem lifecycle records shared by loopback local servers."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import select
+import subprocess
+import sys
+import tempfile
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Iterator
+
+from youtube_automation.core.errors import ConfigError
+
+COLLECTION_SERVER_KIND = "collection-serve"
+_SERVER_KIND_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
+
+
+@dataclass(frozen=True)
+class LifecycleRecord:
+    pid: int
+    token: str
+    configuration: str
+
+
+def pid_file_path(root: Path, port: int, *, server_kind: str = COLLECTION_SERVER_KIND) -> Path:
+    return _state_path(root, port, server_kind=server_kind, suffix="pid")
+
+
+def stop_request_path(root: Path, port: int, *, server_kind: str = COLLECTION_SERVER_KIND) -> Path:
+    return _state_path(root, port, server_kind=server_kind, suffix="stop")
+
+
+def startup_lock_path(root: Path, port: int, *, server_kind: str = COLLECTION_SERVER_KIND) -> Path:
+    _validate_server_kind(server_kind)
+    return root / f".{server_kind}-{port}"
+
+
+def read_pid_file(path: Path) -> LifecycleRecord | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return None
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"PID file を読み取れません: {path}: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ConfigError(f"PID file が不正です: {path}")
+    pid = payload.get("pid")
+    token = payload.get("token")
+    configuration = payload.get("configuration")
+    if (
+        not isinstance(pid, int)
+        or isinstance(pid, bool)
+        or pid <= 0
+        or not isinstance(token, str)
+        or not token
+        or not isinstance(configuration, str)
+        or not configuration
+    ):
+        raise ConfigError(f"PID file が不正です: {path}")
+    return LifecycleRecord(pid=pid, token=token, configuration=configuration)
+
+
+def write_pid_file(path: Path, record: LifecycleRecord) -> None:
+    """Publish a lifecycle record without replacing an existing owner."""
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            delete=False,
+        ) as stream:
+            temporary_path = Path(stream.name)
+            json.dump(
+                {"pid": record.pid, "token": record.token, "configuration": record.configuration},
+                stream,
+            )
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        try:
+            os.link(temporary_path, path)
+        except FileExistsError as exc:
+            raise ConfigError(f"PID file already exists: {path}") from exc
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
+def pid_is_running(
+    pid: int,
+    *,
+    platform: str | None = None,
+    os_module: ModuleType = os,
+    subprocess_module: ModuleType = subprocess,
+    windows_checker: Callable[[int], bool] | None = None,
+) -> bool:
+    current_platform = platform or sys.platform
+    if current_platform == "win32":
+        checker = windows_checker or pid_is_running_windows
+        return checker(pid)
+    try:
+        os_module.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    try:
+        status = subprocess_module.run(
+            ["ps", "-o", "stat=", "-p", str(pid)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError:
+        return True
+    return not (status.returncode == 0 and status.stdout.lstrip().startswith("Z"))
+
+
+@contextmanager
+def process_exit_watcher(
+    pid: int,
+    *,
+    os_module: ModuleType = os,
+    select_module: ModuleType = select,
+) -> Iterator[Callable[[float], bool] | None]:
+    """Yield an efficient process-exit waiter when the platform provides one."""
+    pidfd_open = getattr(os_module, "pidfd_open", None)
+    if callable(pidfd_open):
+        try:
+            descriptor = pidfd_open(pid)
+        except OSError:
+            pass
+        else:
+            try:
+                yield lambda timeout: bool(select_module.select([descriptor], [], [], timeout)[0])
+            finally:
+                os_module.close(descriptor)
+            return
+
+    if hasattr(select_module, "kqueue") and hasattr(select_module, "KQ_NOTE_EXIT"):
+        queue = select_module.kqueue()
+        try:
+            event = select_module.kevent(
+                pid,
+                filter=select_module.KQ_FILTER_PROC,
+                flags=select_module.KQ_EV_ADD | select_module.KQ_EV_ENABLE,
+                fflags=select_module.KQ_NOTE_EXIT,
+            )
+            queue.control([event], 0, 0)
+        except OSError:
+            queue.close()
+        else:
+            try:
+                yield lambda timeout: bool(queue.control(None, 1, timeout))
+            finally:
+                queue.close()
+            return
+
+    yield None
+
+
+def remove_owned_pid_file(path: Path, pid: int) -> None:
+    try:
+        record = read_pid_file(path)
+        if record is not None and record.pid == pid:
+            path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def remove_matching_record(path: Path, expected: LifecycleRecord) -> None:
+    try:
+        if read_pid_file(path) == expected:
+            path.unlink()
+    except FileNotFoundError:
+        return
+
+
+def consume_stop_request(path: Path, pid: int) -> bool:
+    try:
+        request = read_pid_file(path)
+    except ConfigError:
+        return False
+    if request is None or request.pid != pid:
+        return False
+    path.unlink(missing_ok=True)
+    return True
+
+
+def _state_path(root: Path, port: int, *, server_kind: str, suffix: str) -> Path:
+    _validate_server_kind(server_kind)
+    return root / f".{server_kind}-{port}.{suffix}"
+
+
+def _validate_server_kind(server_kind: str) -> None:
+    if not _SERVER_KIND_PATTERN.fullmatch(server_kind):
+        raise ValueError("server_kind must be a lowercase ASCII slug")
+
+
+def pid_is_running_windows(pid: int) -> bool:
+    """Use WinAPI because ``os.kill(pid, 0)`` is unsupported on Windows."""
+    import ctypes
+
+    process_query_limited_information = 0x1000
+    still_active = 259
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(process_query_limited_information, False, pid)
+    if not handle:
+        return False
+    try:
+        exit_code = ctypes.c_ulong()
+        if not kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code)):
+            return False
+        return exit_code.value == still_active
+    finally:
+        kernel32.CloseHandle(handle)

--- a/tests/infrastructure/localserver/test_shared_primitives.py
+++ b/tests/infrastructure/localserver/test_shared_primitives.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.infrastructure.localserver.collections import (
+    find_collection_dirs,
+    find_suno_collection_dirs,
+)
+from youtube_automation.infrastructure.localserver.cors import is_origin_allowed
+from youtube_automation.infrastructure.localserver.lifecycle import (
+    LifecycleRecord,
+    consume_stop_request,
+    pid_file_path,
+    pid_is_running,
+    read_pid_file,
+    remove_owned_pid_file,
+    startup_lock_path,
+    stop_request_path,
+    write_pid_file,
+)
+
+
+def test_collection_discovery_is_importable_without_collection_server(tmp_path: Path) -> None:
+    planning = tmp_path / "collections" / "planning"
+    live = tmp_path / "collections" / "live"
+    planning.mkdir(parents=True)
+    (planning / "b-collection").mkdir()
+    (planning / "a-collection").mkdir()
+    (planning / "not-a-collection.txt").write_text("ignored", encoding="utf-8")
+    completed = live / "a-collection"
+    completed.mkdir(parents=True)
+    (completed / "workflow-state.json").write_text(
+        json.dumps({"schema_version": 4, "collection_id": "a-collection", "phase": "complete"}),
+        encoding="utf-8",
+    )
+
+    assert [path.name for path in find_collection_dirs(planning)] == ["a-collection", "b-collection"]
+    assert [path.name for path in find_suno_collection_dirs(planning)] == ["b-collection"]
+
+
+def test_lifecycle_paths_preserve_collection_server_names_and_separate_server_kinds(tmp_path: Path) -> None:
+    assert pid_file_path(tmp_path, 7873) == tmp_path / ".collection-serve-7873.pid"
+    assert stop_request_path(tmp_path, 7873) == tmp_path / ".collection-serve-7873.stop"
+    assert startup_lock_path(tmp_path, 7873) == tmp_path / ".collection-serve-7873"
+    assert pid_file_path(tmp_path, 7873, server_kind="audio-studio") == tmp_path / ".audio-studio-7873.pid"
+
+
+def test_lifecycle_record_reader_and_cors_are_importable_without_server_module(tmp_path: Path) -> None:
+    path = tmp_path / "server.pid"
+    path.write_text(
+        json.dumps({"pid": 123, "token": "owner", "configuration": "digest"}),
+        encoding="utf-8",
+    )
+
+    assert read_pid_file(path) == LifecycleRecord(pid=123, token="owner", configuration="digest")
+    assert is_origin_allowed("chrome-extension://abc", None)
+    assert not is_origin_allowed("https://example.com", None)
+
+
+def test_lifecycle_record_publish_consume_and_owned_cleanup_are_shared(tmp_path: Path) -> None:
+    pid_path = pid_file_path(tmp_path, 7873, server_kind="audio-studio")
+    stop_path = stop_request_path(tmp_path, 7873, server_kind="audio-studio")
+    record = LifecycleRecord(pid=os.getpid(), token="owner", configuration="digest")
+
+    write_pid_file(pid_path, record)
+    write_pid_file(stop_path, record)
+
+    assert read_pid_file(pid_path) == record
+    assert pid_is_running(record.pid)
+    assert consume_stop_request(stop_path, record.pid)
+    assert not stop_path.exists()
+    remove_owned_pid_file(pid_path, record.pid)
+    assert not pid_path.exists()
+
+
+@pytest.mark.parametrize("server_kind", ["../escape", "Audio-Studio", "audio_studio", ""])
+def test_lifecycle_paths_reject_unsafe_server_kinds(tmp_path: Path, server_kind: str) -> None:
+    with pytest.raises(ValueError, match="server_kind"):
+        pid_file_path(tmp_path, 7873, server_kind=server_kind)


### PR DESCRIPTION
## 概要

`yt-collection-serve` 内部に埋まっていた collection 探索、loopback CORS、PID / stop / startup-lock の path と lifecycle record 読取を `infrastructure.localserver` へ抽出します。既存 private 名は import alias として維持し、route・response・既存 lifecycle file 名・stop 動作は変えません。

Closes #4379

## 変更内容

- `localserver.collections`: `*-collection` 探索と live complete 除外
- `localserver.cors`: helper site / Chrome extension / exact origin lock
- `localserver.lifecycle`: server-kind 別 state path と PID record 読取
- 既定 kind を `collection-serve` とし、既存 `.collection-serve-<port>.*` を完全維持
- alternate kind は lowercase ASCII slug に限定し、後続 audio studio と path を分離
- public API の独立 import / path 分離 / unsafe kind 拒否テストを追加

## 検証

- [x] `CHANGELOG.md::[Unreleased]` と architecture inventory を更新
- [x] `pytest tests/commands/collections/ -q`: 472 passed, 2 skipped（既存テスト無改変）
- [x] shared API + fcntl-free import contract: 9 passed
- [x] affected suite: 9,888 passed, 3 skipped; 467/467 targets
- [x] repo-wide Ruff check / format check (1,026 files)
- [x] Any usage gate / `git diff --check`

## 関連

- Blocks #4380
- Epic #4375
