### PR TITLE
fix(doctor): 分析 sidecar を report 対象外にする (#4385)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `feat(audio-studio)`: 曲ごとの cleanup 値を Web Audio EQ で試聴して差分保存し、`yt-suno-audio-cleanup` が対象曲だけへ適用できるようにする（#4381）。
 - `feat(audio-studio)`: `yt-audio-studio` で collection の個別音源を尺・形式つきで一覧表示し、HTTP Range 対応 player から再生・シークできるようにする（#4380）。
 - `refactor(localserver)`: collection 探索・loopback CORS・PID / stop / startup-lock の規約を server 種別に依存しない共有モジュールへ抽出し、既存 collection server の外部挙動を維持する（#4379）。
+- `fix(doctor)`: `analytics_report` の入力を日付形式の本体 JSON に限定し、分析 sidecar を不正 report と誤判定する再実行ループを解消する（#4385）。
 - `fix(skills)`: `yt-skills migrate-config` に統合済み 5 skill の移行先を追加し、孤児 config を `wf-new` / `thumbnail` / `music` / `channel-research` へ安全に移行できるようにする（#4333）。
 - `fix(automation-update)`: multi-channel workspace では単一 channel 用 `channel-gitignore` asset を sync / diff 対象外とし、OAuth secret や channel media を保護する workspace 固有 `.gitignore` を維持する（#4331）。
 - `fix(hybrid)`: `yt-skills migrate-state-git` が workspace root の集約 `.gitignore` を利用し、既追跡の制御面 JSON を移行済みとして検査できるようにする（#4332）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -78,6 +78,7 @@ AUTOMATION_PACKAGE_NAME = "youtube-channels-automation"
 SKILLS_SYNC_ARGV = ("uv", "run", "yt-skills", "sync", "--asset", "skills", "--force")
 SKILLS_SYNC_PRUNE_ARGV = (*SKILLS_SYNC_ARGV, "--prune", "--yes")
 SKILLS_SYNC_CMD = shlex.join(SKILLS_SYNC_ARGV)
+ANALYSIS_REPORT_FILENAME_RE = re.compile(r"analysis_\d{8}\.json")
 LEGACY_BUNDLED_SKILLS = (
     "onboard",
     "distrokid-prep",
@@ -1536,7 +1537,11 @@ def check_analytics_report(channel_dir: Path) -> CheckResult:
 def _resolve_wf_new_input_mode(channel_dir: Path) -> _WfNewInputMode:
     reports_dir = channel_dir / "reports"
     data_dir = channel_dir / "data"
-    report_candidates = _matching_files(reports_dir, "analysis_*.json")
+    report_candidates = [
+        path
+        for path in _matching_files(reports_dir, "analysis_*.json")
+        if ANALYSIS_REPORT_FILENAME_RE.fullmatch(path.name)
+    ]
     reports: list[Path] = []
     invalid_report = False
     for report in report_candidates:

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -2618,6 +2618,18 @@ class TestCheckAnalyticsReport:
         r = doctor.check_analytics_report(tmp_path)
         assert r.status == "ok"
 
+    def test_analysis_sidecars_do_not_count_as_reports(self, tmp_path):
+        reports_dir = tmp_path / "reports"
+        reports_dir.mkdir()
+        _write_analysis_pair(tmp_path, "20240101")
+        for suffix in ("visual-annotations", "vpd-ranking", "win-pattern"):
+            (reports_dir / f"analysis_20240101.{suffix}.json").write_text("{}", encoding="utf-8")
+
+        result = doctor.check_analytics_report(tmp_path)
+
+        assert result.status == "ok"
+        assert "1 件存在" in result.message
+
     def test_invalid_json_or_missing_html_is_not_a_successful_analysis_input(self, tmp_path):
         reports = tmp_path / "reports"
         reports.mkdir()


### PR DESCRIPTION
## 概要

`yt-doctor --check analytics_report` が `/analytics --analyze` の sidecar を不正 report と誤判定し、再分析しても fail が解消しない閉ループを修正します。

## 変更内容

- analytics report 候補を `analysis_YYYYMMDD.json` の本体に限定
- `visual-annotations` / `vpd-ranking` / `win-pattern` sidecar が同居する回帰ケースを追加
- `CHANGELOG.md` の `[Unreleased]` を更新

## 検証

- `uv run pytest -q`: 9882 passed, 3 skipped
- `uv run ruff check ...`: pass
- `uv run ruff format --check ...`: pass
- `uv run yt-skills lint`: pass

Closes #4385