### PR TITLE
fix(tests): shell実行時のOS依存を明示する (#4466)

### DIFF
--- a/.claude/skills/thumbnail/references/codex-image.sh
+++ b/.claude/skills/thumbnail/references/codex-image.sh
@@ -248,7 +248,7 @@ if [ ! -s "$out" ]; then
   exit 1
 fi
 
-header=$(head -c 8 "$out" | xxd -p)
+header=$(LC_ALL=C od -An -tx1 -N8 "$out" | tr -d '[:space:]')
 if [ "${header:0:16}" != "89504e470d0a1a0a" ]; then
   echo "ERROR: 出力ファイルが PNG ヘッダで始まっていません: $out" >&2
   exit 1

--- a/.claude/skills/video/references/benchmark_overlay_encoders.sh
+++ b/.claude/skills/video/references/benchmark_overlay_encoders.sh
@@ -5,6 +5,7 @@ set -eu
 DURATION="${VIDEOUP_BENCH_DURATION:-60}"
 RUNS="${VIDEOUP_BENCH_RUNS:-3}"
 OUTPUT_DIR="${VIDEOUP_BENCH_OUTPUT_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/video --generate-overlay-bench.XXXXXX")}"
+TIME_BIN="${VIDEOUP_BENCH_TIME_BIN:-time}"
 mkdir -p "$OUTPUT_DIR"
 
 FILTER='[1:a]asplit=2[avis_in][aout];[avis_in]showfreqs=mode=bar:s=1280x180:rate=24:fscale=log:win_size=2048:win_func=hann:colors=white,format=rgba,colorchannelmixer=aa=0.85[avis];[0:v]format=yuv420p[bg];[bg][avis]overlay=(W-w)/2:H-h-40:format=auto,format=yuv420p[vout]'
@@ -22,7 +23,7 @@ run_direct() {
     local mode="$1" run="$2"
     local output="$OUTPUT_DIR/${mode}-${run}.mp4" time_file="$OUTPUT_DIR/${mode}-${run}.time"
     shift 2
-    /usr/bin/time -p -o "$time_file" ffmpeg -y \
+    "$TIME_BIN" -p -o "$time_file" ffmpeg -y \
         -f lavfi -i "color=c=0x20252f:s=1920x1080:r=24:d=${DURATION}" \
         -i "$OUTPUT_DIR/audio.wav" \
         -filter_complex "$FILTER" -map '[vout]' -map '[aout]' \
@@ -40,13 +41,13 @@ run_twostage() {
     local output="$OUTPUT_DIR/twostage-${run}.mp4" time_file="$OUTPUT_DIR/twostage-${run}.time"
     local base_elapsed=0
     if [[ ! -f "$OUTPUT_DIR/base.mp4" ]]; then
-        /usr/bin/time -p -o "$OUTPUT_DIR/base.time" ffmpeg -y \
+        "$TIME_BIN" -p -o "$OUTPUT_DIR/base.time" ffmpeg -y \
             -f lavfi -i "color=c=0x20252f:s=1920x1080:r=24:d=${DURATION}" \
             -c:v libx264 -preset ultrafast -crf 20 -pix_fmt yuv420p -r 24 -an \
             -loglevel error "$OUTPUT_DIR/base.mp4"
         base_elapsed="$(awk '/^real /{print $2}' "$OUTPUT_DIR/base.time")"
     fi
-    /usr/bin/time -p -o "$time_file" ffmpeg -y -i "$OUTPUT_DIR/base.mp4" \
+    "$TIME_BIN" -p -o "$time_file" ffmpeg -y -i "$OUTPUT_DIR/base.mp4" \
         -i "$OUTPUT_DIR/audio.wav" \
         -filter_complex "$FILTER" -map '[vout]' -map '[aout]' \
         -c:v libx264 -preset medium -crf 20 -maxrate 4M -bufsize 8M \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- `fix(skills)`: Codex画像ラッパーのPNG検査から未宣言の`xxd`依存を除き、overlay benchmarkの計時コマンドをdevShellで明示してfresh Linux環境でも実行できるようにした（#4466）。
+
 - `feat(skills)`: `/short --thumbnail` が 9:16 画像生成と Veo ループ動画化を担い、`/short-thumbnail` の手順・prompt・script 導線を統合した（#3834）
 
 - `feat(skills)`: `/short` が `content_model.type` から collection / release の手順を自動分岐し、`/short-release` の生成契約・設定・参照スクリプトを統合した（#3833）

--- a/flake.nix
+++ b/flake.nix
@@ -54,6 +54,7 @@
             python314
             uv
             ffmpeg
+            time
           ];
 
           # ランタイム供給のみ。秘密は youtube_automation.infrastructure.secrets から

--- a/tests/repo/test_skill_shell_reference_runtime.py
+++ b/tests/repo/test_skill_shell_reference_runtime.py
@@ -495,6 +495,23 @@ fi
 """,
     )
     _write_executable(bin_dir / "ffprobe", "#!/bin/bash\nprintf 'h264\\n'\n")
+    _write_executable(
+        bin_dir / "time",
+        """#!/bin/bash
+time_file=""
+while [[ "$#" -gt 0 ]]; do
+  case "$1" in
+    -p) shift ;;
+    -o) time_file="$2"; shift 2 ;;
+    *) break ;;
+  esac
+done
+"$@"
+rc=$?
+printf 'real 1.25\nuser 0.50\nsys 0.25\n' > "$time_file"
+exit "$rc"
+""",
+    )
     env = os.environ.copy()
     env.update(
         {


### PR DESCRIPTION
Closes #4466

## 変更概要
- codex-image の乱数生成から xxd 依存を除去
- overlay benchmark の time 実装を環境変数で差し替え可能に変更
- devShell に GNU time を追加し、ランタイムテストを hermetic 化

## 検証
- nix develop --command uv run pytest tests/repo/test_skill_shell_reference_runtime.py tests/repo/test_skill_shell_reference_contract.py -n auto
- 最上段で全 pytest を実行

## 公式資料
- 追加参照なし