### PR TITLE
fix(tests): root環境の権限テストを決定的にする (#4467)

### DIFF
--- a/tests/commands/system/test_preflight_cli.py
+++ b/tests/commands/system/test_preflight_cli.py
@@ -406,17 +406,20 @@ def test_runtime_path_rejects_non_directory_without_leaking_path(
     assert invalid_path.name not in format_report([result])
 
 
-def test_runtime_path_fails_when_directory_is_not_writable(tmp_path: Path) -> None:
+def test_runtime_path_fails_when_directory_is_not_writable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     env = _isolated_env(tmp_path)
     repo = _init_repo(tmp_path, env)
     runtime_root = tmp_path / "current" / ".takt" / ".runtime"
     env.update(_runtime_env(runtime_root))
     read_only_tmp = runtime_root / "tmp"
-    read_only_tmp.chmod(0o500)
-    try:
-        result = check_runtime_path(repo, env)
-    finally:
-        read_only_tmp.chmod(0o700)
+    real_access = preflight.os.access
+    monkeypatch.setattr(
+        preflight.os,
+        "access",
+        lambda path, mode: False if Path(path) == read_only_tmp and mode == os.W_OK else real_access(path, mode),
+    )
+
+    result = check_runtime_path(repo, env)
 
     assert not result.ok
     assert "TMPDIR" in result.detail

--- a/tests/integration/test_dev_shell_sync.py
+++ b/tests/integration/test_dev_shell_sync.py
@@ -126,9 +126,9 @@ def test_nix_develop_syncs_missing_environment_and_is_quiet_on_reentry(project_c
 
 @pytest.mark.skipif(not _nix_is_available(), reason="a usable Nix daemon is required")
 def test_nix_develop_warns_when_sync_fails_but_enters_shell(project_copy: Path, tmp_path: Path) -> None:
-    environment = tmp_path / "missing-parent" / "environment"
-    environment.parent.mkdir()
-    environment.parent.chmod(0o500)
+    non_directory_parent = tmp_path / "not-a-directory"
+    non_directory_parent.write_text("blocks environment creation\n", encoding="utf-8")
+    environment = non_directory_parent / "environment"
 
     result = _nix_develop(project_copy, environment)
 


### PR DESCRIPTION
Closes #4467

## 変更概要
- chmod の実効ユーザー依存を排除し、os.access をテスト境界で制御
- uv sync 失敗ケースを root でも確実に失敗する不正パスで構成

## 検証
- nix develop --command uv run pytest tests/commands/system/test_preflight_cli.py tests/integration/test_dev_shell_sync.py -n auto
- 最上段で全 pytest を実行

## 公式資料
- 追加参照なし