### PR TITLE
chore(takt): リポジトリ専用 workflow を takt 0.60.0 へ追従させる (#4475)

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -1,5 +1,5 @@
 # Repository defaults only. Workflow structure lives in .takt/workflows/ and
-# reusable local differences from takt 0.55.1 builtins live in .takt/steps/.
+# reusable local differences from takt 0.60.0 builtins live in .takt/steps/.
 draft_pr: false
 base_branch: main
 auto_requeue_max_attempts: 0

--- a/.takt/steps/ci-verify.yaml
+++ b/.takt/steps/ci-verify.yaml
@@ -2,8 +2,7 @@ name: ci_verify
 tags: [review, delivery-gate]
 edit: false
 session: refresh
-persona: merge-readiness-reviewer
-provider_options:
-  extends: review-readonly
+persona: coding-reviewer
+capabilities: [readonly, enable-skills]
 instruction: yt-auto-ci-verify
 pass_previous_response: false

--- a/.takt/steps/design-review.yaml
+++ b/.takt/steps/design-review.yaml
@@ -1,12 +1,11 @@
 name: design_review
 tags: [review, design-gate]
+capabilities: [readonly, enable-skills]
 parallel:
   - name: requirements_review
     edit: false
     session: compact
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: supervisor
     instruction: yt-auto-review-design
     output_contracts:
       report:
@@ -16,8 +15,6 @@ parallel:
     edit: false
     session: compact
     persona: architecture-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-review-design
     output_contracts:
       report:
@@ -27,8 +24,6 @@ parallel:
     edit: false
     session: compact
     persona: testing-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-review-design
     output_contracts:
       report:

--- a/.takt/steps/diagnosis-review.yaml
+++ b/.takt/steps/diagnosis-review.yaml
@@ -1,12 +1,11 @@
 name: diagnosis_review
 tags: [review, diagnosis-gate]
+capabilities: [readonly, enable-skills]
 parallel:
   - name: causal_review
     edit: false
     session: compact
     persona: implementation-semantics-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-review-diagnosis
     output_contracts:
       report:
@@ -15,9 +14,7 @@ parallel:
   - name: competing_hypothesis_review
     edit: false
     session: compact
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-diagnosis
     output_contracts:
       report:
@@ -27,8 +24,6 @@ parallel:
     edit: false
     session: compact
     persona: testing-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-review-diagnosis
     output_contracts:
       report:

--- a/.takt/steps/docs-reviewers.yaml
+++ b/.takt/steps/docs-reviewers.yaml
@@ -1,12 +1,11 @@
 name: docs_review
 tags: [review, docs-gate]
+capabilities: [readonly, enable-skills]
 parallel:
   - name: correctness_review
     edit: false
     session: compact
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: supervisor
     instruction: yt-auto-review-docs
     output_contracts:
       report:
@@ -16,8 +15,6 @@ parallel:
     edit: false
     session: compact
     persona: architecture-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-review-docs
     output_contracts:
       report:

--- a/.takt/steps/fix.yaml
+++ b/.takt/steps/fix.yaml
@@ -1,5 +1,6 @@
 name: fix
 tags: [coding]
+capabilities: [edit, enable-skills]
 edit: true
 session: compact
 persona: coder

--- a/.takt/steps/implementation-high-write-tests-to-implement.yaml
+++ b/.takt/steps/implementation-high-write-tests-to-implement.yaml
@@ -1,5 +1,6 @@
 name: write_tests
 tags: [coding, test-planning]
+capabilities: [edit, enable-skills]
 edit: true
 persona: coder
 policy: [coding, testing]

--- a/.takt/steps/intake.yaml
+++ b/.takt/steps/intake.yaml
@@ -3,6 +3,5 @@ tags: [plan, intake]
 edit: false
 session: compact
 persona: planner
-provider_options:
-  extends: review-readonly
+capabilities: [readonly, enable-skills]
 instruction: yt-auto-intake

--- a/.takt/steps/reviewers.yaml
+++ b/.takt/steps/reviewers.yaml
@@ -1,12 +1,11 @@
 name: reviewers
 tags: [review]
+capabilities: [readonly, enable-skills]
 parallel:
   - name: arch_review
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: architecture-reviewer
     policy: review
     knowledge: architecture
@@ -19,8 +18,6 @@ parallel:
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: ai-antipattern-reviewer
     policy: [review, ai-antipattern]
     instruction: ai-antipattern-review
@@ -32,8 +29,6 @@ parallel:
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: coding-reviewer
     policy: [review, coding]
     instruction: review-coding
@@ -45,8 +40,6 @@ parallel:
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: implementation-semantics-reviewer
     policy: review
     knowledge: implementation-semantics
@@ -59,8 +52,6 @@ parallel:
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: contract-lifecycle-reviewer
     policy: review
     knowledge: contract-lifecycle
@@ -73,8 +64,6 @@ parallel:
     tags: [review]
     edit: false
     session: compact
-    provider_options:
-      extends: review-readonly
     persona: robustness-reviewer
     policy: review
     knowledge: robustness

--- a/.takt/steps/spillover.yaml
+++ b/.takt/steps/spillover.yaml
@@ -3,6 +3,5 @@ tags: [delivery]
 edit: false
 session: refresh
 persona: planner
-provider_options:
-  extends: review-readonly
+capabilities: [readonly, enable-skills]
 instruction: yt-auto-spillover

--- a/.takt/workflows/audit-unit-split.yaml
+++ b/.takt/workflows/audit-unit-split.yaml
@@ -1,11 +1,6 @@
 name: audit-unit-split
 description: スコープ分割版ユニットテスト監査。plan が台帳スケルトンを作り、audit が {report} 注入された既存台帳をインクリメンタルに拡張する。コード修正なしで Issue 直貼り可能なレポートを作成する
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-    opencode:
-      network_access: true
+capabilities: readonly
 # 汎用 audit lane と違い、production/test file を個別行へ分割する台帳形式を維持する。
 # plan が全対象を列挙し、audit は既存行を消さず一定量ずつ判定し、supervise と review が
 # 物理行数・進捗・根拠を独立検収する。

--- a/.takt/workflows/yt-auto-audit-runs.yaml
+++ b/.takt/workflows/yt-auto-audit-runs.yaml
@@ -2,12 +2,7 @@ name: yt-auto-audit-runs
 description: >
   takt 資産と読み取り可能な run trace の read-only 監査 lane。定義・参照・有限停止・
   composition・反復失敗を追記型台帳で監査し、独立検収後だけ docs/audits/ へ配置する。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 24
 initial_step: plan
 
@@ -31,8 +26,6 @@ steps:
     tags: [plan, audit]
     edit: false
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-runs-plan
     output_contracts:
       report:
@@ -53,8 +46,6 @@ steps:
     edit: false
     session: refresh
     persona: testing-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-runs-run
     output_contracts:
       report:
@@ -74,8 +65,6 @@ steps:
     tags: [review, supervise]
     edit: false
     persona: supervisor
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-supervise
     pass_previous_response: false
     structured_output:
@@ -91,9 +80,7 @@ steps:
   - name: review
     tags: [review, final-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-audit-review
     pass_previous_response: false
     structured_output:
@@ -108,6 +95,7 @@ steps:
 
   - name: publish
     tags: [delivery, docs]
+    capabilities: [edit, enable-skills]
     edit: true
     persona: coder
     required_permission_mode: edit

--- a/.takt/workflows/yt-auto-audit.yaml
+++ b/.takt/workflows/yt-auto-audit.yaml
@@ -2,12 +2,7 @@ name: yt-auto-audit
 description: >
   汎用の read-only 監査 lane。有限スコープを定義し、追記型台帳を監査と監督で
   単調に拡張し、独立検収後だけ docs/audits/ へ配置する。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 24
 initial_step: plan
 
@@ -31,8 +26,6 @@ steps:
     tags: [plan, audit]
     edit: false
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-plan
     output_contracts:
       report:
@@ -53,8 +46,6 @@ steps:
     edit: false
     session: refresh
     persona: testing-reviewer
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-run
     output_contracts:
       report:
@@ -74,8 +65,6 @@ steps:
     tags: [review, supervise]
     edit: false
     persona: supervisor
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-audit-supervise
     pass_previous_response: false
     structured_output:
@@ -91,9 +80,7 @@ steps:
   - name: review
     tags: [review, final-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-audit-review
     pass_previous_response: false
     structured_output:
@@ -108,6 +95,7 @@ steps:
 
   - name: publish
     tags: [delivery, docs]
+    capabilities: [edit, enable-skills]
     edit: true
     persona: coder
     required_permission_mode: edit

--- a/.takt/workflows/yt-auto-docs.yaml
+++ b/.takt/workflows/yt-auto-docs.yaml
@@ -3,12 +3,7 @@ description: >
   文書・skill・instruction とその repository-contract test だけを変更する lane。
   intake、文書限定計画、実装、2 観点の文書レビュー、CI 同等ゲート、
   fail-closed final gate、spillover を行い production/runtime 変更は拒否する。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 32
 initial_step: intake
 
@@ -62,6 +57,7 @@ steps:
 
   - name: implement
     tags: [coding, docs]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -92,9 +88,7 @@ steps:
   - name: docs_gate
     tags: [review, docs-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-docs-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -111,6 +105,7 @@ steps:
 
   - name: docs_fix
     tags: [coding, docs]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -140,7 +135,7 @@ steps:
 
   - name: final_gate
     kind: workflow_call
-    call: merge-readiness-final-gate
+    call: final-gate
     args:
       supervise_knowledge: [architecture]
     rules:

--- a/.takt/workflows/yt-auto-feature.yaml
+++ b/.takt/workflows/yt-auto-feature.yaml
@@ -2,12 +2,7 @@ name: yt-auto-feature
 description: >
   新機能・機能拡張用。intake、実装前設計ゲート、test-first、6 観点の専門レビュー、
   CI 同等ゲート、fail-closed final gate、spillover を行う。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 50
 initial_step: intake
 
@@ -41,7 +36,7 @@ loop_monitors:
     threshold: 3
     judge:
       persona: supervisor
-      instruction: loop-monitor-reviewers-fix-fc
+      instruction: loop-monitor-reviewers-fix
       rules:
         - condition: 修正進捗があり次の修正が実行可能である
           next: fix
@@ -78,8 +73,6 @@ steps:
     tags: [plan, test-planning]
     edit: false
     persona: test-planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-test-design
     structured_output:
       schema_ref: yt-auto-decision
@@ -108,9 +101,7 @@ steps:
   - name: design_gate
     tags: [review, design-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-design-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -130,8 +121,6 @@ steps:
     edit: false
     session: compact
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-design-fix
     structured_output:
       schema_ref: yt-auto-decision
@@ -162,6 +151,7 @@ steps:
 
   - name: implement
     tags: [coding]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -213,9 +203,7 @@ steps:
   - name: review_gate
     tags: [review]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -244,7 +232,7 @@ steps:
 
   - name: final_gate
     kind: workflow_call
-    call: merge-readiness-final-gate
+    call: final-gate
     args:
       supervise_knowledge: [architecture, takt]
     rules:

--- a/.takt/workflows/yt-auto-fix.yaml
+++ b/.takt/workflows/yt-auto-fix.yaml
@@ -3,12 +3,7 @@ description: >
   バグ・回帰修正用。intake、原因診断と対立仮説、診断レビュー、修正前 red、
   root-cause repair、6 観点の専門レビュー、CI 同等ゲート、fail-closed final gate、
   spillover を行う。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 50
 initial_step: intake
 
@@ -42,7 +37,7 @@ loop_monitors:
     threshold: 3
     judge:
       persona: supervisor
-      instruction: loop-monitor-reviewers-fix-fc
+      instruction: loop-monitor-reviewers-fix
       rules:
         - condition: 修正進捗があり次の修正が実行可能である
           next: fix
@@ -69,8 +64,6 @@ steps:
     edit: false
     session: compact
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-diagnose
     structured_output:
       schema_ref: yt-auto-decision
@@ -97,9 +90,7 @@ steps:
   - name: diagnosis_gate
     tags: [review, diagnosis-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-diagnosis-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -119,8 +110,6 @@ steps:
     edit: false
     session: compact
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-diagnosis-fix
     structured_output:
       schema_ref: yt-auto-decision
@@ -134,6 +123,7 @@ steps:
 
   - name: reproduce
     tags: [coding, test-planning]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -153,6 +143,7 @@ steps:
 
   - name: repair
     tags: [coding]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -193,9 +184,7 @@ steps:
   - name: review_gate
     tags: [review]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -224,7 +213,7 @@ steps:
 
   - name: final_gate
     kind: workflow_call
-    call: merge-readiness-final-gate
+    call: final-gate
     args:
       supervise_knowledge: [architecture, takt]
     rules:

--- a/.takt/workflows/yt-auto-maintenance.yaml
+++ b/.takt/workflows/yt-auto-maintenance.yaml
@@ -3,12 +3,7 @@ description: >
   挙動維持の保守・リファクタ用。intake、維持契約の計画と設計ゲート、変更前
   safety net、リファクタ、6 観点の専門レビュー、CI 同等ゲート、
   fail-closed final gate、spillover を行う。
-workflow_config:
-  provider_options:
-    codex:
-      network_access: true
-      skills:
-        repo: true
+capabilities: [readonly, enable-skills]
 max_steps: 44
 initial_step: intake
 
@@ -42,7 +37,7 @@ loop_monitors:
     threshold: 3
     judge:
       persona: supervisor
-      instruction: loop-monitor-reviewers-fix-fc
+      instruction: loop-monitor-reviewers-fix
       rules:
         - condition: 修正進捗があり次の修正が実行可能である
           next: fix
@@ -90,9 +85,7 @@ steps:
   - name: plan_gate
     tags: [review, design-gate]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-design-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -112,8 +105,6 @@ steps:
     edit: false
     session: compact
     persona: planner
-    provider_options:
-      extends: review-readonly
     instruction: yt-auto-design-fix
     structured_output:
       schema_ref: yt-auto-decision
@@ -127,6 +118,7 @@ steps:
 
   - name: safety_net
     tags: [coding, test-planning]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -145,6 +137,7 @@ steps:
 
   - name: refactor
     tags: [coding]
+    capabilities: [edit, enable-skills]
     edit: true
     session: compact
     persona: coder
@@ -185,9 +178,7 @@ steps:
   - name: review_gate
     tags: [review]
     edit: false
-    persona: merge-readiness-reviewer
-    provider_options:
-      extends: review-readonly
+    persona: review-adjudicator
     instruction: yt-auto-review-gate
     structured_output:
       schema_ref: yt-auto-decision
@@ -216,7 +207,7 @@ steps:
 
   - name: final_gate
     kind: workflow_call
-    call: merge-readiness-final-gate
+    call: final-gate
     args:
       supervise_knowledge: [architecture, takt]
     rules:

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -60,9 +60,10 @@
 
 ## workflow 設計の要点(保守者向け)
 
-公開定義は `.takt/workflows/`、takt 0.55.1 builtin から eject した共有 step とリポジトリ固有 step は `.takt/steps/`、固有 instruction / report contract だけを `.takt/facets/` に置く。一般的な plan / test-first / implementation review / fix / final gate は builtin 由来 fragment を正とし、旧内部構造への互換 adapter は持たない。
+公開定義は `.takt/workflows/`、takt 0.60.0 builtin から eject した共有 step とリポジトリ固有 step は `.takt/steps/`、固有 instruction / report contract だけを `.takt/facets/` に置く。一般的な plan / test-first / implementation review / fix / final gate は builtin 由来 fragment を正とし、旧内部構造への互換 adapter は持たない。
 
-- **検証は実行時 takt を正とする。** 変更前に `takt --version` と `takt catalog` / `takt eject` の内容を確認し、全公開 workflow へ `takt workflow doctor`、各 workflow へ `takt prompt <workflow>` を実行する
+- **検証は実行時 takt を正とする。** 変更前に `takt --version` と `takt catalog` / `takt eject` の内容を確認し、全公開 workflow へ `takt workflow doctor`、各 workflow へ `takt prompt <workflow>` を実行する。`takt prompt` は `workflow_call` の final gate だけ `[ERROR] reportContent is required for report-based judgment` で止まる — builtin `review-fix-default` でも同じ位置で止まるため、その 1 点より前の全 step が合成できていれば正常
+- **実行環境の権限は `capabilities` で宣言する。** workflow 直下の `capabilities: [readonly, enable-skills]` が全 step の既定になり、step 側の宣言は**継承ではなく置換**する。したがって `edit: true` の step は必ず `capabilities: [edit, enable-skills]` を自分で宣言する(落とすと readonly を継承して実行時に書き込めない)。`tests/repo/test_takt_workflow_contract.py::test_edit_boundaries_are_pinned_by_explicit_capability_sets` が静的に担保する
 - **CI 同等ゲート(`ci_verify`)を final gate より前に置く。** 最低でも ruff check / format、全 pytest、any-usage gate、`git diff --check` を実行し、変更 path に応じた CI job も追加する。ローカルで実行できるゲートの失敗は `fail` として修正へ戻す。実測した環境でコマンドまたは前提リソースを利用できない項目は、項目名と理由を findings に列挙して CI-only とし、ローカル判定から除外して正本の CI へ委ねる。`ci_verify` の verdict は `pass` / `fail` の 2 値とし、環境差を理由に ABORT しない
 - **レビューと final gate は fail-closed。** 専門レビューは未解決 finding / conflict / 判定不能を修正・再計画・ABORT へ送り、既知 verdict に一致しない出力も ABORT する。final gate も COMPLETE 以外をレビュー・修正・再計画・ABORT へ戻す
 - **分岐は 1 個の strict structured schema と `when(structured.*)` で決定する。** 並列 reviewer は各 report を生成するだけにし、直後の gate が全 report を読み structured verdict を返す。これにより判定不能を fallback ABORT へ送り、`takt prompt` でも全 step を reportContent なしで合成できる

--- a/tests/repo/test_takt_workflow_contract.py
+++ b/tests/repo/test_takt_workflow_contract.py
@@ -1,4 +1,4 @@
-"""takt 0.55 系 workflow の利用者向け契約を静的に検証する。"""
+"""takt 0.60 系 workflow の利用者向け契約を静的に検証する。"""
 
 from __future__ import annotations
 
@@ -133,6 +133,15 @@ def _walk(value: object) -> Iterable[tuple[str, object]]:
             yield from _walk(child)
 
 
+def _capabilities(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    assert isinstance(value, list)
+    return [str(item) for item in value]
+
+
 def _next_targets(workflow: dict[str, object]) -> set[str]:
     return {value for key, value in _walk(workflow) if key == "next" and isinstance(value, str)}
 
@@ -151,10 +160,7 @@ def test_public_workflow_surface_is_exact_and_named_consistently() -> None:
 
 def test_all_local_references_exist_and_builtin_calls_are_explicit() -> None:
     documents = [*WORKFLOWS.glob("*.yaml"), *STEPS.glob("*.yaml")]
-    allowed_builtin_calls = {
-        "merge-readiness-final-gate",
-        "merge-readiness-finding-contract-final-gate",
-    }
+    allowed_builtin_calls = {"final-gate"}
     allowed_builtin_formats = {"unit-audit-plan"}
 
     for path in documents:
@@ -445,6 +451,32 @@ def test_lane_edit_boundaries_are_explicit_and_minimal() -> None:
         assert editable == expected, name
 
 
+def test_edit_boundaries_are_pinned_by_explicit_capability_sets() -> None:
+    # step の capabilities は workflow 既定を継承ではなく置換する。edit step が宣言を落とすと
+    # readonly を継承して実行時に書き込めなくなるため、宣言の有無を静的に固定する。
+    for name in PUBLIC_WORKFLOWS:
+        workflow = _workflow(name)
+        assert _capabilities(workflow.get("capabilities"))[:1] == ["readonly"], name
+        for step in _steps(workflow):
+            expanded = _expanded_step(step)
+            capabilities = _capabilities(expanded.get("capabilities"))
+            if expanded.get("edit") is True:
+                assert capabilities[:1] == ["edit"], (name, step["name"])
+            else:
+                assert "edit" not in capabilities, (name, step["name"])
+
+    for path in STEPS.glob("*.yaml"):
+        fragment = _load(path)
+        capabilities = _capabilities(fragment.get("capabilities"))
+        if fragment.get("edit") is True:
+            assert capabilities[:1] == ["edit"], path
+
+    for path in (*WORKFLOWS.glob("*.yaml"), *STEPS.glob("*.yaml")):
+        for key, value in _walk(_load(path)):
+            if key == "capabilities":
+                assert set(_capabilities(value)) <= {"readonly", "edit", "enable-skills"}, (path, value)
+
+
 def test_report_consumers_receive_concrete_artifacts_or_report_directory() -> None:
     consumers = {
         "yt-auto-design-fix": ("plan.md", "requirements-design-review.md", "test-design-review.md"),
@@ -498,6 +530,12 @@ def test_removed_legacy_internal_assets_do_not_return() -> None:
     for relative in ("scripts", "facets/partials", "facets/personas", "facets/policies"):
         path = TAKT / relative
         assert not path.exists() or not any(candidate.is_file() for candidate in path.rglob("*"))
+    # takt 0.60 で撤去された綴り。復活すると workflow が load 段階で落ちるか、
+    # 存在しない facet を静かに参照する。
+    for path in (*WORKFLOWS.glob("*.yaml"), *STEPS.glob("*.yaml")):
+        text = path.read_text(encoding="utf-8")
+        for removed in ("provider_options", "review-readonly", "merge-readiness"):
+            assert removed not in text, (path, removed)
 
 
 def test_docs_and_config_match_the_public_surface() -> None:


### PR DESCRIPTION
Closes #4475

## 変更概要

`.takt/` の公開 workflow 7 本は takt 0.55.1 builtin から eject した fork のままで、実行時の takt 0.60.0 では **7 本すべてが load 段階で失敗**していた（`takt workflow doctor` 全滅）。takt 正規経路が全 lane で使用不能だったのを解消する。

### 1. `provider_options` → `capabilities`

0.60 で `provider_options` は workflow YAML の全階層から削除された。workflow 直下を `capabilities: [readonly, enable-skills]`、`edit: true` の step を `capabilities: [edit, enable-skills]` に移行する。

step の `capabilities` は **workflow 既定へマージせず置換する**（`workflowStepNormalizer.js`: `A step's own capabilities: replaces the workflow default rather than merging`）。edit step が宣言を落とすと readonly を継承して実行時にだけ書き込み不能になり、load も `doctor` も通過してしまうため、宣言の有無を contract test で固定した。

旧 `workflow_config` は codex へ `network_access: true` + `skills: {repo: true}` を与えていた。builtin preset `enable-skills` は `repo: true, user: true` なので、user skill が worker から見えるようになる点だけが挙動の広がり。

### 2. preset `review-readonly` → `readonly`

改名に追従。共有 fragment（`design-review` / `diagnosis-review` / `docs-reviewers` / `reviewers`）は parallel 親に read-only 境界を明示し、呼び出し元 workflow の既定に依存しないようにした。

### 3. `merge-readiness-final-gate` → `final-gate`

builtin から削除され supervise 1 step 構成の `final-gate` へ集約された。返り値（`needs_fix` / `need_replan`）と `supervise_knowledge` param は互換のため、呼び出し側の rule はそのまま。

### 4. persona `merge-readiness-reviewer` の写像

削除済み。`.takt/facets/personas/` が空であることは既存 contract test で機械担保されており、`docs/takt-operations.md` も互換 adapter を禁じているため、0.60 builtin の担当境界へ写像した。

| 用途 | 移行先 | 根拠 |
| --- | --- | --- |
| 各 lane の structured gate | `review-adjudicator` | builtin `peer-review-adjudication` と同じ「全 report を読み証拠で裁定する」役割 |
| `ci_verify` | `coding-reviewer` | builtin `peer-review-fix-verifier` と同じ検証役。`supervisor` は役割定義で「機械ゲートの実行状況・結果・ログの審査はしない」と明記されており不適 |
| 並列レビュー 1 レーン | `supervisor`（requirements / docs-correctness）、`review-adjudicator`（competing-hypothesis） | 要件充足判定と証拠裁定で担当を分けた |

### 5. `loop-monitor-reviewers-fix-fc` → `loop-monitor-reviewers-fix`

削除された `-fc` 版は Finding Contract 専用だった。本リポジトリは structured gate 方式で finding contract を使っていないため、非依存版が正しい移行先。

## 追加した機械担保

- `test_edit_boundaries_are_pinned_by_explicit_capability_sets`: edit step の capability 宣言漏れと、宣言できる capability 名の集合を静的に検証
- `test_removed_legacy_internal_assets_do_not_return`: `provider_options` / `review-readonly` / `merge-readiness` の綴り復活ガードを追加
- `allowed_builtin_calls` を `{"final-gate"}` へ更新

## 検証コマンド

```bash
takt workflow doctor
takt prompt yt-auto-feature   # 各 lane で実行
nix develop --command uv run pytest tests/repo -q -n auto
nix develop --command uv run ruff check .
nix develop --command uv run ruff format --check .
bash .github/scripts/any-usage-gate.sh
git diff --check
```

### 結果

- `takt workflow doctor`: **7/7 OK**（移行前は 7/7 失敗）
- `takt prompt`: audit 系 3 本は全 step 合成成功。delivery 系 4 本は終端の `final_gate`（`workflow_call`）でのみ `[ERROR] reportContent is required for report-based judgment`。**takt 自身の builtin `review-fix-default` でも同じ位置で止まる**ため仕様側の制約で、それより前の全 step は合成できている
- `pytest tests/repo -n auto`: **1615 passed, 2 skipped**
- ruff check / format、any-usage gate、`git diff --check`: all pass

なお `tests/repo/test_select_affected_tests.py::test_cli_output_is_deterministic_unique_and_existing_subset` が並列実行で 1 度だけ失敗したが、単体実行でも再実行でも通るため本 PR とは無関係な flaky。別途対応する。

## 参照した資料

- 実行時 takt 0.60.0 の `builtins/ja/`（workflows / steps / facets / provider-options）と `dist/core/models/workflow-schemas.js` / `dist/infra/config/loaders/workflowStepNormalizer.js` / `dist/infra/config/loaders/capabilitySetResolver.js`
- takt 0.60.0 `README.md`「Dedicated provider configuration (`runtime.yaml`)」
- 0.55.1 builtin との差分（persona / instruction / output-contract / workflow の増減）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
