### PR TITLE
fix(wf-status): 要対応カードの赤い左枠を削除する (#4398)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(wf-status)`: 制作状況 View の要対応カードから重複した赤い左枠を削除し、通常カードと同じ薄いグレーの外枠で表示する（#4398）。
 - `feat(wf-status)`: 制作状況 View で phase・要対応・成果物詳細の順に情報を整理し、停滞・警告・未生成を先頭表示して mobile と keyboard でも絞り込みやすくする（#4378）。
 - `feat(documents)`: review View で候補名・preview・固定 QA・確定操作を一意に関連付け、画像・音声・動画・テキストを mobile と keyboard でも比較しやすくする（#4377）。
 - `feat(documents)`: schema 文書 View で要点・主要指標を先に表示し、長い根拠や未知の追加データを欠落させず native details へ段階表示する（#4376）。

--- a/src/youtube_automation/domains/documents/resources/workflow_status.css
+++ b/src/youtube_automation/domains/documents/resources/workflow_status.css
@@ -49,7 +49,6 @@ h1 { font-size: clamp(1.75rem, 5vw, 2.75rem); margin: .2rem 0; }
   padding: 1.25rem;
   box-shadow: 0 4px 16px rgb(31 45 70 / 6%);
 }
-.collection-card[data-attention=true] { border-left: .35rem solid #b5473c; }
 .collection-card h2 { margin: .2rem 0 1rem; }
 .attention {
   background: #fff4f2;

--- a/tests/domains/documents/test_workflow_status_rendering.py
+++ b/tests/domains/documents/test_workflow_status_rendering.py
@@ -107,6 +107,8 @@ def test_attention_collections_and_missing_artifacts_render_before_normal_detail
     assert "停滞: 6日" in segment
     assert "Master: 未生成" in segment
     assert "workflow state が古い" in segment
+    assert ".collection-card[data-attention=true]" not in html
+    assert "border: 1px solid #d3dae5" in html
 
 
 def test_empty_snapshot_renders_an_explicit_empty_state() -> None:


### PR DESCRIPTION
## Summary
- 要対応カード専用の赤い左枠を削除し、通常カードと同じ薄いグレーの外枠へ統一
- 内部の要対応表示と要対応カードを先に並べる挙動を回帰テストで維持

Closes #4398