### PR TITLE
fix(collection-serve): owner昇格前に自己登録を完了する (#4477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- `fix(collection-serve)`: discovery owner takeover時に自己登録を完了してからowner readinessを公開し、公開endpointが一時的に空になるraceを解消した（#4477）。
+
 - `fix(tests)`: 過去issueのcommit差分だけを固定する履歴依存テストを削除し、release noteのtag整合は履歴を取得したCIで維持しつつshallow checkoutでは誤ってredにしないようにした（#4469）。
 
 - `fix(tests)`: 通常のpytestからNix wrapperと`pnpm dlx`自体の再検証を除き、extension契約をリポジトリ内のflake・workflow設定だけで決定的に検査するようにした（#4468）。

--- a/src/youtube_automation/commands/collections/collection_serve_discovery.py
+++ b/src/youtube_automation/commands/collections/collection_serve_discovery.py
@@ -327,12 +327,21 @@ class DiscoveryLifecycle:
             if self._endpoint_responds():
                 raise DiscoveryRegistryError("discovery registry endpoint has incompatible schema") from bind_error
             return False
+        # Seed the replacement registry before either its HTTP endpoint or the
+        # owner readiness flag becomes observable.  Otherwise takeover can
+        # briefly expose a valid registry response with no servers.
+        try:
+            state.register({"instance_id": self.instance_id, "server_info": self.server_info})
+        except (DiscoveryRegistryError, ValueError):
+            server.server_close()
+            raise
         self._state = state
         self._registry_server = server
         self.registry_port = int(server.server_address[1])
-        self.is_owner = True
+        self._registered = True
         self._registry_thread = threading.Thread(target=server.serve_forever, daemon=True)
         self._registry_thread.start()
+        self.is_owner = True
         return True
 
     def _endpoint_responds(self) -> bool:
@@ -412,7 +421,8 @@ class DiscoveryLifecycle:
         deadline = time.monotonic() + self._startup_timeout_seconds
         last_error: OSError | None = None
         while True:
-            self._become_owner()
+            if self._become_owner():
+                return
             try:
                 self._register()
                 return
@@ -443,7 +453,7 @@ class DiscoveryLifecycle:
                     continue
             except (OSError, urllib.error.URLError):
                 if self._become_owner():
-                    self._register()
+                    return
 
     def stop(self) -> None:
         self._stop_event.set()

--- a/tests/commands/collections/test_collection_serve_discovery.py
+++ b/tests/commands/collections/test_collection_serve_discovery.py
@@ -604,6 +604,28 @@ def test_real_socket_owner_follower_takeover_keeps_public_endpoint_available():
     assert not lifecycle_b.ownership_thread.is_alive()
 
 
+def test_become_owner_registers_before_publishing_owner_readiness(monkeypatch):
+    lifecycle = DiscoveryLifecycle.for_loopback_test(
+        server_info("http://beta.localhost:49152", "Beta"), discovery_port=0
+    )
+    owner_state_during_registration: list[bool] = []
+    original_register = RegistryState.register
+
+    def record_owner_state(state: RegistryState, payload: object) -> None:
+        owner_state_during_registration.append(lifecycle.is_owner)
+        original_register(state, payload)
+
+    monkeypatch.setattr(RegistryState, "register", record_owner_state)
+
+    try:
+        assert lifecycle._become_owner()
+        assert owner_state_during_registration == [False]
+        assert lifecycle.is_owner
+        assert_urls(lifecycle._endpoint(), {"http://beta.localhost:49152"})
+    finally:
+        lifecycle.stop()
+
+
 def test_lifecycle_start_fails_when_fixed_port_http_responder_returns_404():
     methods: list[str] = []
 


### PR DESCRIPTION
Closes #4477

## 変更概要
- 新しいdiscovery ownerのRegistryStateへ自己登録してからHTTP endpointとowner readinessを公開
- owner初期化後の重複登録を除去
- 登録中はis_ownerがfalseで、公開直後のendpointに自身が存在する回帰テストを追加

## 検証
- 対象takeoverテスト単独100回: 100/100 passed
- 対象ファイル並列: 44 passed
- 関連SIGTERMテスト単独10回: 10/10 passed
- nix develop --command uv run pytest -n auto: 9963 passed, 4 skipped
- ruff check / format check: passed

## 公式資料
- 追加参照なし