### PR TITLE
test: tests/ ツリーの走査と書き換えを直列化する (#4487)

### DIFF
--- a/tests/helpers/tests_tree.py
+++ b/tests/helpers/tests_tree.py
@@ -1,0 +1,60 @@
+"""実 `tests/` ツリーを触るテスト同士を直列化する reader-writer lock。
+
+`tests/repo/test_pytest_lane_contract.py` の relocation probe だけが、契約検証のために
+`tests/` 配下の実ファイルを一時的に別 path へ動かす writer になる（lane 判定は
+`tests/conftest.py` の配下でしか効かないので tmp_path へ逃がせない）。一方で `tests/`
+を全走査する契約テストと `.github/scripts/select-affected-tests.py` は reader にあたる。
+
+`-n auto` では両者が別 worker で同時に走るため、writer の窓に reader が重なると走査
+結果からモジュールが欠けたり、rglob 直後の `read_text` が `FileNotFoundError` になる。
+selector はそれを OSError として掴んで `ALL` へ fail-safe するので、症状は「計画が
+ALL に化ける」形で現れる。
+
+reader 同士は互いに干渉しないので `LOCK_SH` で並行させ、writer だけ `LOCK_EX` で
+締め出す。全部を `LOCK_EX` にすると `-n auto` の並列度を無駄に削る。
+
+公開名を `test` で始めてはならない。pytest の既定 `python_functions = test*` は
+アンダースコアを要求しないグロブなので、`tests_tree_read_lock` のような名前は
+import した先の module で「テスト関数」として収集されてしまう。
+"""
+
+from __future__ import annotations
+
+import fcntl
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+# プロセス跨ぎで共有する必要があるので tmp 配下の固定 path に置く。flock は fd の
+# close で必ず解放されるため、異常終了しても stale lock は残らない。
+TESTS_TREE_LOCK: Path = Path(tempfile.gettempdir()) / "pytest-tests-tree.lock"
+
+
+@contextmanager
+def _flock(mode: int) -> Iterator[None]:
+    with TESTS_TREE_LOCK.open("a+") as lock_file:
+        fcntl.flock(lock_file, mode)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+@contextmanager
+def shared_tests_tree_lock() -> Iterator[None]:
+    """`tests/` を走査する間、実ファイルを動かす writer を締め出す。"""
+    with _flock(fcntl.LOCK_SH):
+        yield
+
+
+@contextmanager
+def exclusive_tests_tree_lock() -> Iterator[None]:
+    """`tests/` 配下の実ファイルを一時的に動かす間、走査側を締め出す。
+
+    同一プロセスでも fd が違えば別の lock holder として扱われるため、この lock の
+    内側から `shared_tests_tree_lock()` を取ると自己 deadlock する。内側では
+    `*_without_lock` 系の非ロック版を呼ぶこと。
+    """
+    with _flock(fcntl.LOCK_EX):
+        yield

--- a/tests/repo/test_pytest_lane_contract.py
+++ b/tests/repo/test_pytest_lane_contract.py
@@ -3,22 +3,19 @@
 from __future__ import annotations
 
 import ast
-import fcntl
 import shutil
 import subprocess
 import sys
 import tempfile
-from contextlib import contextmanager
 from pathlib import Path
-from typing import Iterator
 
 from tests.helpers.paths import REPO_ROOT
+from tests.helpers.tests_tree import exclusive_tests_tree_lock, shared_tests_tree_lock
 
 ROOT = REPO_ROOT
 TESTS = ROOT / "tests"
 CONFTEST = TESTS / "conftest.py"
 _RELOCATION_PROBE_PREFIX = "pytest-lane-relocation-"
-_REGISTRY_LOCK = Path(tempfile.gettempdir()) / "pytest-lane-registry.lock"
 
 
 def _registry_ast_value(name: str) -> ast.expr:
@@ -65,18 +62,8 @@ def _registered_lane_module_names() -> frozenset[str]:
     return frozenset(REPO_CONTRACT_MODULES | SLOW_MODULES) | frozenset(module_name for module_name, _ in SLOW_NODE_IDS)
 
 
-@contextmanager
-def _lane_registry_lock() -> Iterator[None]:
-    with _REGISTRY_LOCK.open("a+") as lock_file:
-        fcntl.flock(lock_file, fcntl.LOCK_EX)
-        try:
-            yield
-        finally:
-            fcntl.flock(lock_file, fcntl.LOCK_UN)
-
-
 def _source_module_paths(module_name: str) -> tuple[Path, ...]:
-    with _lane_registry_lock():
+    with shared_tests_tree_lock():
         return _source_module_paths_without_lock(module_name)
 
 
@@ -108,7 +95,7 @@ def test_registered_lane_modules_exist() -> None:
 
 def test_registered_slow_nodes_belong_to_slow_lane() -> None:
     """REQ-3042-01a: every registered slow node belongs to the slow lane."""
-    with _lane_registry_lock():
+    with shared_tests_tree_lock():
         expected = _slow_node_paths_without_lock()
         result = subprocess.run(
             [
@@ -144,32 +131,37 @@ def test_slow_marker_survives_nested_module_relocation() -> None:
     """REQ-3042-01c: a registered slow node remains slow in a nested module path."""
     module_name, test_identifier = SLOW_NODE_IDS[0]
 
-    with tempfile.TemporaryDirectory(prefix="pytest-lane-relocation-", dir=TESTS) as temp_dir:
+    # probe directory の作成から後始末までを write lock の内側に収める。実ツリーを
+    # 走査する reader（select-affected / layout 契約）から見て、この窓の外では
+    # `tests/` が常に本来の姿でなければならない。
+    with (
+        exclusive_tests_tree_lock(),
+        tempfile.TemporaryDirectory(prefix=_RELOCATION_PROBE_PREFIX, dir=TESTS) as temp_dir,
+    ):
         relocated = Path(temp_dir) / "nested" / module_name
         relocated.parent.mkdir()
-        with _lane_registry_lock():
-            source = _source_module_paths_without_lock(module_name)
-            assert len(source) == 1, f"slow node module must resolve uniquely: {module_name} -> {source}"
-            shutil.move(source[0], relocated)
-            try:
-                result = subprocess.run(
-                    [
-                        sys.executable,
-                        "-m",
-                        "pytest",
-                        "--collect-only",
-                        "-q",
-                        "-m",
-                        "slow",
-                        str(relocated.relative_to(ROOT)),
-                    ],
-                    cwd=ROOT,
-                    capture_output=True,
-                    text=True,
-                    check=False,
-                )
-            finally:
-                shutil.move(relocated, source[0])
+        source = _source_module_paths_without_lock(module_name)
+        assert len(source) == 1, f"slow node module must resolve uniquely: {module_name} -> {source}"
+        shutil.move(source[0], relocated)
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "--collect-only",
+                    "-q",
+                    "-m",
+                    "slow",
+                    str(relocated.relative_to(ROOT)),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            shutil.move(relocated, source[0])
 
     relocated_node = f"{relocated.relative_to(ROOT)}::{test_identifier}"
     collected = {line for line in result.stdout.splitlines() if line.startswith("tests/")}
@@ -187,7 +179,7 @@ def test_registered_lane_module_basenames_are_unique_source_modules() -> None:
 
 def test_slow_node_ids_reference_existing_modules_and_tests() -> None:
     """REQ-3042-02: every registered slow node resolves to one collected test."""
-    with _lane_registry_lock():
+    with shared_tests_tree_lock():
         expected = _slow_node_paths_without_lock()
         result = subprocess.run(
             [sys.executable, "-m", "pytest", "--collect-only", "-q", *expected],

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
+from tests.helpers.tests_tree import shared_tests_tree_lock
 
 SCRIPT = REPO_ROOT / ".github/scripts/select-affected-tests.py"
 
@@ -176,22 +177,28 @@ def test_cli_output_is_deterministic_unique_and_existing_subset(tmp_path: Path) 
         encoding="utf-8",
     )
 
-    first = _run_cli(changes)
-    second = _run_cli(changes)
-    json_result = _run_cli(changes, "--format", "json")
+    # CLI も この test 自身も実ツリーを走査する。lane 契約の relocation probe が
+    # `tests/` の実ファイルを動かす窓と重なると、selector は設計どおり `ALL` へ
+    # fail-safe するため決定性の契約が成立しない。観測はすべて read lock の内側で
+    # 済ませ、判定だけ外に出す。
+    with shared_tests_tree_lock():
+        first = _run_cli(changes)
+        second = _run_cli(changes)
+        json_result = _run_cli(changes, "--format", "json")
+        targets = first.stdout.splitlines()
+        all_tests = {
+            path.relative_to(REPO_ROOT).as_posix()
+            for path in (REPO_ROOT / "tests").rglob("*.py")
+            if path.name.startswith("test_") or path.name.endswith("_test.py")
+        }
+        targets_exist = all((REPO_ROOT / target).is_file() for target in targets)
 
     assert first.returncode == second.returncode == json_result.returncode == 0
     assert first.stdout == second.stdout
-    targets = first.stdout.splitlines()
     assert targets == sorted(set(targets))
     assert targets
-    all_tests = {
-        path.relative_to(REPO_ROOT).as_posix()
-        for path in (REPO_ROOT / "tests").rglob("*.py")
-        if path.name.startswith("test_") or path.name.endswith("_test.py")
-    }
     assert set(targets) <= all_tests
-    assert all((REPO_ROOT / target).is_file() for target in targets)
+    assert targets_exist
     assert json.loads(json_result.stdout) == {"mode": "selected", "targets": targets}
 
 

--- a/tests/repo/test_tests_layout_contract.py
+++ b/tests/repo/test_tests_layout_contract.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT, TESTS_DIR
+from tests.helpers.tests_tree import shared_tests_tree_lock
 
 ROOT_TEST_ALLOWLIST = frozenset(
     {
@@ -148,12 +149,13 @@ def test_tests_do_not_resolve_paths_from_file_location() -> None:
     violations = []
     allowed = TESTS_DIR / "helpers" / "paths.py"
 
-    for path in TESTS_DIR.rglob("*.py"):
-        if path == allowed:
-            continue
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        if _uses_path_from_file(tree):
-            violations.append(path.relative_to(REPO_ROOT).as_posix())
+    with shared_tests_tree_lock():
+        for path in TESTS_DIR.rglob("*.py"):
+            if path == allowed:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            if _uses_path_from_file(tree):
+                violations.append(path.relative_to(REPO_ROOT).as_posix())
 
     assert violations == []
 
@@ -271,17 +273,19 @@ def _exact_source_owner_paths(test_path: Path) -> tuple[Path, Path]:
 
 
 def test_root_test_modules_match_allowlist() -> None:
-    actual = frozenset(path.name for path in _pytest_test_modules(TESTS_DIR) if path.parent == TESTS_DIR)
+    with shared_tests_tree_lock():
+        actual = frozenset(path.name for path in _pytest_test_modules(TESTS_DIR) if path.parent == TESTS_DIR)
     assert actual == ROOT_TEST_ALLOWLIST
 
 
 def test_test_layers_match_source_layers() -> None:
     source_layers = frozenset(path.name for path in SOURCE_ROOT.iterdir() if (path / "__init__.py").is_file())
-    test_layers = {
-        path.relative_to(TESTS_DIR).parts[0]
-        for path in TESTS_DIR.iterdir()
-        if path.is_dir() and _pytest_test_modules(path)
-    }
+    with shared_tests_tree_lock():
+        test_layers = {
+            path.relative_to(TESTS_DIR).parts[0]
+            for path in TESTS_DIR.iterdir()
+            if path.is_dir() and _pytest_test_modules(path)
+        }
     mirrored_layers = test_layers - LAYOUT_EXCEPTIONS
     assert mirrored_layers <= source_layers
 
@@ -309,16 +313,17 @@ def test_source_owner_candidates_stay_within_mirror_package() -> None:
 
 def test_mirrored_test_modules_have_source_owner() -> None:
     violations = []
-    for test_path in _mirrored_test_paths():
-        relative = test_path.relative_to(TESTS_DIR)
-        mirror_package = relative.parts[:-1]
-        exact_owner, package_owner = _exact_source_owner_paths(test_path)
-        if exact_owner.is_file() or package_owner.is_file():
-            continue
+    with shared_tests_tree_lock():
+        for test_path in _mirrored_test_paths():
+            relative = test_path.relative_to(TESTS_DIR)
+            mirror_package = relative.parts[:-1]
+            exact_owner, package_owner = _exact_source_owner_paths(test_path)
+            if exact_owner.is_file() or package_owner.is_file():
+                continue
 
-        tree = ast.parse(test_path.read_text(encoding="utf-8"), filename=str(test_path))
-        candidates = _source_owner_candidates(tree, mirror_package)
-        if not candidates:
-            violations.append(relative.as_posix())
+            tree = ast.parse(test_path.read_text(encoding="utf-8"), filename=str(test_path))
+            candidates = _source_owner_candidates(tree, mirror_package)
+            if not candidates:
+                violations.append(relative.as_posix())
 
     assert violations == []


### PR DESCRIPTION
## 概要

Closes #4487

`pytest tests/repo -q -n auto` で
`test_select_affected_tests.py::test_cli_output_is_deterministic_unique_and_existing_subset`
が稀に落ちる flaky を解消する。

干渉源は `test_pytest_lane_contract.py::test_slow_marker_survives_nested_module_relocation`
**1 つだけ**（`tests/` 配下へ書くテストはこれのみ。`src/youtube_automation/` を汚すものは皆無）。
実在モジュール `tests/test_analytics_cli_integration.py` を `shutil.move` で退避し、
`pytest --collect-only` サブプロセスを挟んで戻す数秒の窓を開ける。flock は持っていたが、
そのロックを取るのは lane 契約テストだけだった。

`.github/scripts/select-affected-tests.py` は `tests/` を rglob した直後に各ファイルを
`read_text` するため、窓と重なると `FileNotFoundError` → `except (OSError, ...)` が
**設計どおり `ALL` へ fail-safe** する。つまり selector にバグはなく、同一入力に対して
`ALL` と選択結果が混在することでテスト側の決定性契約が壊れていた。**production script は変更していない。**

## 変更内容

- `tests/helpers/tests_tree.py` を新設。flock ベースの reader-writer lock
  - writer（relocation probe）は `LOCK_EX`。probe directory の生成〜後始末まで内側に収めた（従来は生成が外側だった）
  - reader は `LOCK_SH`。`-n auto` の並列度を落とさない
- `test_pytest_lane_contract.py`: lane 内部の `_lane_registry_lock` を共有 helper に置換
- `test_select_affected_tests.py`: CLI 実行と走査を read lock で囲み、判定だけ外に出した
- `test_tests_layout_contract.py`: 同じ churn で落ちる 4 走査を read lock 化
  （`test_root_test_modules_match_allowlist` / `test_test_layers_match_source_layers` /
  `test_mirrored_test_modules_have_source_owner` / `test_tests_do_not_resolve_paths_from_file_location`）

### 採らなかった案

| 案 | 却下理由 |
|---|---|
| `all_tests` を `git ls-files tests` から取る | 欠けるのは `all_tests` 側ではなく `targets` 側（`ALL`）なので直らない |
| selector の inventory を `git ls-files` 化 | selector は CI では suite の**前**に静止したツリーへ走る。production にバグはない。未 tracked の新規テストが走査対象から外れ under-select に劣化する |
| CLI テストを hermetic 化 | この 1 件しか直らない。layout 契約は実ツリーを見ることが契約の中身で hermetic 化できない |
| probe を `tmp_path` へ寄せる | lane 判定は `tests/conftest.py` 配下でしか効かず、外に出すと検証対象が消える |

### 落とし穴（コメントとして残した）

lock helper の公開名を `test` で始めてはならない。pytest の既定 `python_functions = test*` は
アンダースコアを要求しないグロブなので、import した先の module でテスト関数として収集される。
最初の命名 `tests_tree_read_lock` で実際に踏み、収集数 1616 → 1620 で検知した。

## 検証

| | 対象テストの結果 |
|---|---|
| 修正前・自然発生（`tests/repo -n auto` ×3） | **1/3 で failed** |
| 修正前・churn harness | select 8/8 failed、layout 3/4 failed |
| 修正後・`tests/repo -n auto` ×9 | 0 failed（`14 failed, 1600 passed, 2 skipped, 12 warnings` で完全一定） |
| 修正後・3 モジュール `-n auto` ×10 | 0 failed |
| 修正後・ロック対応 probe を連続稼働させながら ×5 | 0 failed |

- `pytest tests/repo --collect-only` の収集ノード ID は変更前と完全一致
- ruff format / check 通過

> [!NOTE]
> 上表の 14 failed は**本 PR と無関係な既存 red**（`.claude/skills/wf-auto` と `wf-new-batch` が
> 存在するのに contract は削除済みを期待する skill inventory 系）。base commit 0030e636 の時点で
> 同じ 14 件が落ちるため、差分で判定している。

## チェックリスト

- [x] `CHANGELOG.md::[Unreleased]` にエントリを追加した
  - tests のみの変更のため `skip-changelog` ラベルで免除（ゲート対象は `src/youtube_automation/` /
    `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）
- [x] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
  - 下流に影響なし
- [x] 必要なテストを追加・更新した

## 関連

- Closes #4487
- #4469（repo contract テストの Git 履歴依存）とは別件。あちらは git 履歴依存、本件は filesystem 並行性で、触るコードに重複はない

🤖 Generated with [Claude Code](https://claude.com/claude-code)
