### PR TITLE
feat(wf-status): 制作状況Viewを運用キューへ再設計する (#4405)

### DIFF
--- a/.hallmark/log.json
+++ b/.hallmark/log.json
@@ -1,6 +1,20 @@
 [
   {
     "date": "2026-08-22",
+    "scope": "workflow status view",
+    "target": "src/youtube_automation/domains/documents/resources/workflow_status.html",
+    "genre": "editorial",
+    "theme": "Technical Ledger",
+    "macrostructure": "Operational Queue",
+    "audience": "YouTube operators",
+    "decision": "Lead with triage counts, then scan a ruled operational queue from collection identity through attention, next action, and artifact evidence.",
+    "excluded": [
+      "schema document view",
+      "candidate review view"
+    ]
+  },
+  {
+    "date": "2026-08-22",
     "scope": "schema document view only",
     "target": "src/youtube_automation/domains/documents/resources/base.css",
     "genre": "editorial",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
+
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。
 
 - `feat(documents)`: schema 文書 View を technical / austere な長文構造へ再設計し、要点を先に走査できる階層、named token、mobile containment、明瞭な keyboard focus を追加する（#4403）。

--- a/src/youtube_automation/domains/documents/resources/workflow_status.css
+++ b/src/youtube_automation/domains/documents/resources/workflow_status.css
@@ -1,80 +1,112 @@
+/* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5
+ * genre: editorial · macrostructure: Operational Queue · theme: Technical Ledger
+ * audience: YouTube operators · tone: technical / austere · motion: cut
+ */
 :root {
   color-scheme: light;
-  font-family: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic", Meiryo, system-ui, sans-serif;
-  background: #f5f7fb;
-  color: #172033;
+  --font-body: "Hiragino Kaku Gothic ProN", "Hiragino Sans", "Yu Gothic", Meiryo, system-ui, sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --color-paper: #f1f2ee;
+  --color-surface: #fafaf7;
+  --color-ink: #18201f;
+  --color-muted: #596461;
+  --color-rule: #b7bfbb;
+  --color-rule-strong: #65706c;
+  --color-accent: #185a4b;
+  --color-accent-soft: #dce9e3;
+  --color-alert: #8a3028;
+  --color-alert-soft: #f5e3df;
+  --color-warning: #6c5200;
+  --color-warning-soft: #f2e8c6;
+  --color-focus: #075eb4;
+  --space-2xs: .25rem;
+  --space-xs: .5rem;
+  --space-sm: .75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --space-2xl: 3rem;
+  background: var(--color-paper);
+  color: var(--color-ink);
+  font-family: var(--font-body);
   line-height: 1.55;
 }
 * { box-sizing: border-box; }
-body { margin: 0; }
-main { width: min(1180px, calc(100% - 2rem)); margin: 0 auto; padding: 2.5rem 0; }
-.page-header { border-bottom: 1px solid #dce2ec; margin-bottom: 1.5rem; }
-.page-header > p:last-child { color: #52617a; }
-.eyebrow, .status { color: #355f55; font-size: .8rem; font-weight: 700; }
-h1 { font-size: clamp(1.75rem, 5vw, 2.75rem); margin: .2rem 0; }
-.filter-control {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: inset(50%);
-}
-.filters { display: flex; flex-wrap: wrap; gap: .5rem; margin-bottom: 1.25rem; }
-.filters label { border: 1px solid #8794a8; border-radius: 999px; cursor: pointer; padding: .55rem 1rem; }
+html, body { margin: 0; max-width: 100%; overflow-x: clip; }
+main { width: min(76rem, calc(100% - 2rem)); margin: 0 auto; padding: var(--space-xl) 0 var(--space-2xl); }
+.page-header { align-items: end; border-bottom: 2px solid var(--color-ink); display: grid; gap: var(--space-xl); grid-template-columns: minmax(0, 1fr) auto; padding-bottom: var(--space-lg); }
+.eyebrow, .section-index, .status, dt { color: var(--color-muted); font-family: var(--font-mono); font-size: .72rem; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+.eyebrow { margin: 0 0 var(--space-sm); }
+h1 { font-size: clamp(2.5rem, 8vw, 6.5rem); font-style: normal; font-weight: 800; letter-spacing: -.055em; line-height: .78; margin: 0; min-width: 0; overflow-wrap: anywhere; }
+h1 span { color: var(--color-muted); font-family: var(--font-mono); font-size: .32em; font-weight: 500; letter-spacing: 0; }
+.generated-at { display: grid; font-family: var(--font-mono); font-size: .75rem; gap: var(--space-2xs); margin: 0; text-align: right; }
+.generated-at span { color: var(--color-muted); text-transform: uppercase; }
+.generated-at time { overflow-wrap: anywhere; }
+.overview { border-bottom: 1px solid var(--color-rule-strong); display: grid; grid-template-columns: minmax(9rem, .7fr) minmax(0, 2fr); }
+.overview-heading, .browser-heading { padding: var(--space-lg) 0; }
+.section-index { margin: 0 0 var(--space-xs); }
+h2 { font-size: clamp(1.25rem, 3vw, 1.85rem); font-style: normal; line-height: 1.1; margin: 0; overflow-wrap: anywhere; }
+.overview-metrics { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); margin: 0; }
+.overview-metrics > div { border-left: 1px solid var(--color-rule); min-width: 0; padding: var(--space-lg) var(--space-md); }
+.overview-metrics dd { align-items: baseline; display: flex; flex-wrap: wrap; gap: var(--space-xs); margin: var(--space-xs) 0 0; }
+.overview-value { font-family: var(--font-mono); font-size: clamp(1.6rem, 4vw, 2.6rem); line-height: 1; }
+.overview-metrics dd span { color: var(--color-muted); font-size: .72rem; }
+.browser-heading { align-items: end; display: grid; gap: var(--space-xl); grid-template-columns: minmax(0, 1fr) minmax(14rem, .7fr); }
+.browser-heading > p { color: var(--color-muted); font-size: .82rem; margin: 0; }
+.filter-control { clip-path: inset(50%); height: 1px; margin: -1px; overflow: hidden; position: absolute; width: 1px; }
+.filters { border-block: 1px solid var(--color-rule-strong); display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); margin-bottom: var(--space-lg); }
+.filters label { align-items: center; border-right: 1px solid var(--color-rule); cursor: pointer; display: flex; font-family: var(--font-mono); font-size: .78rem; justify-content: center; min-height: 2.8rem; padding: var(--space-xs); text-align: center; white-space: nowrap; }
+.filters label:last-child { border-right: 0; }
 .filter-selected { display: none; }
 #filter-all:checked ~ .filters label[for=filter-all],
 #filter-planning:checked ~ .filters label[for=filter-planning],
 #filter-live:checked ~ .filters label[for=filter-live],
-#filter-complete:checked ~ .filters label[for=filter-complete] {
-  background: #d8eee8;
-  border-color: #357363;
-  color: #173f35;
-  font-weight: 700;
-}
+#filter-complete:checked ~ .filters label[for=filter-complete] { background: var(--color-accent-soft); box-shadow: inset 0 -4px 0 var(--color-accent); color: var(--color-ink); font-weight: 800; }
 #filter-all:checked ~ .filters label[for=filter-all] .filter-selected,
 #filter-planning:checked ~ .filters label[for=filter-planning] .filter-selected,
 #filter-live:checked ~ .filters label[for=filter-live] .filter-selected,
 #filter-complete:checked ~ .filters label[for=filter-complete] .filter-selected { display: inline; }
-.filter-control:focus-visible ~ .filters { outline: 3px solid #1557b0; outline-offset: 3px; }
+.filter-control:focus-visible ~ .filters { outline: 3px solid var(--color-focus); outline-offset: 3px; }
 #filter-planning:checked ~ .collection-grid [data-status]:not([data-status=planning]),
 #filter-live:checked ~ .collection-grid [data-status]:not([data-status=live]),
 #filter-complete:checked ~ .collection-grid [data-status]:not([data-status=complete]) { display: none; }
-.collection-grid { display: grid; gap: 1rem; }
-.collection-card {
-  background: #fff;
-  border: 1px solid #d3dae5;
-  border-radius: .75rem;
-  min-width: 0;
-  padding: 1.25rem;
-  box-shadow: 0 4px 16px rgb(31 45 70 / 6%);
-}
-.collection-card h2 { margin: .2rem 0 1rem; }
-.attention {
-  background: #fff4f2;
-  border: 1px solid #f0bbb5;
-  border-radius: .5rem;
-  color: #76231c;
-  margin-bottom: 1rem;
-  padding: .85rem 1rem;
-}
-.attention h3 { margin: 0 0 .35rem; font-size: 1rem; }
+.collection-grid { border-top: 1px solid var(--color-rule-strong); display: grid; }
+.collection-card { background: transparent; border-bottom: 1px solid var(--color-rule-strong); display: grid; gap: var(--space-md) var(--space-lg); grid-template-columns: minmax(11rem, .65fr) minmax(0, 1.6fr); min-width: 0; padding: var(--space-lg) 0; }
+.collection-card > header { min-width: 0; }
+.collection-card h2 { font-size: clamp(1.3rem, 3vw, 2rem); margin: var(--space-xs) 0 0; }
+.status { color: var(--color-accent); margin: 0; }
+.attention { background: var(--color-alert-soft); border-block: 1px solid var(--color-alert); color: var(--color-alert); grid-column: 2; padding: var(--space-sm) var(--space-md); }
+.attention h3 { font-size: .82rem; margin: 0 0 var(--space-xs); text-transform: uppercase; }
 .attention ul { margin: 0; padding-left: 1.25rem; }
-.summary { display: grid; gap: .5rem; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); }
-.summary div { background: #f7f9fc; border-radius: .5rem; padding: .75rem; }
-dt { color: #52617a; font-size: .75rem; font-weight: 700; text-transform: uppercase; }
-dd { margin: .25rem 0 0; overflow-wrap: anywhere; }
-.table-scroll { max-width: 100%; overflow-x: auto; width: 100%; }
-table { border-collapse: collapse; margin-top: 1rem; min-width: 42rem; width: 100%; }
-caption { font-weight: 700; text-align: left; padding: .5rem 0; }
-th, td { border-top: 1px solid #dce2ec; padding: .65rem; text-align: left; vertical-align: top; }
-th { color: #52617a; }
-.artifact { border-radius: 999px; display: inline-block; font-size: .75rem; font-weight: 700; padding: .2rem .55rem; }
-.artifact.complete { background: #d9f2e8; color: #135b47; }
-.artifact.missing { background: #fff0c7; color: #654b00; }
-.artifact.inconsistent { background: #fde2df; color: #84251d; }
-.empty { border: 1px dashed #8794a8; border-radius: .75rem; color: #52617a; padding: 3rem; text-align: center; }
-@media (max-width: 640px) {
-  main { width: min(100% - 1rem, 1180px); padding: 1.25rem 0; }
-  .collection-card { padding: 1rem; }
+.summary { display: grid; gap: 0; grid-column: 2; grid-template-columns: repeat(2, minmax(0, 1fr)); margin: 0; }
+.summary div { border-top: 1px solid var(--color-rule); min-width: 0; padding: var(--space-sm) var(--space-md) var(--space-sm) 0; }
+dd { margin: var(--space-2xs) 0 0; overflow-wrap: anywhere; }
+.table-scroll { grid-column: 2; max-width: 100%; overflow-x: auto; width: 100%; }
+table { border-collapse: collapse; min-width: 38rem; width: 100%; }
+caption { font-family: var(--font-mono); font-size: .75rem; font-weight: 700; padding: var(--space-xs) 0; text-align: left; text-transform: uppercase; }
+th, td { border-top: 1px solid var(--color-rule); padding: var(--space-sm) var(--space-sm) var(--space-sm) 0; text-align: left; vertical-align: top; }
+th { color: var(--color-muted); font-family: var(--font-mono); font-size: .72rem; }
+.artifact { border: 1px solid currentcolor; display: inline-block; font-family: var(--font-mono); font-size: .7rem; font-weight: 700; padding: .1rem .4rem; white-space: nowrap; }
+.artifact.complete { background: var(--color-accent-soft); color: var(--color-accent); }
+.artifact.missing { background: var(--color-warning-soft); color: var(--color-warning); }
+.artifact.inconsistent { background: var(--color-alert-soft); color: var(--color-alert); }
+.empty { border-block: 1px dashed var(--color-rule-strong); color: var(--color-muted); margin: 0; padding: var(--space-2xl) var(--space-md); text-align: center; }
+@media (max-width: 768px) {
+  .overview { grid-template-columns: 1fr; }
+  .overview-metrics { border-top: 1px solid var(--color-rule); }
+  .overview-metrics > div:first-child { border-left: 0; }
+  .collection-card { grid-template-columns: 1fr; }
+  .attention, .summary, .table-scroll { grid-column: 1; }
+}
+@media (max-width: 520px) {
+  main { width: min(100% - 1rem, 76rem); padding-top: var(--space-md); }
+  .page-header, .browser-heading { align-items: start; gap: var(--space-md); grid-template-columns: 1fr; }
+  .generated-at { text-align: left; }
+  .overview-metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .overview-metrics > div { border-bottom: 1px solid var(--color-rule); }
+  .overview-metrics > div:nth-child(odd) { border-left: 0; }
+  .filters { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .filters label:nth-child(2) { border-right: 0; }
+  .filters label:nth-child(-n+2) { border-bottom: 1px solid var(--color-rule); }
+  .summary { grid-template-columns: 1fr; }
 }

--- a/src/youtube_automation/domains/documents/resources/workflow_status.html
+++ b/src/youtube_automation/domains/documents/resources/workflow_status.html
@@ -10,11 +10,27 @@
 <body>
   <main>
     <header class="page-header">
-      <p class="eyebrow">読み取り専用 snapshot</p>
-      <h1>制作状況</h1>
-      <p>生成日時: $generated_at</p>
+      <div>
+        <p class="eyebrow">YT / OPERATIONS · READ ONLY</p>
+        <h1>制作状況<br><span>snapshot</span></h1>
+      </div>
+      <p class="generated-at"><span>生成日時</span><time>$generated_at</time></p>
     </header>
+    <section class="overview" aria-labelledby="overview-title">
+      <div class="overview-heading">
+        <p class="section-index">01 / TRIAGE</p>
+        <h2 id="overview-title">運用サマリー</h2>
+      </div>
+      <dl class="overview-metrics">$overview</dl>
+    </section>
     <section class="status-browser" aria-label="コレクション制作状況">
+      <header class="browser-heading">
+        <div>
+          <p class="section-index">02 / QUEUE</p>
+          <h2>コレクション</h2>
+        </div>
+        <p>phase で表示を限定できます。矢印キーまたは Space で選択してください。</p>
+      </header>
       $filters
       <div class="collection-grid">$collections</div>
     </section>

--- a/src/youtube_automation/domains/documents/workflow_status_rendering.py
+++ b/src/youtube_automation/domains/documents/workflow_status_rendering.py
@@ -20,10 +20,11 @@ def render_workflow_status(snapshot: WorkflowStatusSnapshot) -> str:
     filters = (
         "".join(
             f'<input class="filter-control" type="radio" name="status-filter" id="filter-{status}"'
+            ' aria-keyshortcuts="ArrowLeft ArrowRight Space"'
             f"{' checked' if status == 'all' else ''}>"
             for status in _FILTERS
         )
-        + '<nav class="filters" aria-label="表示フィルター">'
+        + '<nav class="filters" aria-label="現在の表示">'
         + "".join(
             f'<label for="filter-{status}"><span class="filter-selected" aria-hidden="true">'
             f"選択中 · </span>{label}</label>"
@@ -40,10 +41,25 @@ def render_workflow_status(snapshot: WorkflowStatusSnapshot) -> str:
         css=css,
         generated_at=escape(snapshot.generated_at.isoformat()),
         filters=filters,
+        overview=_render_overview(snapshot),
         collections=collections,
     )
     validate_workflow_status_html(html)
     return html
+
+
+def _render_overview(snapshot: WorkflowStatusSnapshot) -> str:
+    counts = {
+        "全件": len(snapshot.collections),
+        "要対応": sum(_needs_attention(item) for item in snapshot.collections),
+        "企画中": sum(item.status == "planning" for item in snapshot.collections),
+        "公開工程": sum(item.status == "live" for item in snapshot.collections),
+        "完了": sum(item.status == "complete" for item in snapshot.collections),
+    }
+    return "".join(
+        f'<div><dt>{label}</dt><dd><strong class="overview-value">{count}</strong><span>{label}</span></dd></div>'
+        for label, count in counts.items()
+    )
 
 
 def _render_collection(item: CollectionStatusView) -> str:

--- a/tests/commands/collections/test_workflow_status.py
+++ b/tests/commands/collections/test_workflow_status.py
@@ -37,6 +37,10 @@ def test_command_generates_fixed_snapshot_and_opens_it(tmp_path: Path, monkeypat
     destination = channel / "tmp" / "reviews" / "workflow-status.html"
     assert code == 0
     assert destination.is_file()
+    rendered = destination.read_text(encoding="utf-8")
+    assert "運用サマリー" in rendered
+    assert "現在の表示" in rendered
+    assert "<script" not in rendered
     assert opened == [destination.resolve()]
     assert str(destination.resolve()) in capsys.readouterr().out
 

--- a/tests/domains/documents/test_workflow_status_rendering.py
+++ b/tests/domains/documents/test_workflow_status_rendering.py
@@ -60,6 +60,38 @@ def test_renderer_provides_css_only_client_filters_for_all_statuses() -> None:
     assert '<span class="filter-selected" aria-hidden="true">選択中 · </span>' in html
     assert ".filter-control:focus-visible" in html
     assert "#filter-planning:checked ~ .collection-grid [data-status]:not([data-status=planning])" in html
+    assert 'aria-keyshortcuts="ArrowLeft ArrowRight Space"' in html
+    assert "現在の表示" in html
+
+
+def test_renderer_exposes_an_operational_overview_before_collection_rows() -> None:
+    snapshot = WorkflowStatusSnapshot(
+        generated_at=datetime(2026, 8, 16, 12, 0, tzinfo=UTC),
+        collections=(
+            _snapshot().collections[0],
+            CollectionStatusView(
+                name="Published",
+                slug="published",
+                status="complete",
+                phase="complete",
+                blocker="なし",
+                next_action="なし",
+                updated_at="2026-08-16 11:00 UTC",
+                stalled_for="1時間",
+                stale=False,
+                warnings=(),
+                artifacts=(),
+            ),
+        ),
+    )
+
+    html = render_workflow_status(snapshot)
+
+    assert html.index("運用サマリー") < html.index("Night &amp; Rain")
+    assert '<strong class="overview-value">2</strong><span>全件</span>' in html
+    assert '<strong class="overview-value">0</strong><span>要対応</span>' in html
+    assert "Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5" in html
+    assert "overflow-x: clip" in html
 
 
 def test_attention_collections_and_missing_artifacts_render_before_normal_details() -> None:
@@ -108,7 +140,7 @@ def test_attention_collections_and_missing_artifacts_render_before_normal_detail
     assert "Master: 未生成" in segment
     assert "workflow state が古い" in segment
     assert ".collection-card[data-attention=true]" not in html
-    assert "border: 1px solid #d3dae5" in html
+    assert "border-bottom: 1px solid var(--color-rule-strong)" in html
 
 
 def test_empty_snapshot_renders_an_explicit_empty_state() -> None:


### PR DESCRIPTION
## Summary
- 制作状況snapshotを運用サマリー、phase filter、要対応優先キューへ再設計
- 件数、phase/status、警告、next action、成果物根拠の情報階層を明確化
- CSS-only filterの選択状態、focus、responsive containmentを契約化

Closes #4405
Closes #4406