### PR TITLE
feat(dx): changelog fragment 基盤を導入し並列 PR の CHANGELOG conflict を解消

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -40,7 +40,7 @@
           },
           {
             "type": "command",
-            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *src/youtube_automation/*|*.claude/skills/*|*.claude/CLAUDE.template.md|*pyproject.toml) echo \"NOTE: $f は CHANGELOG 必須エリア。PR 出す前に CHANGELOG.md [Unreleased] に追記すること（skip-changelog ラベルで escape 可）\" >&2; break;; esac; done; exit 0"
+            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *src/youtube_automation/*|*.claude/skills/*|*.claude/CLAUDE.template.md|*pyproject.toml) echo \"NOTE: $f は CHANGELOG 必須エリア。PR 出す前に changelog.d/ に fragment（<issue>-<slug>.<type>.md）を追加すること（CHANGELOG.md 直接編集も可、skip-changelog で escape 可）\" >&2; break;; esac; done; exit 0"
           },
           {
             "type": "command",

--- a/.claude/skills/automation-release/references/changelog-promotion.md
+++ b/.claude/skills/automation-release/references/changelog-promotion.md
@@ -27,6 +27,17 @@ Migration セクションのフォーマット契約は [release contract](relea
 
 ---
 
+## Step 0: fragment を `[Unreleased]` へ集約
+
+昇格操作の前に次を実行する。fragment が無い場合は no-op になる。
+
+```bash
+uv run yt-changelog-compile
+test -z "$(find changelog.d -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit)"
+```
+
+`changelog.d/` に `README.md` 以外の Markdown が残っていたら昇格を開始しない。
+
 ## 昇格手順（3 段階）
 
 ### Step 1: `[Unreleased]` ヘッダの直後に新セクションを挿入

--- a/.claude/skills/automation-release/references/prepare-checklist.md
+++ b/.claude/skills/automation-release/references/prepare-checklist.md
@@ -25,7 +25,16 @@ git rev-list --count HEAD..origin/main
 # → 0 であること（origin/main より遅れていない）
 ```
 
-### 3. CHANGELOG.md::[Unreleased] に内容がある
+### 3. changelog fragment を集約（必須）
+
+```bash
+uv run yt-changelog-compile
+test -z "$(find changelog.d -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit)"
+```
+
+fragment が無い場合は no-op。`README.md` 以外が残った場合は abort する。
+
+### 4. CHANGELOG.md::[Unreleased] に内容がある
 
 ```bash
 # Unreleased セクションの本文（次の ## までを抽出して空白行を除去）
@@ -34,7 +43,7 @@ awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md | gr
 
 何も出力されない（実質空）場合は「リリースする変更がない」ので abort。
 
-### 4. CHANGELOG.md::[Unreleased] に `### Migration` セクションがある（warning レベル）
+### 5. CHANGELOG.md::[Unreleased] に `### Migration` セクションがある（warning レベル）
 
 ```bash
 awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
@@ -44,7 +53,7 @@ awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
 
 無くても abort はしない。`AskUserQuestion` で「Migration セクション無しで続行するか」を確認する。Migration セクションは下流の `/automation --update` が `所要時間の目安` / `local fix 衝突注意` を抽出する契約上の入力源（詳細: [release contract](release-contracts.md#python-migration-producer-contract)）。
 
-### 4a. Python module 移動監査（必須）
+### 5a. Python module 移動監査（必須）
 
 <!-- import-migration-audit-contract:start -->
 1. previous tag から HEAD までの production module 差分を rename 検出付きで取得する。
@@ -61,7 +70,7 @@ awk '/^## \[Unreleased\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md \
 5. 対象となる facade 無し移動が 0 件なら、監査結果と `### Migration` に `Python module 移動: なし` を明示する。
 <!-- import-migration-audit-contract:end -->
 
-### 4b. CLI 撤去・改名時の利用側監査（必須）
+### 5b. CLI 撤去・改名時の利用側監査（必須）
 
 previous tag から HEAD までに `pyproject.toml::[project.scripts]` の entry point が撤去または改名されている場合、release 前に次を完了する。CLI 実装と entry point だけを消しても、skill や smoke check が旧コマンドを起動すると下流の更新処理が最後に失敗するため、利用側まで同じ変更で移行する。
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## チェックリスト
 
-- [ ] `CHANGELOG.md::[Unreleased]` にエントリを追加した
+- [ ] `changelog.d/` に fragment を追加した（書き方: [`changelog.d/README.md`](../changelog.d/README.md)。`CHANGELOG.md` 直接編集も可）
   - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
 - [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
   - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,11 +239,11 @@ jobs:
             echo "No significant code changes, skipping CHANGELOG check"
             exit 0
           fi
-          if ! echo "$changed" | grep -q '^CHANGELOG\.md$'; then
-            echo "::error::CHANGELOG.md must be updated under [Unreleased]. Add an entry or apply 'skip-changelog' label."
+          if ! echo "$changed" | grep -qE '^(CHANGELOG\.md|changelog\.d/.+\.md)$'; then
+            echo "::error::Add a changelog fragment under changelog.d/ (or update CHANGELOG.md), or apply 'skip-changelog' label."
             exit 1
           fi
-          echo "CHANGELOG.md updated"
+          echo "Changelog update found"
 
   adr-numbering:
     needs: changes

--- a/changelog.d/4483-changelog-fragments.changed.md
+++ b/changelog.d/4483-changelog-fragments.changed.md
@@ -1,0 +1,1 @@
+- `yt-changelog-compile` と `changelog.d/` を導入し、並列 PR が `CHANGELOG.md` の同一箇所を編集せず変更履歴を書き溜められるようにする（#4483）。

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -1,0 +1,13 @@
+# Changelog fragments
+
+変更ごとに `<issue番号>-<slug>.<type>.md` を追加し、CHANGELOG に載せる
+bullet（`- ` で始まる行）を記述します。issue 番号がない場合は PR 番号または
+日付を使えます。
+
+利用可能な type は `added`、`changed`、`deprecated`、`removed`、`fixed`、
+`security`、`migration` です。
+
+リリース時に `yt-changelog-compile` が fragment を type 別に
+`CHANGELOG.md` の `[Unreleased]` へ集約し、集約済みファイルを削除します。
+詳細なセクション契約は [docs/changelog-contract.md](../docs/changelog-contract.md) を
+参照してください。

--- a/docs/changelog-contract.md
+++ b/docs/changelog-contract.md
@@ -51,6 +51,19 @@ local fix 衝突注意:
 - サブセクション: `Added` / `Changed` / `Deprecated` / `Removed` / `Fixed` / `Security` / `Migration`
 - ファイル末尾にリンク参照定義（`[<VER>]: <URL>`）を集約
 
+## fragment 運用（書き溜め方）
+
+通常の PR は `CHANGELOG.md` を直接編集せず、`changelog.d/` に
+`<issue番号>-<slug>.<type>.md` を追加する。type と本文書式は
+[`changelog.d/README.md`](../changelog.d/README.md) を正とする。リリース prepare
+の冒頭で `yt-changelog-compile` が fragment を契約順の見出しへ集約し、処理済み
+fragment を削除する。
+
+この変更は `[Unreleased]` への書き込み経路だけを分離する。コンパイル後の
+`CHANGELOG.md`、リリース済み version section、GitHub Release body の形式は変わらない。
+したがって prepare の Migration warning、下流 `/automation --update`、libecity digest
+という既存 3 消費者のパース契約にも変更はない。
+
 ## `### Migration` セクション必須要素
 
 下流の `/automation --update` が決定論的に抽出できるよう、以下を **必須要素** とする。

--- a/docs/development.md
+++ b/docs/development.md
@@ -275,7 +275,7 @@ uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q
 品質ゲートはローカル git hook ではなく CI（`.github/workflows/ci.yml`）で一元的に担保する（issue #2534 で lefthook を廃止。sandbox 化された worker が `.git/hooks` へ書き込めず bootstrap が反復失敗していたため、ローカル hook は持たない）。
 
 - **lint ジョブ**: `ruff check` / `ruff format --check`（旧 pre-commit と同等）
-- **changelog ジョブ**: 実コード（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）を変更したのに `CHANGELOG.md` の `[Unreleased]` が未更新なら fail する。意図的に省く場合は PR に `skip-changelog` ラベルを付与する
+- **changelog ジョブ**: 実コード（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）を変更したのに `changelog.d/` の fragment 追加または `CHANGELOG.md` の更新が無ければ fail する。fragment の書式は `changelog.d/README.md` を参照する。意図的に省く場合は PR に `skip-changelog` ラベルを付与する
 - **any-gate ジョブ**: 広すぎる型注釈ゲート。基準点からの新規追加行だけを対象に、ディレクトリを問わず全 `*.py` / `*.ts` / `*.tsx` の Python の typing module 経由の Any 型、または TypeScript の any 型注釈を検出したら fail する。既存行は対象外。ロジック本体は `.github/scripts/any-usage-gate.sh`（ローカルでも `bash .github/scripts/any-usage-gate.sh` で単体実行できる）
   - **基準点の解決順**: `PRE_PUSH_DIFF_BASE`（CI の any-gate ジョブが PR の base sha を渡す）→ `origin/main` → `main`。実際の diff 基準は解決した ref と HEAD の merge-base。`main` へのフォールバックは、remote を 1 つも持たない隔離クローンで takt がタスクを実行するため（クローンのローカル `main` はクローン時点の main そのものなので基準点は変わらない）。この経路が無いと `ci_verify` が push 前に再現すべき 4 ゲートのうち any-gate だけが常に self-skip する（issue #3048）。どの ref も解決できないときは、試した ref を列挙して skip する。解決順そのものは `tests/repo/test_any_usage_gate.py` が機械担保する
   - **Python**: `.github/scripts/any_usage_python_resolver.py` が `ast` でファイルを解析し、`typing.Any` の修飾アクセス（`import typing` / `import typing as t` 経由）と `from typing import Any`（複数行の括弧 import・`as` alias 含む）の直接 import 経由の裸 `Any` の両方を、実際に参照されている行番号として解決する。コメント・docstring・文字列リテラル中の "Any" は AST 上に現れないため誤検知しない。`python3` が無い場合は警告を出して Python 側の検出のみ省略する
@@ -292,9 +292,15 @@ devShell の運用:
 - **TMPDIR の worktree 分離**: macOS の TMPDIR は per-user のグローバル値のため、複数 worktree の並行 pytest が同一パスへ書くと一時ディレクトリが run 間で干渉しうる（issue #2088）。shellHook は `.nix/worktree-tmpdir.sh` の出力を `TMPDIR` へ export し、共有 TMPDIR 配下の worktree ごとの決定的なサブディレクトリ（`yt-automation-tmp-<slug>-<cksum>`）へ分離する。TMPDIR が既に checkout 内へ隔離済みの場合はその値を尊重し、解決に失敗した場合は共有 TMPDIR のまま fail-open で続行する
 - **Nix キャッシュの worktree 分離**: 並列 worktree が同一 fingerprint の flake を同時評価すると、ユーザーグローバルの Nix キャッシュ（既定 `~/.cache/nix` の eval-cache / fetcher-cache SQLite）への同時書込みが競合し、「error (ignored): SQLite database ... is busy」を stderr へ出しつつキャッシュ書込みを破棄し続ける（issue #2089）。`.envrc` / shellHook は Nix 専用の `NIX_CACHE_HOME` を worktree 分離 TMPDIR 配下（`<worktree_tmpdir>/nix-cache`）へ export し、各 worktree が自分の評価結果だけを参照する。`XDG_CACHE_HOME` には触れないため uv 等の他ツールのキャッシュは共有のまま変わらない。継承値は別 worktree の値がシェル経由でリークし得るため尊重せず、解決に失敗した場合は共有キャッシュのまま fail-open で続行する
 - **sandbox worker での挙動**: takt worker は `.takt/runtime-prepare.sh` が TMPDIR / XDG_* / UV_CACHE_DIR を run ごとの runtime root 配下へ再構成する（issue #2163）
-- refactor / fix でも src を触れば CHANGELOG 追記が要る。tests / docs だけの変更はゲート対象外（CI が自動 skip）
+- refactor / fix でも src を触れば changelog fragment が要る。tests / docs だけの変更はゲート対象外（CI が自動 skip）
 
-### CHANGELOG.md の union merge（conflict 緩和）
+### changelog fragment（conflict 回避）
+
+通常の PR は `changelog.d/<issue>-<slug>.<type>.md` という PR 固有ファイルへ変更履歴を
+書き、リリース prepare で `uv run yt-changelog-compile` を実行して `[Unreleased]` へ
+集約する。移行中の PR との後方互換のため、CI は `CHANGELOG.md` の直接編集も許容する。
+
+### CHANGELOG.md の union merge（移行期の conflict 緩和）
 
 CHANGELOG ゲートにより並行 PR が `[Unreleased]` 先頭へ同時に追記するため、`.gitattributes` で `CHANGELOG.md merge=union` を指定している（issue #2155）。両側の追記行を conflict にせず機械的に取り込むが、union merge には以下の副作用があるため merge 後は `[Unreleased]` を目視確認すること:
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -4,6 +4,12 @@
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
+## 第 6 回監査（開発並列性、2026-08-22）
+
+| Plan | Title | Priority | Effort | Depends on | Issue | Status |
+|------|-------|----------|--------|------------|-------|--------|
+| 033 | changelog fragment 基盤を導入し CHANGELOG の並列マージコンフリクトを解消 | P1 | M | — | [#4483](https://github.com/daiki-beppu/youtube-automation/issues/4483) | DONE |
+
 ## 第 5 回監査（セキュリティ専門監査、2026-07-21、基準 commit `37b362ce`）
 
 セキュリティ集中監査（フォーカス指定 /improve）。並列 4 subagent（シークレット/認証 / インジェクション・パス / ネットワーク・サーバー / Chrome 拡張・配布）→ 全 findings を advisor が実読 vet。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,7 @@ yt-shorts-bulk-update-loc = "youtube_automation.entrypoints:yt_shorts_bulk_updat
 # Skill management
 yt-skills = "youtube_automation.entrypoints:yt_skills"
 yt-setup-dirs = "youtube_automation.entrypoints:yt_setup_dirs"
+yt-changelog-compile = "youtube_automation.entrypoints:yt_changelog_compile"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/youtube_automation"]

--- a/src/youtube_automation/commands/system/changelog_compile.py
+++ b/src/youtube_automation/commands/system/changelog_compile.py
@@ -6,6 +6,7 @@ import argparse
 import re
 from pathlib import Path
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ConfigError
 
 _SECTION_ORDER = (
@@ -117,7 +118,7 @@ def compile_fragments(changelog_path: Path, fragments_dir: Path, *, dry_run: boo
     return compiled
 
 
-def _build_parser() -> argparse.ArgumentParser:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="changelog fragments を [Unreleased] へ集約します")
     parser.add_argument("--dry-run", action="store_true", help="ファイルを変更せず集約後の内容を表示します")
     parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"), help="CHANGELOG ファイルのパス")
@@ -125,8 +126,7 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> None:
-    args = _build_parser().parse_args()
+def run(args: argparse.Namespace) -> int:
     compiled = compile_fragments(args.changelog, args.fragments_dir, dry_run=args.dry_run)
     if compiled is None:
         print("no fragments")
@@ -134,3 +134,12 @@ def main() -> None:
         print(compiled, end="")
     else:
         print("changelog fragments compiled")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_cli(build_parser, run, argv, failure_message="changelog fragment compile failed")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/youtube_automation/commands/system/changelog_compile.py
+++ b/src/youtube_automation/commands/system/changelog_compile.py
@@ -1,0 +1,136 @@
+"""Compile changelog fragments into the Unreleased section."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+from youtube_automation.core.errors import ConfigError
+
+_SECTION_ORDER = (
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+    "migration",
+)
+_SECTION_NAMES = {section: section.title() for section in _SECTION_ORDER}
+_FRAGMENT_PATTERN = re.compile(rf"^.+\.(?P<type>{'|'.join(_SECTION_ORDER)})\.md$")
+
+
+def _load_fragments(fragments_dir: Path) -> dict[str, list[tuple[Path, str]]]:
+    grouped = {section: [] for section in _SECTION_ORDER}
+    if not fragments_dir.exists():
+        return grouped
+
+    for path in sorted(fragments_dir.glob("*.md")):
+        if path.name.casefold() == "readme.md":
+            continue
+        match = _FRAGMENT_PATTERN.fullmatch(path.name)
+        if match is None:
+            raise ConfigError(f"不正な changelog fragment ファイル名です: {path.name}")
+        body = path.read_text(encoding="utf-8").strip()
+        lines = [line for line in body.splitlines() if line.strip()]
+        if not lines or any(not line.startswith("- ") for line in lines):
+            raise ConfigError(f"changelog fragment は '- ' で始まる bullet で記述してください: {path.name}")
+        grouped[match.group("type")].append((path, "\n".join(lines)))
+    return grouped
+
+
+def _unreleased_bounds(changelog: str) -> tuple[int, int]:
+    header = re.search(r"^## \[Unreleased\]\s*$", changelog, re.MULTILINE)
+    if header is None:
+        raise ConfigError("CHANGELOG.md に ## [Unreleased] がありません")
+    start = header.end()
+    next_version = re.search(r"^## \[.+\].*$", changelog[start:], re.MULTILINE)
+    end = start + next_version.start() if next_version else len(changelog)
+    return start, end
+
+
+def _append_to_section(unreleased: str, section_type: str, bullets: str) -> str:
+    heading = f"### {_SECTION_NAMES[section_type]}"
+    match = re.search(rf"^{re.escape(heading)}\s*$", unreleased, re.MULTILINE)
+    if match is None:
+        insert_at = len(unreleased.rstrip())
+        wanted_index = _SECTION_ORDER.index(section_type)
+        for later_type in _SECTION_ORDER[wanted_index + 1 :]:
+            later = re.search(
+                rf"^### {re.escape(_SECTION_NAMES[later_type])}\s*$",
+                unreleased,
+                re.MULTILINE,
+            )
+            if later is not None:
+                insert_at = later.start()
+                break
+        block = f"{heading}\n\n"
+        if section_type == "migration":
+            block += "サマリ:\n\n"
+        block += f"{bullets}\n\n"
+        prefix = unreleased[:insert_at].rstrip()
+        suffix = unreleased[insert_at:].lstrip("\n")
+        return f"{prefix}\n\n{block}{suffix}"
+
+    next_heading = re.search(r"^### .+$", unreleased[match.end() :], re.MULTILINE)
+    section_end = match.end() + next_heading.start() if next_heading else len(unreleased)
+    section = unreleased[match.end() : section_end]
+    if section_type == "migration":
+        summary = re.search(r"^サマリ:\s*$", section, re.MULTILINE)
+        if summary is None:
+            insertion = f"\n\nサマリ:\n\n{bullets}\n"
+            section = section.rstrip() + insertion
+        else:
+            summary_end = summary.end()
+            next_label = re.search(r"^[^\s#-].*:\s*$", section[summary_end:], re.MULTILINE)
+            insertion_at = summary_end + (next_label.start() if next_label else len(section[summary_end:]))
+            section = section[:insertion_at].rstrip() + f"\n\n{bullets}\n" + section[insertion_at:]
+    else:
+        section = section.rstrip() + f"\n\n{bullets}\n"
+    return unreleased[: match.end()] + section + unreleased[section_end:]
+
+
+def compile_fragments(changelog_path: Path, fragments_dir: Path, *, dry_run: bool = False) -> str | None:
+    """Compile fragments and return the resulting CHANGELOG text, or None when empty."""
+    grouped = _load_fragments(fragments_dir)
+    fragment_paths = [path for entries in grouped.values() for path, _ in entries]
+    if not fragment_paths:
+        return None
+
+    original = changelog_path.read_text(encoding="utf-8")
+    start, end = _unreleased_bounds(original)
+    unreleased = original[start:end]
+    for section_type in _SECTION_ORDER:
+        entries = grouped[section_type]
+        if entries:
+            unreleased = _append_to_section(
+                unreleased,
+                section_type,
+                "\n".join(body for _, body in entries),
+            )
+    compiled = original[:start] + unreleased.rstrip() + "\n\n" + original[end:].lstrip("\n")
+    if not dry_run:
+        changelog_path.write_text(compiled, encoding="utf-8")
+        for path in fragment_paths:
+            path.unlink()
+    return compiled
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="changelog fragments を [Unreleased] へ集約します")
+    parser.add_argument("--dry-run", action="store_true", help="ファイルを変更せず集約後の内容を表示します")
+    parser.add_argument("--changelog", type=Path, default=Path("CHANGELOG.md"), help="CHANGELOG ファイルのパス")
+    parser.add_argument("--fragments-dir", type=Path, default=Path("changelog.d"), help="fragment ディレクトリのパス")
+    return parser
+
+
+def main() -> None:
+    args = _build_parser().parse_args()
+    compiled = compile_fragments(args.changelog, args.fragments_dir, dry_run=args.dry_run)
+    if compiled is None:
+        print("no fragments")
+    elif args.dry_run:
+        print(compiled, end="")
+    else:
+        print("changelog fragments compiled")

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -93,6 +93,7 @@ yt_channel_init = _make_entrypoint("youtube_automation.commands.channel.channel_
 yt_channel_seed = _make_entrypoint("youtube_automation.commands.channel.channel_seed")
 yt_channel_settings = _make_entrypoint("youtube_automation.commands.channel.channel_settings")
 yt_channel_status = _make_entrypoint("youtube_automation.commands.channel.channel_status")
+yt_changelog_compile = _make_entrypoint("youtube_automation.commands.system.changelog_compile")
 yt_workspace_status = _make_entrypoint("youtube_automation.commands.channel.workspace_status")
 yt_workspace_guard = _make_entrypoint("youtube_automation.commands.channel.workspace_guard")
 yt_workflow_state = _make_entrypoint("youtube_automation.commands.collections.workflow_state_cli")

--- a/tests/commands/system/test_changelog_compile.py
+++ b/tests/commands/system/test_changelog_compile.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.commands.system.changelog_compile import compile_fragments
+from youtube_automation.core.errors import ConfigError
+
+_BASE_CHANGELOG = """# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2026-01-01
+
+### Fixed
+
+- old
+"""
+
+
+def _setup(tmp_path: Path, changelog: str = _BASE_CHANGELOG) -> tuple[Path, Path]:
+    changelog_path = tmp_path / "CHANGELOG.md"
+    changelog_path.write_text(changelog, encoding="utf-8")
+    fragments_dir = tmp_path / "changelog.d"
+    fragments_dir.mkdir()
+    return changelog_path, fragments_dir
+
+
+def test_compiles_mixed_fragments_in_contract_order_and_deletes_them(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    (fragments / "1-feature.added.md").write_text("- feature\n", encoding="utf-8")
+    (fragments / "2-bug.fixed.md").write_text("- bug fix\n", encoding="utf-8")
+
+    compile_fragments(changelog, fragments)
+
+    result = changelog.read_text(encoding="utf-8")
+    unreleased = result.split("## [1.0.0]", maxsplit=1)[0]
+    assert unreleased.index("### Added") < unreleased.index("### Fixed")
+    assert "- feature" in unreleased
+    assert "- bug fix" in unreleased
+    assert list(fragments.glob("*.md")) == []
+
+
+def test_appends_to_existing_heading_without_duplicate(tmp_path: Path) -> None:
+    source = _BASE_CHANGELOG.replace("## [1.0.0]", "### Fixed\n\n- existing\n\n## [1.0.0]")
+    changelog, fragments = _setup(tmp_path, source)
+    (fragments / "2-bug.fixed.md").write_text("- new fix\n", encoding="utf-8")
+
+    compile_fragments(changelog, fragments)
+
+    unreleased = changelog.read_text(encoding="utf-8").split("## [1.0.0]", maxsplit=1)[0]
+    assert unreleased.count("### Fixed") == 1
+    assert "- existing\n\n- new fix" in unreleased
+
+
+def test_migration_is_added_only_below_summary(tmp_path: Path) -> None:
+    source = _BASE_CHANGELOG.replace(
+        "## [1.0.0]",
+        "### Migration\n\n所要時間の目安: 10 分\n\nサマリ:\n\n- existing\n\n## [1.0.0]",
+    )
+    changelog, fragments = _setup(tmp_path, source)
+    (fragments / "3-move.migration.md").write_text("- move module\n", encoding="utf-8")
+
+    compile_fragments(changelog, fragments)
+
+    unreleased = changelog.read_text(encoding="utf-8").split("## [1.0.0]", maxsplit=1)[0]
+    assert unreleased.count("所要時間の目安") == 1
+    assert unreleased.index("サマリ:") < unreleased.index("- move module")
+
+
+def test_no_fragments_is_noop(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    before = changelog.read_bytes()
+    assert compile_fragments(changelog, fragments) is None
+    assert changelog.read_bytes() == before
+
+
+def test_invalid_type_raises_domain_error(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    (fragments / "4-task.chore.md").write_text("- task\n", encoding="utf-8")
+    with pytest.raises(ConfigError, match="不正な changelog fragment"):
+        compile_fragments(changelog, fragments)
+
+
+def test_dry_run_leaves_changelog_and_fragment_unchanged(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    fragment = fragments / "5-feature.added.md"
+    fragment.write_text("- feature\n", encoding="utf-8")
+    before = changelog.read_bytes()
+
+    preview = compile_fragments(changelog, fragments, dry_run=True)
+
+    assert preview is not None and "- feature" in preview
+    assert changelog.read_bytes() == before
+    assert fragment.exists()
+
+
+def test_second_run_is_idempotent(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    (fragments / "6-feature.added.md").write_text("- feature\n", encoding="utf-8")
+    compile_fragments(changelog, fragments)
+    once = changelog.read_bytes()
+    assert compile_fragments(changelog, fragments) is None
+    assert changelog.read_bytes() == once
+
+
+def test_readme_is_ignored(tmp_path: Path) -> None:
+    changelog, fragments = _setup(tmp_path)
+    (fragments / "README.md").write_text("guide", encoding="utf-8")
+    before = changelog.read_bytes()
+    assert compile_fragments(changelog, fragments) is None
+    assert changelog.read_bytes() == before

--- a/tests/repo/test_changelog_ci_contract.py
+++ b/tests/repo/test_changelog_ci_contract.py
@@ -41,7 +41,7 @@ def _build_ci_path_filter_pattern(gated_paths: tuple[str, ...]) -> str:
 _PATH_FILTER_PATTERN = _build_ci_path_filter_pattern(_CHANGELOG_GATED_PATHS)
 # push で CI を回す対象 branch。PR は stacked PR base でも発火するよう branch 制限しない。
 _PUSH_TRIGGER_BRANCHES = ["main"]
-_CHANGELOG_FILE_PATTERN = "^CHANGELOG\\.md$"
+_CHANGELOG_FILE_PATTERN = "^(CHANGELOG\\.md|changelog\\.d/.+\\.md)$"
 _LABELS_JOIN_EXPRESSION = "${{ join(github.event.pull_request.labels.*.name, ',') }}"
 _PR_EVENT_GUARD = "github.event_name == 'pull_request'"
 _PR_TEMPLATE_TEXT = """## 概要
@@ -54,7 +54,8 @@ _PR_TEMPLATE_TEXT = """## 概要
 
 ## チェックリスト
 
-- [ ] `CHANGELOG.md::[Unreleased]` にエントリを追加した
+- [ ] `changelog.d/` に fragment を追加した（書き方: [`changelog.d/README.md`](../changelog.d/README.md)。\
+`CHANGELOG.md` 直接編集も可）
   - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
 - [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
   - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)
@@ -69,8 +70,8 @@ _EXPECTED_RUN_LINES = [
     'if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then',
     'changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")',
     f"if ! echo \"$changed\" | grep -qE '{_PATH_FILTER_PATTERN}'; then",
-    f"if ! echo \"$changed\" | grep -q '{_CHANGELOG_FILE_PATTERN}'; then",
-    'echo "CHANGELOG.md updated"',
+    f"if ! echo \"$changed\" | grep -qE '{_CHANGELOG_FILE_PATTERN}'; then",
+    'echo "Changelog update found"',
 ]
 
 
@@ -136,8 +137,8 @@ def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
     assert _CHANGELOG_LABEL in run_script
     assert _CHANGELOG_FILE_PATTERN in run_script
     assert (
-        "::error::CHANGELOG.md must be updated under [Unreleased]. Add an entry or apply 'skip-changelog' label."
-        in run_script
+        "::error::Add a changelog fragment under changelog.d/ (or update CHANGELOG.md), "
+        "or apply 'skip-changelog' label." in run_script
     )
 
 

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -113,6 +113,7 @@ NON_BILLED_CLIS: dict[str, str] = {
     "yt-hybrid-runner": "MediaStore・Git・agent CLIを束ねるだけで、課金は委譲先CLIの分類に従う",
     "yt-human-tasks": "ローカルstateからMarkdownを生成し、無料のDiscord webhookへ要約するのみ",
     "yt-codex-canary-notify": "Codex canary結果を無料のDiscord webhookへ通知するのみ",
+    "yt-changelog-compile": "ローカルの changelog fragment 集約のみ",
     "yt-media-acceptance": "ローカルの ffprobe / ffmpeg による音源受入検証のみ",
     "yt-init-collection": "ローカルの collection 雛形生成のみ",
     "yt-kpi-dashboard": "収集済みデータのローカル KPI 集計のみ",

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -24,6 +24,7 @@ EXPECTED_ENTRYPOINT_MODULES = {
     "yt-bulk-update-desc": "youtube_automation.commands.metadata.bulk_update_descriptions",
     "yt-bulk-update-synthetic-media": "youtube_automation.commands.metadata.bulk_update_synthetic_media",
     "yt-captions-upload": "youtube_automation.commands.youtube.captions_upload",
+    "yt-changelog-compile": "youtube_automation.commands.system.changelog_compile",
     "yt-channel": "youtube_automation.commands.channel.channel",
     "yt-channel-import": "youtube_automation.commands.channel.channel_import",
     "yt-channel-init": "youtube_automation.commands.channel.channel_init",


### PR DESCRIPTION
## Summary
- `changelog.d/` fragment と `yt-changelog-compile` を導入し、`[Unreleased]` への集約をリリース prepare に組み込む
- CI、PR template、settings hook、契約テスト、運用 docs を fragment OR `CHANGELOG.md` の移行期契約へ同期する
- 8 つの CLI 単体テストと共通 CLI harness / API 課金分類契約で新しい入口を固定する

Closes #4483