### PR TITLE
feat: workflow-state owner に named mutator を追加する (#4417)

### DIFF
--- a/changelog.d/4417-owner-named-mutators.added.md
+++ b/changelog.d/4417-owner-named-mutators.added.md
@@ -1,0 +1,1 @@
+- workflow-state owner に section 生成・既知値検証・正準 `updated_at` 刻印を担う named mutator を追加する（#4417）。

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 from collections.abc import Callable, Iterator, Mapping, MutableMapping
 from copy import deepcopy
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Literal, TypedDict, cast
 
@@ -666,6 +666,60 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def distrokid_submission_completed_at(self) -> str | None:
         human_tasks = self.human_tasks
         return human_tasks.distrokid_submission_completed_at if human_tasks is not None else None
+
+    def touch(self) -> None:
+        """`updated_at` を UTC・ミリ秒精度の正準 RFC 3339 形式で刻印する。"""
+        self._data["updated_at"] = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+    def set_phase(self, phase: Phase) -> None:
+        """phase を検証して更新し、更新時刻を刻印する。"""
+        self.phase = phase
+        self.touch()
+
+    def set_stage(self, stage: Stage) -> None:
+        """stage を検証して更新し、更新時刻を刻印する。"""
+        self.stage = stage
+        self.touch()
+
+    def set_asset(self, key: AssetKey, value: JSONValue) -> None:
+        """asset section を必要に応じて生成し、既知 key を検証して更新する。"""
+        assets = self._data.setdefault("assets", {})
+        assert isinstance(assets, dict)
+        AssetsState(assets).set_known(key, value)
+        self.touch()
+
+    def set_planning(self, key: PlanningKey, value: JSONValue) -> None:
+        """planning section を必要に応じて生成し、既知 key を検証して更新する。"""
+        self.set_planning_known(key, value)
+        self.touch()
+
+    def record_upload(
+        self,
+        *,
+        video_id: str,
+        video_url: str | None = None,
+        publish_at: str | None = None,
+    ) -> None:
+        """YouTube upload の既知値を記録し、省略された任意値は保持する。"""
+        if not isinstance(video_id, str):
+            raise WorkflowStateError("workflow-state.json::upload.video_id must be a string")
+        upload = self._data.setdefault("upload", {})
+        assert isinstance(upload, dict)
+        typed_upload = UploadState(upload)
+        typed_upload.video_id = video_id
+        if video_url is not None:
+            if not isinstance(video_url, str):
+                raise WorkflowStateError("workflow-state.json::upload.video_url must be a string or null")
+            typed_upload.video_url = video_url
+        if publish_at is not None:
+            if not isinstance(publish_at, str):
+                raise WorkflowStateError("workflow-state.json::upload.publish_at must be a string or null")
+            typed_upload.publish_at = publish_at
+        self.touch()
+
+    def record_master_video(self, path: str | None) -> None:
+        """master video asset を検証して記録する。"""
+        self.set_asset("master_video", path)
 
     def record_distrokid_submission(self, completed_at: str) -> None:
         """DistroKid提出の初回完了時刻を保持し、再実行では上書きしない。"""

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 import multiprocessing
 import os
+from collections.abc import Callable
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -621,6 +623,52 @@ def test_update_serializes_processes_without_losing_changes(tmp_path: Path) -> N
 
 def test_workflow_state_error_is_an_automation_error() -> None:
     assert issubclass(WorkflowStateError, AutomationError)
+
+
+def test_named_mutators_create_sections_and_use_canonical_updated_at() -> None:
+    state = WorkflowState({"unknown": {"keep": True}})
+
+    state.set_asset("music_prompts", True)
+    state.set_planning("final_title", "Rainy Harbor")
+    state.record_upload(video_id="video-123", video_url="https://youtu.be/video-123")
+    state.record_master_video("01-master/video.mp4")
+
+    document = state.to_dict()
+    assert document["assets"] == {"music_prompts": True, "master_video": "01-master/video.mp4"}
+    assert document["planning"] == {"final_title": "Rainy Harbor"}
+    assert document["upload"] == {"video_id": "video-123", "video_url": "https://youtu.be/video-123"}
+    assert document["unknown"] == {"keep": True}
+    assert isinstance(document["updated_at"], str)
+    assert datetime.strptime(document["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").microsecond % 1000 == 0
+
+
+@pytest.mark.parametrize(
+    ("mutator", "message"),
+    [
+        (lambda state: state.set_asset("music_prompts", "yes"), "assets.music_prompts"),
+        (lambda state: state.set_planning("generated", "yes"), "planning.generated"),
+        (lambda state: state.record_master_video(True), "assets.master_video"),
+    ],
+)
+def test_named_mutators_reject_invalid_known_values(mutator: Callable[[WorkflowState], None], message: str) -> None:
+    state = WorkflowState({})
+
+    with pytest.raises(WorkflowStateError, match=message):
+        mutator(state)
+
+    assert "updated_at" not in state
+
+
+def test_record_upload_preserves_unsupplied_optional_fields() -> None:
+    state = WorkflowState({"upload": {"video_id": "old", "video_url": "https://example.test/old", "future": "keep"}})
+
+    state.record_upload(video_id="new")
+
+    assert state.to_dict()["upload"] == {
+        "video_id": "new",
+        "video_url": "https://example.test/old",
+        "future": "keep",
+    }
 
 
 class TestPlanningPlaylists:


### PR DESCRIPTION
## Summary
- workflow-state owner に named mutator と section 自動生成・既知値検証を追加
- `updated_at` を UTC milliseconds + `Z` の正準形式へ統一
- 既存 caller の移行は後続 issue に限定

Closes #4417