### PR TITLE
refactor: workflow-state の section エラーを型付けする (#4418)

### DIFF
--- a/changelog.d/4418-workflow-state-section-error.changed.md
+++ b/changelog.d/4418-workflow-state-section-error.changed.md
@@ -1,0 +1,1 @@
+- workflow-state の不正な section 型を識別する typed error を追加し、caller のエラー文言依存を解消する（#4418）。

--- a/src/youtube_automation/commands/media/apply_rain_layers.py
+++ b/src/youtube_automation/commands/media/apply_rain_layers.py
@@ -34,7 +34,12 @@ from typing import Any
 
 from youtube_automation.configuration import channel_dir
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.core.errors import (
+    ConfigError,
+    ValidationError,
+    WorkflowStateError,
+    WorkflowStateSectionTypeError,
+)
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.media.collection_paths import (
@@ -185,7 +190,7 @@ def _update_workflow_state_raw_master(workflow_state_path: Path, new_name: str) 
             raise error.__cause__ from error
         if "root must be an object" in str(error):
             raise ValidationError("workflow-state.json の root は object である必要があります") from error
-        if "workflow-state.json::assets must be an object" in str(error):
+        if isinstance(error, WorkflowStateSectionTypeError) and error.section == "assets":
             raise ValidationError("workflow-state.json::assets は object である必要があります") from error
         raise ValidationError(f"workflow-state.json のパースに失敗: {error}") from error
     return True

--- a/src/youtube_automation/commands/media/check_raw_master.py
+++ b/src/youtube_automation/commands/media/check_raw_master.py
@@ -29,7 +29,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, WorkflowStateSectionTypeError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
@@ -188,7 +188,7 @@ def apply_raw_master(collection_dir: Path, new_name: str, *, loudness_receipt: P
             raise error.__cause__ from error
         if "root must be an object" in str(error):
             raise ValidationError("workflow-state.json の root は object である必要があります") from error
-        if "workflow-state.json::assets must be an object" in str(error):
+        if isinstance(error, WorkflowStateSectionTypeError) and error.section == "assets":
             raise ValidationError("workflow-state.json::assets は object である必要があります") from error
         raise ValidationError(f"workflow-state.json のパースに失敗: {error}") from error
 

--- a/src/youtube_automation/commands/media/generate_videos_batch.py
+++ b/src/youtube_automation/commands/media/generate_videos_batch.py
@@ -14,7 +14,12 @@ from pathlib import Path
 
 from youtube_automation.configuration import channel_dir
 from youtube_automation.configuration.skills import load_channel_override
-from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.core.errors import (
+    ConfigError,
+    ValidationError,
+    WorkflowStateError,
+    WorkflowStateSectionTypeError,
+)
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
@@ -183,7 +188,7 @@ def _update_workflow_state(collection: Path) -> str:
     except WorkflowStateError as error:
         if isinstance(error.__cause__, OSError) and "could not be written" in str(error):
             raise error.__cause__ from error
-        if "workflow-state.json::assets must be an object" in str(error):
+        if isinstance(error, WorkflowStateSectionTypeError) and error.section == "assets":
             raise ValidationError(
                 f"workflow-state.json::assets は object である必要があります: {collection}"
             ) from error

--- a/src/youtube_automation/commands/uploads/wf_batch.py
+++ b/src/youtube_automation/commands/uploads/wf_batch.py
@@ -51,7 +51,12 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.errors import ConfigError, ValidationError, WorkflowStateError
+from youtube_automation.core.errors import (
+    ConfigError,
+    ValidationError,
+    WorkflowStateError,
+    WorkflowStateSectionTypeError,
+)
 from youtube_automation.domains.collections.workflow_state import (
     WorkflowState,
 )
@@ -313,7 +318,7 @@ def _record_master_video(collection_dir: Path) -> str:
     try:
         update_workflow_state(paths.workflow_state_path, record_master_video)
     except WorkflowStateError as error:
-        if "workflow-state.json::assets must be an object" in str(error):
+        if isinstance(error, WorkflowStateSectionTypeError) and error.section == "assets":
             raise ValidationError("workflow-state.json::assets は object である必要があります") from error
         raise ValidationError(str(error)) from error
     return video.name

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -125,6 +125,14 @@ class WorkflowStateError(AutomationError):
     """workflow-state.json の読み取り・検証・永続化エラー。"""
 
 
+class WorkflowStateSectionTypeError(WorkflowStateError):
+    """workflow-state.json の section が object でないことを型で識別する例外。"""
+
+    def __init__(self, section: str) -> None:
+        super().__init__(f"workflow-state.json::{section} must be an object")
+        self.section = section
+
+
 class MediaStoreError(AutomationError):
     """境界メディアの転送・完全性検証エラー。"""
 

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -11,7 +11,7 @@ from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Literal, TypedDict, cast
 
-from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, WorkflowStateSectionTypeError
 from youtube_automation.domains.media_store import MediaKey
 from youtube_automation.infrastructure.filesystem import JSONValue, file_lock
 
@@ -566,7 +566,7 @@ class WorkflowState(MutableMapping[str, JSONValue]):
 
     def __setitem__(self, key: str, value: JSONValue) -> None:
         if key in _KNOWN_OBJECT_SECTIONS and not isinstance(value, dict):
-            raise WorkflowStateError(f"workflow-state.json::{key} must be an object")
+            raise WorkflowStateSectionTypeError(key)
         self._data[key] = deepcopy(value)
 
     def __delitem__(self, key: str) -> None:
@@ -581,7 +581,7 @@ class WorkflowState(MutableMapping[str, JSONValue]):
     def _validate_object_sections(self) -> None:
         for key in _KNOWN_OBJECT_SECTIONS & self._data.keys():
             if not isinstance(self._data[key], dict):
-                raise WorkflowStateError(f"workflow-state.json::{key} must be an object")
+                raise WorkflowStateSectionTypeError(key)
         planning = self.planning
         if planning is not None:
             _music = planning.music

--- a/src/youtube_automation/domains/metadata/service.py
+++ b/src/youtube_automation/domains/metadata/service.py
@@ -27,7 +27,7 @@ from youtube_automation.core.adapters.runtime import (
     format_duration_short,
     format_timestamp,
 )
-from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, WorkflowStateSectionTypeError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
@@ -639,14 +639,12 @@ class BAHMetadataGenerator:
         try:
             state = read_workflow_state_or_none(ws_path)
         except WorkflowStateError as error:
-            message = str(error)
-            if "root must be an object" in message:
+            if "root must be an object" in str(error):
                 raise ValidationError(
                     f"workflow-state.json の root は object である必要があります: {ws_path}"
                 ) from error
-            for section in ("planning", "scene_phrases"):
-                if f"workflow-state.json::{section} must be an object" in message:
-                    raise ValidationError(f"workflow-state.json::{section} は object である必要があります") from error
+            if isinstance(error, WorkflowStateSectionTypeError) and error.section in {"planning", "scene_phrases"}:
+                raise ValidationError(f"workflow-state.json::{error.section} は object である必要があります") from error
             raise ValidationError(f"workflow-state.json を読み込めません: {ws_path}: {error}") from error
         return state if state is not None else WorkflowState({})
 

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import now_in_schedule_tz
-from youtube_automation.core.errors import ValidationError, WorkflowStateError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError, WorkflowStateSectionTypeError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
@@ -108,7 +108,7 @@ class TrackingStore:
         except WorkflowStateError as error:
             if isinstance(error.__cause__, json.JSONDecodeError):
                 raise error.__cause__ from error
-            if "workflow-state.json::upload must be an object" in str(error):
+            if isinstance(error, WorkflowStateSectionTypeError) and error.section == "upload":
                 raise ValidationError(f"workflow-state.json upload must be object: {ws_path}") from error
             raise ValidationError(str(error)) from error
 

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 import pytest
 
-from youtube_automation.core.errors import AutomationError, WorkflowStateError
+from youtube_automation.core.errors import AutomationError, WorkflowStateError, WorkflowStateSectionTypeError
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read, read_or_none, update
 from youtube_automation.infrastructure.filesystem import JSONValue
 
@@ -623,6 +623,15 @@ def test_update_serializes_processes_without_losing_changes(tmp_path: Path) -> N
 
 def test_workflow_state_error_is_an_automation_error() -> None:
     assert issubclass(WorkflowStateError, AutomationError)
+
+
+@pytest.mark.parametrize("section", ["assets", "planning", "scene_phrases", "upload"])
+def test_invalid_object_section_raises_typed_error_with_section(section: str) -> None:
+    with pytest.raises(WorkflowStateSectionTypeError) as exc_info:
+        WorkflowState({section: "invalid"})
+
+    assert exc_info.value.section == section
+    assert str(exc_info.value) == f"workflow-state.json::{section} must be an object"
 
 
 def test_named_mutators_create_sections_and_use_canonical_updated_at() -> None:


### PR DESCRIPTION
## Summary
- section 情報を保持する `WorkflowStateSectionTypeError` を追加
- 対象 caller のエラー文字列照合を typed error と section 分岐へ移行

Closes #4418