### PR TITLE
refactor: media と uploads の writer を owner 経由にする (#4419)

### DIFF
--- a/changelog.d/4419-owner-media-upload-writers.changed.md
+++ b/changelog.d/4419-owner-media-upload-writers.changed.md
@@ -1,0 +1,1 @@
+- media / uploads の workflow-state writer を owner mutator 経由へ移行し、rain layer 適用時にも正準 `updated_at` を刻印する（#4419）。

--- a/src/youtube_automation/commands/media/apply_rain_layers.py
+++ b/src/youtube_automation/commands/media/apply_rain_layers.py
@@ -175,13 +175,7 @@ def _update_workflow_state_raw_master(workflow_state_path: Path, new_name: str) 
         return False
 
     def record_raw_master(state: WorkflowState) -> None:
-        assets = state.assets
-        if assets is None:
-            state["assets"] = {}
-            assets = state.assets
-        if assets is None:
-            raise ValidationError("workflow-state.json::assets は object である必要があります")
-        assets.raw_master = new_name
+        state.set_asset("raw_master", new_name)
 
     try:
         update_workflow_state(workflow_state_path, record_raw_master)

--- a/src/youtube_automation/commands/media/check_raw_master.py
+++ b/src/youtube_automation/commands/media/check_raw_master.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 import argparse
 import sys
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from youtube_automation.configuration.skills import load_skill_config
@@ -172,14 +171,7 @@ def apply_raw_master(collection_dir: Path, new_name: str, *, loudness_receipt: P
         raise ValidationError(f"workflow-state.json が見つかりません: {paths.workflow_state_path}")
 
     def record_raw_master(state: WorkflowState) -> None:
-        assets = state.assets
-        if assets is None:
-            state["assets"] = {}
-            assets = state.assets
-        if assets is None:
-            raise ValidationError("workflow-state.json::assets は object である必要があります")
-        assets.raw_master = new_name
-        state["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        state.set_asset("raw_master", new_name)
 
     try:
         update_workflow_state(paths.workflow_state_path, record_raw_master)

--- a/src/youtube_automation/commands/media/generate_videos_batch.py
+++ b/src/youtube_automation/commands/media/generate_videos_batch.py
@@ -9,7 +9,6 @@ import os
 import subprocess
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
 from pathlib import Path
 
 from youtube_automation.configuration import channel_dir
@@ -177,11 +176,7 @@ def _update_workflow_state(collection: Path) -> str:
         raise ValidationError(f"生成成功後も 01-master/*.mp4 が見つかりません: {collection}")
 
     def record_master_video(state: WorkflowState) -> None:
-        assets = state.assets
-        if assets is None:
-            raise ValidationError(f"workflow-state.json::assets は object である必要があります: {collection}")
-        assets.master_video = video.name
-        state["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+        state.record_master_video(video.name)
 
     try:
         update_workflow_state(paths.workflow_state_path, record_master_video)

--- a/src/youtube_automation/commands/uploads/wf_batch.py
+++ b/src/youtube_automation/commands/uploads/wf_batch.py
@@ -47,7 +47,7 @@ import subprocess
 import sys
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 
 from youtube_automation.configuration import channel_dir, load_config
@@ -138,10 +138,6 @@ def _load_state(workflow_state_path: Path) -> dict:
         if isinstance(error.__cause__, json.JSONDecodeError):
             raise ValidationError(f"workflow-state.json のパースに失敗: {error.__cause__}") from error
         raise ValidationError(str(error)) from error
-
-
-def _utc_now() -> str:
-    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
 
 
 def _has_downloaded_audio(music_dir: Path) -> bool:
@@ -305,15 +301,8 @@ def _record_master_video(collection_dir: Path) -> str:
         raise ValidationError(f"workflow-state.json が見つかりません: {paths.workflow_state_path}")
 
     def record_master_video(state: WorkflowState) -> None:
-        assets = state.assets
-        if assets is None:
-            state["assets"] = {}
-            assets = state.assets
-        if assets is None:
-            raise ValidationError("workflow-state.json::assets は object である必要があります")
-        assets.master_video = video.name
+        state.record_master_video(video.name)
         state.phase = "publishing"
-        state["updated_at"] = _utc_now()
 
     try:
         update_workflow_state(paths.workflow_state_path, record_master_video)

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -177,6 +177,13 @@ _PHASES = frozenset({"planning", "prepared", "cloud_owned", "mastered", "publish
 _STAGES = frozenset({"planning", "live"})
 _MUSIC_ENGINES = frozenset({"suno", "lyria", "minimax"})
 _MUSIC_TEMPOS = frozenset({"very slow", "slow", "gentle", "moderate", "lively"})
+
+
+class _UnsetType:
+    pass
+
+
+_UNSET = _UnsetType()
 _KNOWN_OBJECT_SECTIONS = frozenset(
     {
         "assets",
@@ -697,8 +704,8 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         self,
         *,
         video_id: str,
-        video_url: str | None = None,
-        publish_at: str | None = None,
+        video_url: str | None | _UnsetType = _UNSET,
+        publish_at: str | None | _UnsetType = _UNSET,
     ) -> None:
         """YouTube upload の既知値を記録し、省略された任意値は保持する。"""
         if not isinstance(video_id, str):
@@ -707,14 +714,14 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         assert isinstance(upload, dict)
         typed_upload = UploadState(upload)
         typed_upload.video_id = video_id
-        if video_url is not None:
-            if not isinstance(video_url, str):
+        if video_url is not _UNSET:
+            if video_url is not None and not isinstance(video_url, str):
                 raise WorkflowStateError("workflow-state.json::upload.video_url must be a string or null")
-            typed_upload.video_url = video_url
-        if publish_at is not None:
-            if not isinstance(publish_at, str):
+            typed_upload.video_url = cast(str | None, video_url)
+        if publish_at is not _UNSET:
+            if publish_at is not None and not isinstance(publish_at, str):
                 raise WorkflowStateError("workflow-state.json::upload.publish_at must be a string or null")
-            typed_upload.publish_at = publish_at
+            typed_upload.publish_at = cast(str | None, publish_at)
         self.touch()
 
     def record_master_video(self, path: str | None) -> None:

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -89,16 +89,11 @@ class TrackingStore:
             return
 
         def record_upload(state: WorkflowState) -> None:
-            upload = state.upload
-            if upload is None:
-                state["upload"] = {}
-                upload = state.upload
-            if upload is None:
-                raise ValidationError(f"workflow-state.json upload must be object: {ws_path}")
-            upload.video_id = complete_video["video_id"]
-            upload.video_url = complete_video["video_url"]
-            upload.publish_at = publish_at
-            state["updated_at"] = now_in_schedule_tz(self.config).isoformat()
+            state.record_upload(
+                video_id=complete_video["video_id"],
+                video_url=complete_video["video_url"],
+                publish_at=publish_at,
+            )
             if collection_path.parent.name == WORKFLOW_STAGE_LIVE:
                 state.stage = WORKFLOW_STAGE_LIVE
                 state.phase = WORKFLOW_PHASE_COMPLETE

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -679,6 +679,9 @@ def test_record_upload_preserves_unsupplied_optional_fields() -> None:
         "future": "keep",
     }
 
+    state.record_upload(video_id="new", publish_at=None)
+    assert state.to_dict()["upload"]["publish_at"] is None
+
 
 class TestPlanningPlaylists:
     """#4346: planning.playlists は「未決定」と「auto_add のみ」を区別する。"""


### PR DESCRIPTION
## Summary
- media / uploads の対象 writer を workflow-state owner の named mutator 経由へ移行
- 正準 `updated_at` と upload の既存 null/省略 semantics を維持

Closes #4419