### PR TITLE
refactor: documents と review の writer を owner 経由にする (#4420)

### DIFF
--- a/changelog.d/4420-owner-documents-review-writers.changed.md
+++ b/changelog.d/4420-owner-documents-review-writers.changed.md
@@ -1,0 +1,1 @@
+- documents / review の workflow-state writer を検証付き owner mutator へ移行し、`updated_at` を正準形式に統一する（#4420）。

--- a/src/youtube_automation/application/documents/collection_plan.py
+++ b/src/youtube_automation/application/documents/collection_plan.py
@@ -79,15 +79,10 @@ def _write_collection_plan_document(
         return result
 
     def project(state):
-        planning = state.planning
-        if planning is None:
-            state["planning"] = {}
-            planning = state.planning
-        if planning is None:
-            raise DocumentMigrationError("workflow-state.json::planning を初期化できません")
-        planning["generated"] = True
-        planning["final_title"] = selected["final_title"]
-        planning["target_persona"] = selected["target_persona"]
+        state.record_collection_plan(
+            final_title=selected["final_title"],
+            target_persona=selected["target_persona"],
+        )
         return state
 
     update_workflow_state(workflow_state_path, project)

--- a/src/youtube_automation/application/documents/music_prompt.py
+++ b/src/youtube_automation/application/documents/music_prompt.py
@@ -107,13 +107,7 @@ def finalize_music_prompt_review(
         return
 
     def project(state):
-        assets = state.assets
-        if assets is None:
-            state["assets"] = {}
-            assets = state.assets
-        if assets is None:
-            raise DocumentMigrationError("workflow-state.json::assets を初期化できません")
-        assets["music_prompts"] = True
+        state.set_asset("music_prompts", True)
         return state
 
     update_workflow_state(workflow_state_path, project)

--- a/src/youtube_automation/application/documents/video_description.py
+++ b/src/youtube_automation/application/documents/video_description.py
@@ -50,13 +50,7 @@ def write_video_description_document(
     require_quality_pass(persisted)
 
     def project(state):
-        assets = state.assets
-        if assets is None:
-            state["assets"] = {}
-            assets = state.assets
-        if assets is None:
-            raise DocumentMigrationError("workflow-state.json::assets を初期化できません")
-        assets.description = True
+        state.set_asset("description", True)
         return state
 
     update_workflow_state(workflow_state_path, project)

--- a/src/youtube_automation/application/master_audio_review.py
+++ b/src/youtube_automation/application/master_audio_review.py
@@ -416,15 +416,11 @@ def _require_same_selection(
 
 
 def _adopt(state_path: Path, selected: str) -> None:
-    timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
     def transition(state: WorkflowState) -> None:
         assets = state.assets
         if state.phase != "prepared" or assets is None or assets.master_audio is not None:
             raise WorkflowStateError("master audio transition is no longer pending")
-        assets.master_audio = selected
-        state.phase = "mastered"
-        state["updated_at"] = timestamp
+        state.record_master_audio(selected)
 
     update_workflow_state(state_path, transition)
 

--- a/src/youtube_automation/application/master_video_review.py
+++ b/src/youtube_automation/application/master_video_review.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
@@ -216,14 +216,11 @@ def _validate_presentation(presentation: VideoReviewPresentation) -> None:
 
 
 def _record_master_video(state_path: Path, filename: str) -> None:
-    timestamp = datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
     def transition(state: WorkflowState) -> None:
         assets = state.assets
         if assets is None or assets.master_audio is None or assets.master_video is not None:
             raise WorkflowStateError("master video transition is no longer pending")
-        assets.master_video = filename
-        state["updated_at"] = timestamp
+        state.record_master_video(filename)
 
     update_workflow_state(state_path, transition)
 

--- a/src/youtube_automation/application/thumbnail_review.py
+++ b/src/youtube_automation/application/thumbnail_review.py
@@ -205,17 +205,19 @@ def finalize_thumbnail_review_selection(
             )
 
         def record(state: WorkflowState) -> None:
-            state["thumbnail_review_selection"] = {
-                "schema_version": 1,
-                "source": source,
-                "candidate_id": candidate_id,
-                "artifact": artifact,
-                "pattern": pattern,
-                "image_sha256": selected.image_digest,
-                "qa_sha256": selected.qa_digest,
-                "artifact_digest": expected_artifact_digest,
-                "selected_at": datetime.now(UTC).isoformat(),
-            }
+            state.record_thumbnail_review_selection(
+                {
+                    "schema_version": 1,
+                    "source": source,
+                    "candidate_id": candidate_id,
+                    "artifact": artifact,
+                    "pattern": pattern,
+                    "image_sha256": selected.image_digest,
+                    "qa_sha256": selected.qa_digest,
+                    "artifact_digest": expected_artifact_digest,
+                    "selected_at": datetime.now(UTC).isoformat(),
+                }
+            )
 
         update_workflow_state(_collection_root(collection) / "workflow-state.json", record)
     except (OSError, ConfigError, ValidationError, WorkflowStateError) as exc:

--- a/src/youtube_automation/domains/collections/workflow_state.py
+++ b/src/youtube_automation/domains/collections/workflow_state.py
@@ -728,6 +728,29 @@ class WorkflowState(MutableMapping[str, JSONValue]):
         """master video asset を検証して記録する。"""
         self.set_asset("master_video", path)
 
+    def record_master_audio(self, path: str | None) -> None:
+        """master audio asset と mastered phase を一度の遷移で記録する。"""
+        assets = self._data.setdefault("assets", {})
+        assert isinstance(assets, dict)
+        AssetsState(assets).set_known("master_audio", path)
+        self.phase = "mastered"
+        self.touch()
+
+    def record_collection_plan(self, *, final_title: str, target_persona: str) -> None:
+        """承認済み collection plan の既知 planning 値をまとめて記録する。"""
+        planning = self._data.setdefault("planning", {})
+        assert isinstance(planning, dict)
+        typed_planning = PlanningState(planning)
+        typed_planning.set_known("generated", True)
+        typed_planning.set_known("final_title", final_title)
+        typed_planning.set_known("target_persona", target_persona)
+        self.touch()
+
+    def record_thumbnail_review_selection(self, selection: Mapping[str, JSONValue]) -> None:
+        """承認済み thumbnail review selection を記録する。"""
+        self._data["thumbnail_review_selection"] = deepcopy(dict(selection))
+        self.touch()
+
     def record_distrokid_submission(self, completed_at: str) -> None:
         """DistroKid提出の初回完了時刻を保持し、再実行では上書きしない。"""
         human_tasks = self._data.setdefault("human_tasks", {})

--- a/tests/domains/collections/test_workflow_state.py
+++ b/tests/domains/collections/test_workflow_state.py
@@ -683,6 +683,28 @@ def test_record_upload_preserves_unsupplied_optional_fields() -> None:
     assert state.to_dict()["upload"]["publish_at"] is None
 
 
+def test_document_and_review_mutators_validate_and_stamp_updates() -> None:
+    state = WorkflowState({"phase": "prepared", "assets": {}})
+
+    state.record_collection_plan(final_title="Rain", target_persona="reader")
+    state.record_master_audio("01-master/master.wav")
+    state.record_thumbnail_review_selection({"schema_version": 1, "candidate_id": "candidate-a"})
+
+    document = state.to_dict()
+    assert document["planning"] == {
+        "generated": True,
+        "final_title": "Rain",
+        "target_persona": "reader",
+    }
+    assert document["assets"] == {"master_audio": "01-master/master.wav"}
+    assert document["phase"] == "mastered"
+    assert document["thumbnail_review_selection"] == {"schema_version": 1, "candidate_id": "candidate-a"}
+    assert datetime.strptime(document["updated_at"], "%Y-%m-%dT%H:%M:%S.%fZ").microsecond % 1000 == 0
+
+    with pytest.raises(WorkflowStateError, match="planning.final_title"):
+        state.record_collection_plan(final_title=None, target_persona="reader")
+
+
 class TestPlanningPlaylists:
     """#4346: planning.playlists は「未決定」と「auto_add のみ」を区別する。"""
 


### PR DESCRIPTION
## Summary
- documents / review の対象 writer を検証付き owner mutator へ移行
- collection plan、master audio、thumbnail selection の named mutator と正準 timestamp を追加

Closes #4420