### PR TITLE
feat: UploadJournal と Complete Collection 移行を追加する (#4441)

### DIFF
--- a/changelog.d/4441-upload-journal.added.md
+++ b/changelog.d/4441-upload-journal.added.md
@@ -1,1 +1,1 @@
-- upload の再開 token を write 前再読込・破損 quarantine・保存失敗の明示化つきで所有する `UploadJournal` interface を追加する（#4441）。
+- upload の再開 token を write 前再読込・破損 quarantine・保存失敗の明示化つきで所有する `UploadJournal` interface を追加し、Complete Collection 経路を移行する（#4441）。

--- a/changelog.d/4441-upload-journal.added.md
+++ b/changelog.d/4441-upload-journal.added.md
@@ -1,0 +1,1 @@
+- upload の再開 token を write 前再読込・破損 quarantine・保存失敗の明示化つきで所有する `UploadJournal` interface を追加する（#4441）。

--- a/src/youtube_automation/core/errors.py
+++ b/src/youtube_automation/core/errors.py
@@ -113,6 +113,18 @@ class UploadError(AutomationError):
     """
 
 
+class UploadJournalError(UploadError):
+    """upload journal の読み書き・状態契約エラー。"""
+
+
+class UploadJournalCorruptError(UploadJournalError):
+    """破損 journal が quarantine され、再開可否を判断できない。"""
+
+
+class UploadJournalSaveError(UploadJournalError):
+    """upload journal の永続化に失敗した。"""
+
+
 class GeneratorError(AutomationError):
     """返信生成バックエンドの失敗（API エラー・レスポンス不正等）"""
 

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -3,18 +3,20 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from pathlib import Path
 
 from youtube_automation.core.adapters import cost_tracker
 from youtube_automation.core.adapters.security import redact_sensitive_data
 from youtube_automation.core.adapters.youtube import complete_collection_quota_plan, quota_shortages
-from youtube_automation.core.errors import AutomationError, QuotaExhaustedError
+from youtube_automation.core.errors import AutomationError, QuotaExhaustedError, UploadJournalError
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     ACTION_COMPLETE_COLLECTION_DEDUP_SKIPPED,
     ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
     ACTION_COMPLETE_COLLECTION_UPLOADED,
     TRACKING_STATUS_COMPLETED,
 )
+from youtube_automation.domains.uploads.upload_journal import UploadJournal
 from youtube_automation.domains.uploads.youtube import UPLOAD_SOURCE_EXISTING
 
 logger = logging.getLogger(__name__)
@@ -32,12 +34,14 @@ class CompleteCollectionExecutor:
         config: dict,
         playlist_assignment,
         move_collection_to_live,
+        upload_journal_factory: Callable[[Path], UploadJournal] = UploadJournal,
     ) -> None:
         self.uploader = uploader
         self.tracking_store = tracking_store
         self.config = config
         self.playlist_assignment = playlist_assignment
         self.move_collection_to_live = move_collection_to_live
+        self.upload_journal_factory = upload_journal_factory
 
     def failed(self, collection_path: Path, tracking: dict, error: AutomationError) -> dict:
         current = self.tracking_store.load(collection_path) or tracking
@@ -110,9 +114,18 @@ class CompleteCollectionExecutor:
         if publish_at:
             logger.info(f"📅 スケジュール公開: {publish_at}")
 
-        # tracking から resumable upload session URI を取り出す（無ければ None でフレッシュ実行）
+        # 移行前 tracking の URI は journal 初回利用時だけ引き継ぐ。
         cc = tracking.get("complete_collection", {})
-        resume_session_uri = cc.get("resume_session_uri")
+        try:
+            attempt = self.upload_journal_factory(collection_path).begin("complete_collection")
+            resume_session_uri = attempt.resume_uri
+            legacy_resume_uri = cc.get("resume_session_uri")
+            if resume_session_uri is None and isinstance(legacy_resume_uri, str):
+                attempt.record_session(legacy_resume_uri)
+                resume_session_uri = legacy_resume_uri
+        except UploadJournalError as error:
+            logger.error("❌ upload journal 読み込み失敗: %s", error)
+            return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
 
         shortages = quota_shortages(
             complete_collection_quota_plan(),
@@ -127,18 +140,8 @@ class CompleteCollectionExecutor:
             }
 
         def _on_session_uri_changed(uri: str | None) -> None:
-            """upload 中の URI 変化を tracking に永続化する。
-
-            並行更新（プレイリスト追加等が tracking を書く可能性）に備え、
-            毎回 disk から再ロードしてから書き戻す。
-            """
-            current = self.tracking_store.load(collection_path) or {}
-            cc_current = current.setdefault("complete_collection", {})
-            if uri is None:
-                cc_current.pop("resume_session_uri", None)
-            else:
-                cc_current["resume_session_uri"] = uri
-            self.tracking_store.save(collection_path, current)
+            """upload 中の URI 変化を journal に永続化する。"""
+            attempt.record_session(uri)
 
         def _on_upload_complete() -> None:
             """upload 成功通知。後続の status="completed" 書き込みと整合させるため URI を消す。"""
@@ -162,15 +165,23 @@ class CompleteCollectionExecutor:
                 "details": {"error": "quota exhausted", "retry_after_seconds": e.retry_after_seconds},
             }
         except AutomationError as error:
+            try:
+                attempt.fail(_COMPLETE_COLLECTION_ERROR)
+            except UploadJournalError:
+                logger.exception("upload journal への失敗記録にも失敗しました")
             return self.failed(collection_path, tracking, error)
 
         complete_video = result.get("complete_video")
         if complete_video and "video_id" in complete_video:
+            try:
+                attempt.complete(complete_video)
+            except UploadJournalError as error:
+                logger.error("❌ upload journal 完了記録失敗: %s", error)
+                return {"action": "complete_collection_failed", "details": {"error": _COMPLETE_COLLECTION_ERROR}}
             return self.finish(collection_path, tracking, complete_video, publish_at)
 
         error_msg = _COMPLETE_COLLECTION_ERROR
-        # callback が disk に書いた URI 状態（session 失効クリア等）を保ったまま
-        # status 更新を載せるため、disk から再ロードしてから書き戻す。
+        attempt.fail(error_msg)
         current = self.tracking_store.load(collection_path) or tracking
         cc_current = current.setdefault("complete_collection", {})
         cc_current["status"] = "failed"

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 
@@ -27,6 +28,7 @@ from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
+from youtube_automation.domains.uploads.upload_journal import UploadJournal, UploadJournalOutcome
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 from youtube_automation.infrastructure.filesystem import (
     list_directory,
@@ -73,6 +75,7 @@ class CollectionUploader:
         published_dates: PublishedDatesScheduler | None = None,
         playlist_assignment: PlaylistAssignment | None = None,
         complete_collection_executor: CompleteCollectionExecutor | None = None,
+        upload_journal_factory: Callable[[Path], UploadJournal] = UploadJournal,
         allow_duration_outside_target: bool = False,
     ):
         if collections_root is None:
@@ -93,6 +96,7 @@ class CollectionUploader:
         )
         self.config = self._load_config()
         self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
+        self.upload_journal_factory = upload_journal_factory
         self.youtube_service = None
         self.youtube_clients = youtube_clients
         self.published_dates = published_dates or PublishedDatesScheduler(self.config, self._provide_youtube_service)
@@ -108,6 +112,7 @@ class CollectionUploader:
                 self.config,
                 self.playlist_assignment,
                 self._move_collection_to_live,
+                upload_journal_factory,
             )
         )
 
@@ -212,6 +217,13 @@ class CollectionUploader:
         Returns:
             dict: {"action": str, "details": dict}
         """
+        journal_status = self.upload_journal_factory(collection_path).status("complete_collection")
+        if journal_status.outcome is UploadJournalOutcome.CORRUPT:
+            logger.error("❌ upload journal 破損のため upload 可否を判定できません")
+            return {
+                "action": "complete_collection_failed",
+                "details": {"error": "upload journal is corrupt", "quarantine": str(journal_status.quarantine_path)},
+            }
         # tracking 読み込み or 初期化
         tracking = self.tracking_store.load(collection_path)
         if tracking is None:

--- a/src/youtube_automation/domains/uploads/upload_journal.py
+++ b/src/youtube_automation/domains/uploads/upload_journal.py
@@ -60,7 +60,7 @@ class UploadAttempt:
                 record.pop("resume_session_uri", None)
             else:
                 record["resume_session_uri"] = uri
-            record["status"] = "in_progress"
+            record["journal_status"] = "in_progress"
 
         self._journal._mutate(self.kind, mutate)
 
@@ -73,7 +73,7 @@ class UploadAttempt:
 
         def mutate(record: dict[str, JSONValue]) -> None:
             record.pop("resume_session_uri", None)
-            record["status"] = "completed"
+            record["journal_status"] = "completed"
             record["video_id"] = video_id
             for key in ("video_url", "upload_source"):
                 value = video.get(key)
@@ -89,8 +89,8 @@ class UploadAttempt:
             raise TypeError("upload failure must be a non-empty string")
 
         def mutate(record: dict[str, JSONValue]) -> None:
-            record["status"] = "failed"
-            record["error"] = error
+            record["journal_status"] = "failed"
+            record["journal_error"] = error
 
         self._journal._mutate(self.kind, mutate)
 
@@ -113,7 +113,7 @@ class UploadJournal:
         _validate_kind(kind)
         status = self.status(kind)
         if status.outcome is UploadJournalOutcome.ABSENT:
-            self._mutate(kind, lambda record: record.setdefault("status", "pending"))
+            self._mutate(kind, lambda record: record.setdefault("journal_status", "pending"))
             status = self.status(kind)
         return UploadAttempt(self, kind, status)
 
@@ -127,7 +127,7 @@ class UploadJournal:
         if record is not None and not isinstance(record, dict):
             quarantine_path = self._quarantine()
             return UploadJournalStatus(UploadJournalOutcome.CORRUPT, None, quarantine_path)
-        status = record.get("status") if isinstance(record, dict) else None
+        status = record.get("journal_status") if isinstance(record, dict) else None
         return UploadJournalStatus(outcome, status if isinstance(status, str) else None)
 
     def _resume_uri(self, kind: str) -> str | None:

--- a/src/youtube_automation/domains/uploads/upload_journal.py
+++ b/src/youtube_automation/domains/uploads/upload_journal.py
@@ -1,0 +1,195 @@
+"""upload の冪等性 token を所有する journal interface。"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from youtube_automation.core.adapters.media import CollectionPaths
+from youtube_automation.core.errors import UploadJournalCorruptError, UploadJournalSaveError
+from youtube_automation.infrastructure.filesystem import (
+    JSONValue,
+    file_lock,
+    make_directory,
+    path_exists,
+    read_file_text,
+    replace_file,
+    write_file_text,
+)
+
+
+class UploadJournalOutcome(Enum):
+    """journal 読み込みの明示 outcome。"""
+
+    ABSENT = "absent"
+    READY = "ready"
+    CORRUPT = "corrupt"
+
+
+@dataclass(frozen=True)
+class UploadJournalStatus:
+    outcome: UploadJournalOutcome
+    status: str | None
+    quarantine_path: Path | None = None
+
+
+class UploadAttempt:
+    """特定 upload kind の再開 token と遷移操作。"""
+
+    def __init__(self, journal: UploadJournal, kind: str, status: UploadJournalStatus) -> None:
+        self._journal = journal
+        self.kind = kind
+        self.status = status
+
+    @property
+    def resume_uri(self) -> str | None:
+        self._ensure_usable()
+        return self._journal._resume_uri(self.kind)
+
+    def record_session(self, uri: str | None) -> None:
+        """resumable session URI を保存または明示的に消去する。"""
+        self._ensure_usable()
+        if uri is not None and not isinstance(uri, str):
+            raise TypeError("upload session URI must be a string or null")
+
+        def mutate(record: dict[str, JSONValue]) -> None:
+            if uri is None:
+                record.pop("resume_session_uri", None)
+            else:
+                record["resume_session_uri"] = uri
+            record["status"] = "in_progress"
+
+        self._journal._mutate(self.kind, mutate)
+
+    def complete(self, video: Mapping[str, JSONValue]) -> None:
+        """upload 完了を記録し、再開 token を破棄する。"""
+        self._ensure_usable()
+        video_id = video.get("video_id")
+        if not isinstance(video_id, str) or not video_id:
+            raise TypeError("completed upload video_id must be a non-empty string")
+
+        def mutate(record: dict[str, JSONValue]) -> None:
+            record.pop("resume_session_uri", None)
+            record["status"] = "completed"
+            record["video_id"] = video_id
+            for key in ("video_url", "upload_source"):
+                value = video.get(key)
+                if value is not None:
+                    record[key] = value
+
+        self._journal._mutate(self.kind, mutate)
+
+    def fail(self, error: str) -> None:
+        """upload 失敗を記録する。resume token は retry のため保持する。"""
+        self._ensure_usable()
+        if not isinstance(error, str) or not error:
+            raise TypeError("upload failure must be a non-empty string")
+
+        def mutate(record: dict[str, JSONValue]) -> None:
+            record["status"] = "failed"
+            record["error"] = error
+
+        self._journal._mutate(self.kind, mutate)
+
+    def _ensure_usable(self) -> None:
+        if self.status.outcome is UploadJournalOutcome.CORRUPT:
+            raise UploadJournalCorruptError(
+                f"upload journal is corrupt and was quarantined: {self.status.quarantine_path}"
+            )
+
+
+class UploadJournal:
+    """collection 単位で upload kind ごとの冪等性 token を永続化する。"""
+
+    def __init__(self, collection: Path) -> None:
+        self.collection = collection
+        self.path = CollectionPaths(collection).tracking_path
+
+    def begin(self, kind: str) -> UploadAttempt:
+        """kind の attempt を開始する。破損は resume 時に明示 error となる。"""
+        _validate_kind(kind)
+        status = self.status(kind)
+        if status.outcome is UploadJournalOutcome.ABSENT:
+            self._mutate(kind, lambda record: record.setdefault("status", "pending"))
+            status = self.status(kind)
+        return UploadAttempt(self, kind, status)
+
+    def status(self, kind: str) -> UploadJournalStatus:
+        """kind の状態を、欠落・正常・破損を区別して返す。"""
+        _validate_kind(kind)
+        outcome, document, quarantine_path = self._load()
+        if outcome is not UploadJournalOutcome.READY:
+            return UploadJournalStatus(outcome, None, quarantine_path)
+        record = document.get(kind)
+        if record is not None and not isinstance(record, dict):
+            quarantine_path = self._quarantine()
+            return UploadJournalStatus(UploadJournalOutcome.CORRUPT, None, quarantine_path)
+        status = record.get("status") if isinstance(record, dict) else None
+        return UploadJournalStatus(outcome, status if isinstance(status, str) else None)
+
+    def _resume_uri(self, kind: str) -> str | None:
+        outcome, document, quarantine_path = self._load()
+        if outcome is UploadJournalOutcome.CORRUPT:
+            raise UploadJournalCorruptError(f"upload journal is corrupt and was quarantined: {quarantine_path}")
+        record = document.get(kind)
+        if record is not None and not isinstance(record, dict):
+            quarantine_path = self._quarantine()
+            raise UploadJournalCorruptError(f"upload journal is corrupt and was quarantined: {quarantine_path}")
+        if not isinstance(record, dict):
+            return None
+        uri = record.get("resume_session_uri")
+        return uri if isinstance(uri, str) else None
+
+    def _load(self) -> tuple[UploadJournalOutcome, dict[str, JSONValue], Path | None]:
+        if not path_exists(self.path):
+            return UploadJournalOutcome.ABSENT, {}, None
+        try:
+            document = json.loads(read_file_text(self.path))
+            if not isinstance(document, dict):
+                raise json.JSONDecodeError("root must be an object", read_file_text(self.path), 0)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            quarantine_path = self._quarantine()
+            return UploadJournalOutcome.CORRUPT, {}, quarantine_path
+        return UploadJournalOutcome.READY, document, None
+
+    def _quarantine(self) -> Path:
+        quarantine_path = self.path.with_suffix(".json.corrupt")
+        try:
+            replace_file(self.path, quarantine_path)
+        except OSError as exc:
+            raise UploadJournalCorruptError(f"upload journal could not be quarantined: {self.path}") from exc
+        return quarantine_path
+
+    def _mutate(self, kind: str, mutate: Callable[[dict[str, JSONValue]], object]) -> None:
+        with file_lock(self.path):
+            outcome, document, quarantine_path = self._load()
+            if outcome is UploadJournalOutcome.CORRUPT:
+                raise UploadJournalCorruptError(f"upload journal is corrupt and was quarantined: {quarantine_path}")
+            if outcome is UploadJournalOutcome.ABSENT:
+                document = {"schema_version": 3, "collection_name": self.collection.name}
+            record = document.setdefault(kind, {})
+            if not isinstance(record, dict):
+                raise UploadJournalCorruptError(f"upload journal kind must be an object: {kind}")
+            mutate(record)
+            self._save(document)
+
+    def _save(self, document: dict[str, JSONValue]) -> None:
+        make_directory(self.path.parent, parents=True, exist_ok=True)
+        temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        try:
+            write_file_text(temporary, json.dumps(document, ensure_ascii=False, indent=2) + "\n")
+            replace_file(temporary, self.path)
+        except (OSError, TypeError, ValueError) as exc:
+            temporary.unlink(missing_ok=True)
+            raise UploadJournalSaveError(f"upload journal could not be saved: {self.path}") from exc
+
+
+def _validate_kind(kind: str) -> None:
+    if not isinstance(kind, str) or not kind:
+        raise TypeError("upload kind must be a non-empty string")
+
+
+__all__ = ["UploadAttempt", "UploadJournal", "UploadJournalOutcome", "UploadJournalStatus"]

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -27,6 +27,19 @@ from youtube_automation.domains.uploads.collection import PlaylistAssignment, Pu
 sys.path.insert(0, str(REPO_ROOT))
 
 
+def test_corrupt_journal_never_falls_through_to_fresh_upload_or_dedup(tmp_path: Path) -> None:
+    col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
+    tracking_path.write_text("{truncated", encoding="utf-8")
+    uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
+
+    result = uploader.execute_next_step(col)
+
+    assert result["action"] == "complete_collection_failed"
+    assert result["details"]["error"] == "upload journal is corrupt"
+    mock_inner.upload_collection.assert_not_called()
+    assert tracking_path.with_suffix(".json.corrupt").is_file()
+
+
 # ---------------------------------------------------------------------------
 # import smoke test (#77)
 # ---------------------------------------------------------------------------

--- a/tests/domains/uploads/test_upload_journal.py
+++ b/tests/domains/uploads/test_upload_journal.py
@@ -1,0 +1,87 @@
+"""UploadJournal の永続化・破損・失敗契約。"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.core.errors import UploadJournalCorruptError, UploadJournalSaveError
+from youtube_automation.domains.uploads import upload_journal
+from youtube_automation.domains.uploads.upload_journal import UploadJournal, UploadJournalOutcome
+
+
+def test_attempt_records_resume_completion_and_failure(tmp_path: Path) -> None:
+    journal = UploadJournal(tmp_path / "collection")
+    attempt = journal.begin("complete_collection")
+
+    assert attempt.status.outcome is UploadJournalOutcome.READY
+    assert attempt.resume_uri is None
+
+    attempt.record_session("https://upload.example/session")
+    assert journal.begin("complete_collection").resume_uri == "https://upload.example/session"
+
+    attempt.fail("quota exhausted")
+    assert journal.status("complete_collection").status == "failed"
+    assert journal.begin("complete_collection").resume_uri == "https://upload.example/session"
+
+    attempt.complete({"video_id": "video-123", "video_url": "https://youtu.be/video-123"})
+    assert journal.status("complete_collection").status == "completed"
+    assert journal.begin("complete_collection").resume_uri is None
+
+
+def test_each_write_reloads_and_preserves_concurrent_fields(tmp_path: Path) -> None:
+    journal = UploadJournal(tmp_path / "collection")
+    attempt = journal.begin("complete_collection")
+    document = json.loads(journal.path.read_text(encoding="utf-8"))
+    document["concurrent_writer"] = {"keep": True}
+    journal.path.write_text(json.dumps(document), encoding="utf-8")
+
+    attempt.record_session("https://upload.example/session")
+
+    persisted = json.loads(journal.path.read_text(encoding="utf-8"))
+    assert persisted["concurrent_writer"] == {"keep": True}
+
+
+def test_corrupt_journal_is_quarantined_and_never_looks_absent(tmp_path: Path) -> None:
+    journal = UploadJournal(tmp_path / "collection")
+    journal.path.parent.mkdir(parents=True)
+    journal.path.write_text("{broken", encoding="utf-8")
+
+    attempt = journal.begin("complete_collection")
+
+    assert attempt.status.outcome is UploadJournalOutcome.CORRUPT
+    assert attempt.status.quarantine_path is not None
+    assert attempt.status.quarantine_path.is_file()
+    with pytest.raises(UploadJournalCorruptError):
+        _ = attempt.resume_uri
+    with pytest.raises(UploadJournalCorruptError):
+        attempt.record_session("https://upload.example/new")
+    assert not journal.path.exists()
+
+
+def test_malformed_kind_record_is_corrupt_not_an_empty_attempt(tmp_path: Path) -> None:
+    journal = UploadJournal(tmp_path / "collection")
+    journal.path.parent.mkdir(parents=True)
+    journal.path.write_text('{"complete_collection":"broken"}', encoding="utf-8")
+
+    attempt = journal.begin("complete_collection")
+
+    assert attempt.status.outcome is UploadJournalOutcome.CORRUPT
+    with pytest.raises(UploadJournalCorruptError):
+        _ = attempt.resume_uri
+
+
+def test_save_failure_is_not_silenced(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    journal = UploadJournal(tmp_path / "collection")
+
+    def fail_write(_path: Path, _text: str, *, encoding: str = "utf-8") -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(upload_journal, "write_file_text", fail_write)
+
+    with pytest.raises(UploadJournalSaveError) as exc_info:
+        journal.begin("complete_collection")
+
+    assert isinstance(exc_info.value.__cause__, OSError)


### PR DESCRIPTION
## Summary
- UploadJournal / UploadAttempt interface と status outcome を追加
- lock 内再読込、破損 quarantine、保存失敗 typed error を実装
- Complete Collection の resume・完了・失敗記録を UploadJournal 経由へ移行

Closes #4441