### PR TITLE
feat(collections): collection inventory を追加する (#4426)

### DIFF
--- a/changelog.d/4426-collection-inventory.added.md
+++ b/changelog.d/4426-collection-inventory.added.md
@@ -1,0 +1,1 @@
+- planning / live の collection 探索規則を inventory に集約し、symlink・予約 prefix・重複名を一貫して扱いながら読取不能な workflow state を明示値として返す（#4426）。

--- a/src/youtube_automation/domains/collections/inventory.py
+++ b/src/youtube_automation/domains/collections/inventory.py
@@ -1,0 +1,98 @@
+"""チャンネル内 collection の決定的で安全な inventory。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.workflow_state import Stage, WorkflowState, read
+
+_DEFAULT_STAGES: tuple[Stage, ...] = ("planning", "live")
+_SUPPORTED_STAGES = frozenset(_DEFAULT_STAGES)
+
+
+@dataclass(frozen=True, slots=True)
+class UnreadableWorkflowState:
+    """読み込めなかった workflow-state.json の明示的な値。"""
+
+    path: Path
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class CollectionRecord:
+    """collection directory とその読み取り済み workflow state。"""
+
+    directory: Path
+    stage: Stage
+    state: WorkflowState | UnreadableWorkflowState
+
+
+def _validate_stages(stages: tuple[Stage, ...]) -> None:
+    seen: set[Stage] = set()
+    for stage in stages:
+        if stage not in _SUPPORTED_STAGES:
+            raise WorkflowStateError(f"unsupported collection stage: {stage}")
+        if stage in seen:
+            raise WorkflowStateError(f"duplicate collection stage: {stage}")
+        seen.add(stage)
+
+
+def _require_directory(path: Path, *, label: str) -> None:
+    if path.is_symlink():
+        raise WorkflowStateError(f"{label} must not be a symlink: {path}")
+    if not path.is_dir():
+        raise WorkflowStateError(f"{label} is not a directory: {path}")
+
+
+def iter_collections(
+    channel_dir: Path,
+    stages: tuple[Stage, ...] = _DEFAULT_STAGES,
+) -> tuple[CollectionRecord, ...]:
+    """指定 stage の collection と state を名前順で返す。
+
+    ``.`` / ``_`` で始まる名前は予約領域として除外する。構造上の hazard
+    （symlink と stage 間の同名 collection）は fail loud とし、個々の state の
+    読取不能だけは :class:`UnreadableWorkflowState` として呼び出し側へ渡す。
+    """
+
+    _validate_stages(stages)
+    collections_root = channel_dir / "collections"
+    if not collections_root.exists() and not collections_root.is_symlink():
+        return ()
+    _require_directory(collections_root, label="collections directory")
+
+    records: list[CollectionRecord] = []
+    names: dict[str, Stage] = {}
+    for stage in stages:
+        stage_dir = collections_root / stage
+        if not stage_dir.exists() and not stage_dir.is_symlink():
+            continue
+        _require_directory(stage_dir, label=f"collection stage {stage}")
+        try:
+            entries = sorted(stage_dir.iterdir(), key=lambda path: path.name)
+        except OSError as exc:
+            raise WorkflowStateError(f"collection stage could not be read: {stage_dir}") from exc
+        for directory in entries:
+            if directory.name.startswith((".", "_")):
+                continue
+            if directory.is_symlink():
+                raise WorkflowStateError(f"collection must not be a symlink: {directory}")
+            if not directory.is_dir():
+                continue
+            previous_stage = names.get(directory.name)
+            if previous_stage is not None:
+                raise WorkflowStateError(
+                    f"duplicate collection name across stages: {directory.name} ({previous_stage}, {stage})"
+                )
+            names[directory.name] = stage
+            resolved = directory.resolve(strict=True)
+            state_path = resolved / "workflow-state.json"
+            try:
+                state: WorkflowState | UnreadableWorkflowState = read(state_path)
+            except WorkflowStateError as exc:
+                state = UnreadableWorkflowState(path=state_path, reason=str(exc))
+            records.append(CollectionRecord(directory=resolved, stage=stage, state=state))
+
+    return tuple(sorted(records, key=lambda record: record.directory.name))

--- a/tests/domains/collections/test_collection_inventory.py
+++ b/tests/domains/collections/test_collection_inventory.py
@@ -1,0 +1,100 @@
+"""Collection inventory domain tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.core.errors import WorkflowStateError
+from youtube_automation.domains.collections.inventory import (
+    CollectionRecord,
+    UnreadableWorkflowState,
+    iter_collections,
+)
+from youtube_automation.domains.collections.workflow_state import WorkflowState
+
+
+def _collection(channel_dir: Path, stage: str, name: str, payload: object = None) -> Path:
+    directory = channel_dir / "collections" / stage / name
+    directory.mkdir(parents=True)
+    if payload is not None:
+        (directory / "workflow-state.json").write_text(json.dumps(payload), encoding="utf-8")
+    return directory
+
+
+def test_iter_collections_returns_resolved_records_in_name_order(tmp_path: Path) -> None:
+    live = _collection(tmp_path, "live", "beta", {"phase": "complete"})
+    planning = _collection(tmp_path, "planning", "alpha", {"phase": "planning"})
+
+    records = iter_collections(tmp_path)
+
+    assert [record.directory for record in records] == [planning.resolve(), live.resolve()]
+    assert [record.stage for record in records] == ["planning", "live"]
+    assert all(isinstance(record, CollectionRecord) for record in records)
+    assert all(isinstance(record.state, WorkflowState) for record in records)
+
+
+def test_iter_collections_honors_requested_stages_and_empty_stage(tmp_path: Path) -> None:
+    _collection(tmp_path, "planning", "draft", {})
+    (tmp_path / "collections" / "live").mkdir(parents=True)
+
+    assert iter_collections(tmp_path, stages=("live",)) == ()
+    assert [record.directory.name for record in iter_collections(tmp_path, stages=("planning",))] == ["draft"]
+
+
+def test_iter_collections_skips_private_prefixes_and_non_directories(tmp_path: Path) -> None:
+    _collection(tmp_path, "planning", "_internal", {})
+    _collection(tmp_path, "planning", ".hidden", {})
+    visible = _collection(tmp_path, "planning", "visible", {})
+    (tmp_path / "collections" / "planning" / "note.txt").write_text("ignore", encoding="utf-8")
+
+    assert [record.directory for record in iter_collections(tmp_path)] == [visible.resolve()]
+
+
+@pytest.mark.parametrize("target", ["collections", "stage", "collection"])
+def test_iter_collections_rejects_symlinks(tmp_path: Path, target: str) -> None:
+    real = tmp_path / "real"
+    real.mkdir()
+    collections = tmp_path / "collections"
+    if target == "collections":
+        collections.symlink_to(real, target_is_directory=True)
+    elif target == "stage":
+        collections.mkdir()
+        (collections / "planning").symlink_to(real, target_is_directory=True)
+    else:
+        stage = collections / "planning"
+        stage.mkdir(parents=True)
+        (stage / "linked").symlink_to(real, target_is_directory=True)
+
+    with pytest.raises(WorkflowStateError, match="symlink"):
+        iter_collections(tmp_path)
+
+
+@pytest.mark.parametrize("state_contents", [None, "not json", "[]"])
+def test_iter_collections_represents_unreadable_state(tmp_path: Path, state_contents: str | None) -> None:
+    directory = _collection(tmp_path, "planning", "broken")
+    if state_contents is not None:
+        (directory / "workflow-state.json").write_text(state_contents, encoding="utf-8")
+
+    state = iter_collections(tmp_path)[0].state
+
+    assert isinstance(state, UnreadableWorkflowState)
+    assert state.path == directory.resolve() / "workflow-state.json"
+    assert "workflow-state.json" in state.reason
+
+
+def test_iter_collections_rejects_duplicate_names_across_stages(tmp_path: Path) -> None:
+    _collection(tmp_path, "planning", "same", {})
+    _collection(tmp_path, "live", "same", {})
+
+    with pytest.raises(WorkflowStateError, match="duplicate collection name.*same"):
+        iter_collections(tmp_path)
+
+
+def test_iter_collections_rejects_unknown_or_repeated_stage(tmp_path: Path) -> None:
+    with pytest.raises(WorkflowStateError, match="unsupported collection stage"):
+        iter_collections(tmp_path, stages=("archive",))  # type: ignore[arg-type]
+    with pytest.raises(WorkflowStateError, match="duplicate collection stage"):
+        iter_collections(tmp_path, stages=("planning", "planning"))


### PR DESCRIPTION
## Summary
- collection の列挙結果を表す `CollectionRecord` と workflow state の読取不能 variant を追加
- planning / live を決定的順序で列挙し、symlink・予約 prefix・重複名を一元的に扱う `iter_collections` を追加
- hazard 行列を inventory の単体テストで固定

Closes #4426