### PR TITLE
feat(review): review lifecycle と source adapter を追加する (#4430)

### DIFF
--- a/changelog.d/4430-review-lifecycle.added.md
+++ b/changelog.d/4430-review-lifecycle.added.md
@@ -1,0 +1,1 @@
+- review lifecycle と artifact source adapter interface を追加し、terminal 契約と確定前の変異検出を単一 protocol で提供する（#4430）。

--- a/src/youtube_automation/application/review_lifecycle.py
+++ b/src/youtube_automation/application/review_lifecycle.py
@@ -1,0 +1,111 @@
+"""Single owner for the review, selection, TOCTOU validation, and commit lifecycle."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Protocol
+
+from youtube_automation.core.errors import ReviewError
+from youtube_automation.domains.documents.review import (
+    ReviewArtifact,
+    ReviewCandidate,
+    ReviewOutcome,
+    ReviewSnapshot,
+    ReviewTransport,
+    SelectionManifest,
+)
+from youtube_automation.domains.documents.review_rendering import render_review_html, validate_review_html
+from youtube_automation.infrastructure.browser import open_local_file
+from youtube_automation.infrastructure.browser.selection_broker import SelectionBroker
+from youtube_automation.infrastructure.documents.publishing import publish_html_snapshot
+
+
+class ReviewSource(Protocol):
+    """Adapter implemented by each reviewable artifact source."""
+
+    @property
+    def artifact(self) -> ReviewArtifact: ...
+
+    @property
+    def html_path(self) -> Path: ...
+
+    def candidates(self) -> tuple[ReviewCandidate, ...]: ...
+
+    def media(self) -> tuple[tuple[str, Path], ...]: ...
+
+    def digest(self, candidates: tuple[ReviewCandidate, ...]) -> str: ...
+
+    def commit(self, candidate: ReviewCandidate) -> None: ...
+
+
+def review(source: ReviewSource, transport: ReviewTransport, automatic: bool, timeout: float) -> ReviewOutcome:
+    """Select and commit a candidate only if the source remains unchanged."""
+    snapshot = _snapshot(source)
+    candidate_ids = tuple(candidate.id for candidate in snapshot.manifest.candidates)
+    if not automatic and transport == "terminal":
+        return ReviewOutcome("terminal_required", snapshot.manifest.artifact_digest, candidate_ids)
+
+    destination: Path | None = None
+    if automatic:
+        selected_id = snapshot.manifest.candidates[0].id
+    else:
+        with SelectionBroker(snapshot.manifest) as broker:
+            destination = _display(source.html_path, snapshot, broker.endpoint)
+            selection = broker.wait(timeout=timeout)
+        selected_id = selection.candidate_id
+        if selection.artifact_digest != snapshot.manifest.artifact_digest:
+            raise ReviewError("review中にartifactまたは候補実体が変わりました。未確定のまま再実行してください")
+
+    current = _snapshot(source)
+    selected = _same_selection(snapshot, current, selected_id)
+    source.commit(selected)
+    return ReviewOutcome(
+        "selected",
+        current.manifest.artifact_digest,
+        candidate_ids,
+        candidate_id=selected.id,
+        html_path=destination,
+    )
+
+
+def _snapshot(source: ReviewSource) -> ReviewSnapshot:
+    candidates = source.candidates()
+    manifest = SelectionManifest.create(
+        artifact=source.artifact,
+        artifact_digest=source.digest(candidates),
+        candidates=candidates,
+        now=datetime.now(UTC),
+        lifetime=timedelta(minutes=5),
+    )
+    return ReviewSnapshot(manifest, source.media())
+
+
+def _same_selection(original: ReviewSnapshot, current: ReviewSnapshot, candidate_id: str) -> ReviewCandidate:
+    original_candidate = next((item for item in original.manifest.candidates if item.id == candidate_id), None)
+    current_candidate = next((item for item in current.manifest.candidates if item.id == candidate_id), None)
+    if (
+        original.manifest.artifact_digest != current.manifest.artifact_digest
+        or original_candidate is None
+        or current_candidate is None
+        or original_candidate.digest != current_candidate.digest
+    ):
+        raise ReviewError("review中にartifactまたは候補実体が変わりました。未確定のまま再実行してください")
+    return current_candidate
+
+
+def _display(destination: Path, snapshot: ReviewSnapshot, endpoint: str) -> Path:
+    media = dict(snapshot.media)
+    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media)
+    publish_html_snapshot(
+        destination,
+        html,
+        lambda persisted: validate_review_html(persisted, manifest=snapshot.manifest, endpoint=endpoint, media=media),
+    )
+    resolved = destination.resolve()
+    if not open_local_file(resolved):
+        raise ReviewError(f"browserでreview HTMLを開けません: {resolved}")
+    return resolved
+
+
+__all__ = ["ReviewSource", "review"]

--- a/src/youtube_automation/domains/documents/review.py
+++ b/src/youtube_automation/domains/documents/review.py
@@ -6,11 +6,14 @@ import re
 import secrets
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Literal
 
 from youtube_automation.core.errors import ReviewSelectionError
 
 ReviewArtifact = Literal["plan", "music-prompt", "thumbnail", "audio", "video"]
+ReviewTransport = Literal["web", "terminal"]
+ReviewStatus = Literal["terminal_required", "selected"]
 _CANDIDATE_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$")
 _DIGEST = re.compile(r"^[a-f0-9]{64}$")
 
@@ -82,3 +85,38 @@ class SelectionManifest:
         if candidate is None:
             raise ReviewSelectionError(f"許可されていない候補です: {candidate_id}")
         return candidate
+
+
+@dataclass(frozen=True)
+class ReviewSnapshot:
+    """Immutable view of one reviewable source at a point in time."""
+
+    manifest: SelectionManifest
+    media: tuple[tuple[str, Path], ...] = ()
+
+
+@dataclass(frozen=True)
+class ReviewOutcome:
+    """Transport-neutral result, including the terminal CLI contract."""
+
+    status: ReviewStatus
+    artifact_digest: str
+    candidates: tuple[str, ...]
+    candidate_id: str | None = None
+    html_path: Path | None = None
+
+    @property
+    def exit_code(self) -> int:
+        return 2 if self.status == "terminal_required" else 0
+
+    def json_payload(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "artifact_digest": self.artifact_digest,
+            "candidates": list(self.candidates),
+        }
+        if self.candidate_id is not None:
+            payload["candidate_id"] = self.candidate_id
+        if self.html_path is not None:
+            payload["html_path"] = str(self.html_path)
+        return payload

--- a/tests/application/test_review_lifecycle.py
+++ b/tests/application/test_review_lifecycle.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import pytest
+
+from youtube_automation.application import review_lifecycle
+from youtube_automation.core.errors import ReviewError
+from youtube_automation.domains.documents.review import ReviewCandidate
+from youtube_automation.infrastructure.browser.selection_broker import BrokerSelection
+
+
+def _digest(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+@dataclass
+class _Source:
+    html_path: Path
+    artifact: str = "thumbnail"
+    version: int = 0
+    reads: int = 0
+    commits: list[str] = field(default_factory=list)
+
+    def candidates(self) -> tuple[ReviewCandidate, ...]:
+        self.reads += 1
+        digest = _digest(f"candidate:{self.version}")
+        return (ReviewCandidate("candidate-1", "Candidate", digest),)
+
+    def media(self) -> tuple[tuple[str, Path], ...]:
+        return ()
+
+    def digest(self, candidates: tuple[ReviewCandidate, ...]) -> str:
+        return _digest(f"artifact:{self.version}:{candidates[0].digest}")
+
+    def commit(self, candidate: ReviewCandidate) -> None:
+        self.commits.append(candidate.id)
+
+
+class _Broker:
+    def __init__(self, manifest, source: _Source) -> None:
+        self.manifest = manifest
+        self.source = source
+        self.endpoint = "http://127.0.0.1/select"
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+    def wait(self, *, timeout: float) -> BrokerSelection:
+        assert timeout == 1
+        self.source.version += 1
+        return BrokerSelection("candidate-1", self.manifest.artifact_digest)
+
+
+def test_terminal_transport_returns_exit_code_two_and_json_contract(tmp_path: Path) -> None:
+    source = _Source(tmp_path / "review.html")
+
+    outcome = review_lifecycle.review(source, "terminal", False, 1)
+
+    assert outcome.exit_code == 2
+    assert outcome.json_payload() == {
+        "status": "terminal_required",
+        "artifact_digest": _digest(f"artifact:0:{_digest('candidate:0')}"),
+        "candidates": ["candidate-1"],
+    }
+    assert source.commits == []
+
+
+@pytest.mark.parametrize("initial_version", range(5))
+def test_review_rejects_every_candidate_mutation_before_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, initial_version: int
+) -> None:
+    """Property: any selected candidate byte version change prevents commit."""
+    source = _Source(tmp_path / "review.html", version=initial_version)
+    monkeypatch.setattr(review_lifecycle, "SelectionBroker", lambda manifest: _Broker(manifest, source))
+    monkeypatch.setattr(review_lifecycle, "_display", lambda *_args: source.html_path)
+
+    with pytest.raises(ReviewError, match="候補実体が変わりました"):
+        review_lifecycle.review(source, "web", False, 1)
+
+    assert source.commits == []
+
+
+def test_automatic_selection_revalidates_then_commits(tmp_path: Path) -> None:
+    source = _Source(tmp_path / "review.html")
+
+    outcome = review_lifecycle.review(source, "web", True, 1)
+
+    assert outcome.status == "selected"
+    assert outcome.exit_code == 0
+    assert source.reads == 2
+    assert source.commits == ["candidate-1"]


### PR DESCRIPTION
## Summary
- review lifecycle の単一 owner と source adapter interface を追加
- 再 snapshot と digest 比較による TOCTOU ガードを共通化
- terminal/JSON 契約と変異拒否をテストで固定

Closes #4430