### PR TITLE
refactor(collections): 列挙を inventory へ移行する (#4427)

### DIFF
--- a/changelog.d/4427-migrate-domain-application-vcs.changed.md
+++ b/changelog.d/4427-migrate-domain-application-vcs.changed.md
@@ -1,0 +1,1 @@
+- domain / application / VCS の collection 列挙を共通 inventory 経由へ移行し、readiness policy を filesystem 探索から分離する（#4427）。

--- a/src/youtube_automation/application/human_tasks.py
+++ b/src/youtube_automation/application/human_tasks.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from youtube_automation.core.errors import WorkflowStateError
-from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.collections.inventory import UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.human_tasks import (
     CollectionTaskState,
     HumanTaskNotifier,
@@ -27,43 +27,23 @@ class HumanTasksGenerationResult:
 
 
 def _collection_states(channel_dir: Path) -> tuple[CollectionTaskState, ...]:
-    collections_dir = channel_dir / "collections"
-    if collections_dir.is_symlink():
-        raise WorkflowStateError(f"collections directory に symlink は使えません: {collections_dir}")
-    if not collections_dir.exists():
-        return ()
-    if not collections_dir.is_dir():
-        raise WorkflowStateError(f"collections directory が不正です: {collections_dir}")
-    discovered: list[CollectionTaskState] = []
-    names: set[str] = set()
-    for area_name in ("planning", "live"):
-        area = collections_dir / area_name
-        if not area.exists():
-            continue
-        if area.is_symlink() or not area.is_dir():
-            raise WorkflowStateError(f"collection area が不正です: {area}")
-        for collection in sorted(area.iterdir(), key=lambda path: path.name):
-            if collection.is_symlink():
-                raise WorkflowStateError(f"collection に symlink は使えません: {collection}")
-            if not collection.is_dir():
-                continue
-            state_path = collection / "workflow-state.json"
-            if not state_path.exists():
-                continue
-            if state_path.is_symlink() or not state_path.is_file():
-                raise WorkflowStateError(f"workflow-state.json が不正です: {state_path}")
-            if collection.name in names:
-                raise WorkflowStateError(f"collection identifier が重複しています: {collection.name}")
-            state = read_workflow_state(state_path)
-            discovered.append(
-                CollectionTaskState(
-                    collection.name,
-                    state.phase,
-                    state.distrokid_submission_completed_at,
-                )
-            )
-            names.add(collection.name)
-    return tuple(discovered)
+    records = iter_collections(channel_dir)
+    unreadable = next(
+        (
+            record.state
+            for record in records
+            if isinstance(record.state, UnreadableWorkflowState)
+            and (record.state.path.exists() or record.state.path.is_symlink())
+        ),
+        None,
+    )
+    if unreadable:
+        raise WorkflowStateError(unreadable.reason)
+    return tuple(
+        CollectionTaskState(record.directory.name, record.state.phase, record.state.distrokid_submission_completed_at)
+        for record in records
+        if not isinstance(record.state, UnreadableWorkflowState)  # narrowed after the fail-loud check above
+    )
 
 
 def generate_human_tasks(

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 
 _PROMPT_FILES = {
@@ -22,28 +23,15 @@ class PlanningReadiness:
     collection: Path | None
 
 
-def _planning_states(root: Path) -> list[tuple[Path, WorkflowState]]:
-    planning = root.resolve() / "collections" / "planning"
-    if not planning.exists():
-        return []
-    if planning.is_symlink() or not planning.is_dir():
-        raise StateSyncError("collections/planning must be a regular directory")
+def _planning_states(records: tuple[CollectionRecord, ...]) -> list[tuple[Path, WorkflowState]]:
     states: list[tuple[Path, WorkflowState]] = []
-    for collection in sorted(planning.iterdir(), key=lambda path: path.name):
-        if collection.is_symlink():
-            raise StateSyncError(f"planning collection must not be a symlink: {collection.name}")
-        if not collection.is_dir() or collection.name.startswith("_"):
-            continue
-        state_path = collection / "workflow-state.json"
-        if not state_path.exists() and not state_path.is_symlink():
-            continue
-        try:
-            state = read(state_path)
-            phase = state.phase
-        except WorkflowStateError as exc:
-            raise StateSyncError(f"cloud planning state is invalid: {collection.name}") from exc
-        if phase != "complete":
-            states.append((collection.resolve(), state))
+    for record in records:
+        if isinstance(record.state, UnreadableWorkflowState):
+            if not record.state.path.exists() and not record.state.path.is_symlink():
+                continue
+            raise StateSyncError(f"cloud planning state is invalid: {record.directory.name}")
+        if record.state.phase != "complete":
+            states.append((record.directory, record.state))
     return states
 
 
@@ -59,7 +47,10 @@ def _sort_key(item: tuple[Path, WorkflowState]) -> tuple[str, str]:
 def resolve_planning_readiness(root: Path) -> PlanningReadiness:
     """Select the oldest active collection without mutating repository state."""
 
-    active = _planning_states(root)
+    try:
+        active = _planning_states(iter_collections(root.resolve(), ("planning",)))
+    except WorkflowStateError as exc:
+        raise StateSyncError("cloud planning inventory is invalid") from exc
     if not active:
         return PlanningReadiness("ready", None)
     collection, state = min(active, key=_sort_key)
@@ -75,7 +66,10 @@ def verify_planning_completion(root: Path, collection: Path | None) -> Path:
     """Verify artifact and state owners completed the selected planning stage."""
 
     if collection is None:
-        active = _planning_states(root)
+        try:
+            active = _planning_states(iter_collections(root.resolve(), ("planning",)))
+        except WorkflowStateError as exc:
+            raise StateSyncError("cloud planning inventory is invalid") from exc
         if len(active) != 1:
             raise StateSyncError("cloud planning must create exactly one active collection")
         collection, state = active[0]

--- a/src/youtube_automation/domains/post_publish.py
+++ b/src/youtube_automation/domains/post_publish.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
 from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 from youtube_automation.infrastructure.filesystem import file_lock
 
@@ -188,30 +190,45 @@ def _all_steps_complete(root: Path, collection: Path) -> bool:
     return _pinned_actual_exists(root, video_id)
 
 
-def resolve_post_publish_readiness(root: Path, requested: str | None = None) -> PostPublishReadiness:
-    root = root.resolve()
-    live = root / "collections" / "live"
-    if not live.exists():
-        return PostPublishReadiness("waiting", None)
-    if live.is_symlink() or not live.is_dir():
-        raise StateSyncError("collections/live must be a regular directory")
+def _post_publish_readiness(
+    records: tuple[CollectionRecord, ...],
+    requested: str | None,
+    is_complete: Callable[[Path], bool],
+) -> PostPublishReadiness:
     candidates: list[tuple[str, str, Path]] = []
-    for collection in sorted(live.iterdir(), key=lambda path: path.name):
-        if collection.is_symlink():
-            raise StateSyncError(f"live collection must not be a symlink: {collection.name}")
-        if not collection.is_dir() or collection.name.startswith("_"):
-            continue
+    for record in records:
+        collection = record.directory
         if requested and collection.name != requested:
             continue
-        try:
-            _, state = _video_id(collection)
-        except StateSyncError:
+        if isinstance(record.state, UnreadableWorkflowState):
             continue
-        if not _all_steps_complete(root, collection):
-            candidates.append((state.created_at or "9999", collection.name, collection.resolve()))
+        try:
+            upload = record.state.upload
+            eligible = (
+                record.state.phase == "complete"
+                and record.state.stage == "live"
+                and upload is not None
+                and bool(upload.video_id)
+            )
+        except WorkflowStateError:
+            continue
+        if not eligible:
+            continue
+        complete = is_complete(collection)
+        if not complete:
+            candidates.append((record.state.created_at or "9999", collection.name, collection))
     if not candidates:
         return PostPublishReadiness("waiting", None)
     return PostPublishReadiness("ready", min(candidates)[2])
+
+
+def resolve_post_publish_readiness(root: Path, requested: str | None = None) -> PostPublishReadiness:
+    root = root.resolve()
+    try:
+        records = iter_collections(root, ("live",))
+    except WorkflowStateError as exc:
+        raise StateSyncError("post-publish inventory is invalid") from exc
+    return _post_publish_readiness(records, requested, lambda collection: _all_steps_complete(root, collection))
 
 
 def verify_post_publish_completion(root: Path, collection: Path) -> Path:

--- a/src/youtube_automation/infrastructure/vcs/state_git.py
+++ b/src/youtube_automation/infrastructure/vcs/state_git.py
@@ -12,7 +12,8 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Final
 
-from youtube_automation.core.errors import ConfigError
+from youtube_automation.core.errors import ConfigError, WorkflowStateError
+from youtube_automation.domains.collections.inventory import iter_collections
 
 STATE_GITIGNORE_MARKER: Final[str] = "# yt-state-git control plane (ADR-0024)"
 _ROOT_HISTORY_NAMES: Final[tuple[str, ...]] = (
@@ -97,32 +98,32 @@ def _regular_file(path: Path, *, label: str) -> None:
 
 
 def _collection_control_files(channel_dir: Path) -> list[Path]:
-    collections = channel_dir / "collections"
-    if not collections.exists() and not collections.is_symlink():
-        return []
-    _regular_directory(collections, label="collections directory")
     discovered: list[Path] = []
-    for stage in sorted(collections.iterdir(), key=lambda path: path.name):
-        if stage.is_symlink():
-            raise ConfigError(f"collections 配下に symlink は使えません: {stage}")
-        if not stage.is_dir():
-            continue
-        for collection in sorted(stage.iterdir(), key=lambda path: path.name):
-            if collection.is_symlink():
-                raise ConfigError(f"collection に symlink は使えません: {collection}")
-            if not collection.is_dir():
-                continue
-            state = collection / "workflow-state.json"
-            if state.exists() or state.is_symlink():
-                _regular_file(state, label="workflow-state.json")
-                discovered.append(state)
-            docs = collection / "20-documentation"
-            if docs.is_symlink():
-                raise ConfigError(f"20-documentation に symlink は使えません: {docs}")
-            tracking = docs / "upload_tracking.json"
-            if tracking.exists() or tracking.is_symlink():
-                _regular_file(tracking, label="upload_tracking.json")
-                discovered.append(tracking)
+    try:
+        records = iter_collections(channel_dir)
+    except WorkflowStateError as exc:
+        raise ConfigError(str(exc)) from exc
+    collections_root = channel_dir / "collections"
+    if collections_root.is_dir():
+        try:
+            unknown_entries = (entry for entry in collections_root.iterdir() if entry.name not in {"planning", "live"})
+            symlink = next((entry for entry in unknown_entries if entry.is_symlink()), None)
+        except OSError as exc:
+            raise ConfigError(f"collections directory を読み取れません: {collections_root}") from exc
+        if symlink is not None:
+            raise ConfigError(f"collections 配下に symlink は使えません: {symlink}")
+    for record in records:
+        state = record.directory / "workflow-state.json"
+        if state.exists() or state.is_symlink():
+            _regular_file(state, label="workflow-state.json")
+            discovered.append(state)
+        documentation = record.directory / "20-documentation"
+        if documentation.is_symlink():
+            raise ConfigError(f"20-documentation に symlink は使えません: {documentation}")
+        tracking = documentation / "upload_tracking.json"
+        if tracking.exists() or tracking.is_symlink():
+            _regular_file(tracking, label="upload_tracking.json")
+            discovered.append(tracking)
     return discovered
 
 

--- a/tests/application/test_human_tasks_generation.py
+++ b/tests/application/test_human_tasks_generation.py
@@ -80,6 +80,21 @@ def test_invalid_state_does_not_overwrite_existing_human_tasks(tmp_path: Path) -
     assert destination.read_text(encoding="utf-8") == "keep\n"
 
 
+def test_missing_state_is_skipped_without_hiding_valid_human_tasks(tmp_path: Path) -> None:
+    (tmp_path / "collections" / "planning" / "initializing").mkdir(parents=True)
+    _state(tmp_path, "pending", {"phase": "complete"})
+    notifier = RecordingNotifier()
+
+    result = generate_human_tasks(
+        tmp_path,
+        channel="soulful-grooves",
+        distrokid_enabled=True,
+        notifier=notifier,
+    )
+
+    assert [task.collection for task in result.report.tasks] == ["pending"]
+
+
 def test_recording_submission_removes_task_from_file_and_next_discord_summary(tmp_path: Path) -> None:
     collection = _state(tmp_path, "volume-one", {"phase": "complete"})
     notifier = RecordingNotifier()

--- a/tests/commands/system/test_state_git_migration.py
+++ b/tests/commands/system/test_state_git_migration.py
@@ -224,6 +224,34 @@ def test_symlinked_collection_is_rejected_without_reading_external_data(tmp_path
     assert "secret outside data" not in captured.out + captured.err
 
 
+def test_symlinked_documentation_is_rejected_without_reading_external_tracking(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    collection = channel / "collections" / "planning" / "demo"
+    collection.mkdir(parents=True)
+    (collection / "workflow-state.json").write_text('{"phase": "planning"}\n', encoding="utf-8")
+    outside = tmp_path / "external-documentation"
+    outside.mkdir()
+    (outside / "upload_tracking.json").write_text('{"schema_version": 3}\n', encoding="utf-8")
+    (collection / "20-documentation").symlink_to(outside, target_is_directory=True)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 1
+
+    captured = capsys.readouterr()
+    assert "symlink" in captured.err
+
+
+def test_symlinked_unknown_collection_stage_is_rejected(tmp_path: Path, capsys) -> None:
+    channel = _init_repo(tmp_path / "channel")
+    outside = tmp_path / "outside-stage"
+    outside.mkdir()
+    collections = channel / "collections"
+    collections.mkdir()
+    (collections / "backup").symlink_to(outside, target_is_directory=True)
+
+    assert main(["migrate-state-git", "--channel-dir", str(channel), "--dry-run"]) == 1
+    assert "symlink" in capsys.readouterr().err
+
+
 def test_check_rejects_untracked_control_file_even_when_policy_exists(tmp_path: Path, capsys) -> None:
     channel = _init_repo(tmp_path / "channel", gitignore="")
     state, *_ = _write_control_files(channel)

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -8,9 +8,12 @@ import pytest
 from youtube_automation.core.errors import StateSyncError
 from youtube_automation.domains.cloud_planning import (
     PlanningReadiness,
+    _planning_states,
     resolve_planning_readiness,
     verify_planning_completion,
 )
+from youtube_automation.domains.collections.inventory import CollectionRecord
+from youtube_automation.domains.collections.workflow_state import WorkflowState
 
 
 def _state(root: Path, name: str, *, phase: str, created_at: str, engine: str = "suno") -> Path:
@@ -36,6 +39,13 @@ def test_readiness_selects_new_planning_when_no_unfinished_collection_exists(tmp
     assert resolve_planning_readiness(tmp_path) == PlanningReadiness("ready", None)
 
 
+def test_planning_policy_projects_inventory_records_without_reading_files(tmp_path: Path) -> None:
+    directory = tmp_path / "not-created"
+    state = WorkflowState({"phase": "planning", "created_at": "2026-01-01T00:00:00Z"})
+
+    assert _planning_states((CollectionRecord(directory, "planning", state),)) == [(directory, state)]
+
+
 def test_readiness_selects_oldest_planning_collection(tmp_path: Path) -> None:
     newer = _state(tmp_path, "newer", phase="planning", created_at="2026-02-02T00:00:00Z")
     older = _state(tmp_path, "older", phase="planning", created_at="2026-01-01T00:00:00Z")
@@ -49,6 +59,13 @@ def test_readiness_waits_when_oldest_active_collection_has_left_planning(tmp_pat
     _state(tmp_path, "planning", phase="planning", created_at="2026-02-01T00:00:00Z")
 
     assert resolve_planning_readiness(tmp_path) == PlanningReadiness("waiting", prepared.resolve())
+
+
+def test_readiness_skips_collection_whose_state_is_not_created_yet(tmp_path: Path) -> None:
+    (tmp_path / "collections" / "planning" / "initializing").mkdir(parents=True)
+    active = _state(tmp_path, "active", phase="planning", created_at="2026-01-01T00:00:00Z")
+
+    assert resolve_planning_readiness(tmp_path) == PlanningReadiness("ready", active.resolve())
 
 
 def test_completion_requires_prepared_state_and_engine_prompt_pair(tmp_path: Path) -> None:

--- a/tests/domains/test_post_publish.py
+++ b/tests/domains/test_post_publish.py
@@ -6,8 +6,12 @@ from pathlib import Path
 import pytest
 
 from youtube_automation.core.errors import StateSyncError
+from youtube_automation.domains.collections.inventory import CollectionRecord
+from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.post_publish import (
     PostPublishDecision,
+    PostPublishReadiness,
+    _post_publish_readiness,
     evaluate,
     mark_complete,
     resolve_post_publish_readiness,
@@ -73,6 +77,39 @@ def test_cloud_readiness_selects_oldest_incomplete_live_collection(tmp_path: Pat
 
     assert readiness.status == "ready"
     assert readiness.collection == older.resolve()
+
+
+def test_readiness_skips_live_collection_whose_phase_is_not_complete(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state["phase"] = "publishing"
+    state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+
+    assert resolve_post_publish_readiness(tmp_path) == PostPublishReadiness("waiting", None)
+
+
+def test_readiness_reports_invalid_shared_post_publish_history(tmp_path: Path) -> None:
+    _collection(tmp_path)
+    (tmp_path / "post_publish_history.json").write_text('{"schema_version": 999, "videos": {}}\n', encoding="utf-8")
+
+    with pytest.raises(StateSyncError, match="unsupported post-publish history schema"):
+        resolve_post_publish_readiness(tmp_path)
+
+
+def test_post_publish_policy_selects_inventory_record_without_reading_files(tmp_path: Path) -> None:
+    directory = tmp_path / "not-created"
+    state = WorkflowState(
+        {
+            "phase": "complete",
+            "stage": "live",
+            "created_at": "2026-01-01T00:00:00Z",
+            "upload": {"video_id": "video-1"},
+        }
+    )
+    records = (CollectionRecord(directory, "live", state),)
+
+    assert _post_publish_readiness(records, None, lambda _: False) == PostPublishReadiness("ready", directory)
 
 
 def test_completion_requires_all_tracking_and_pinned_actual_artifact(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- domain / application / VCS の collection 列挙を共通 inventory 経由へ移行
- readiness policy を `CollectionRecord` 入力へ分離し filesystem 非依存で検証可能に変更

Closes #4427