### PR TITLE
refactor(review): mediaレビューをadapter化する (#4432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `refactor(review)`: thumbnail / master audio / master video を source adapter 化し、review 表示・再 snapshot 検証・digest 計算を共通 lifecycle に集約する（#4432）。
-
-- `refactor(review)`: collection plan / music prompt を source adapter と共通 select CLI harness へ移行する（#4431）。
-
-- `feat(review)`: review lifecycle と artifact source adapter interface を追加し、terminal 契約と確定前の変異検出を単一 protocol で提供する（#4430）。
-
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `refactor(review)`: thumbnail / master audio / master video を source adapter 化し、review 表示・再 snapshot 検証・digest 計算を共通 lifecycle に集約する（#4432）。
+
+- `refactor(review)`: collection plan / music prompt を source adapter と共通 select CLI harness へ移行する（#4431）。
+
+- `feat(review)`: review lifecycle と artifact source adapter interface を追加し、terminal 契約と確定前の変異検出を単一 protocol で提供する（#4430）。
+
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/changelog.d/4432-media-review-adapters.changed.md
+++ b/changelog.d/4432-media-review-adapters.changed.md
@@ -1,0 +1,1 @@
+- thumbnail / master audio / master video を source adapter 化し、review 表示・再 snapshot 検証・digest 計算を共通 lifecycle に集約する（#4432）。

--- a/src/youtube_automation/application/master_audio_review.py
+++ b/src/youtube_automation/application/master_audio_review.py
@@ -12,15 +12,17 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
+from youtube_automation.application.review_lifecycle import ReviewSource as LifecycleSource
+from youtube_automation.application.review_lifecycle import collection_root as _collection_root
+from youtube_automation.application.review_lifecycle import review
+from youtube_automation.application.review_lifecycle import sha256_file as _sha256
 from youtube_automation.core.errors import ReviewError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.documents.review import ReviewCandidate, SelectionManifest
-from youtube_automation.domains.documents.review_rendering import render_review_html, validate_review_html
 from youtube_automation.infrastructure.browser import open_local_file
 from youtube_automation.infrastructure.browser.selection_broker import SelectionBroker
-from youtube_automation.infrastructure.documents.publishing import publish_html_snapshot
 from youtube_automation.infrastructure.media.probe import probe_duration
 
 ReviewTransport = Literal["web", "terminal"]
@@ -60,6 +62,48 @@ class MasterAudioReviewSnapshot:
         return {candidate.candidate_id: candidate.path for candidate in self.candidates}
 
 
+class _AudioSource(LifecycleSource):
+    def __init__(self, collection: Path, skip: bool, main: Path | None, source: ReviewSource) -> None:
+        self.collection, self.skip, self.main, self.source = collection, skip, main, source
+        self.snapshot: MasterAudioReviewSnapshot | None = None
+
+    @property
+    def artifact(self):
+        return "audio"
+
+    @property
+    def html_path(self):
+        return self.collection.resolve() / "tmp/reviews/master-audio.html"
+
+    @property
+    def compact_image_ids(self):
+        return frozenset()
+
+    def candidates(self):
+        self.snapshot = build_master_audio_review_snapshot(
+            self.collection, skip_manual_mastering=self.skip, main_repo_root=self.main, now=datetime.now(UTC)
+        )
+        return self.snapshot.manifest.candidates
+
+    def media(self):
+        assert self.snapshot is not None
+        return tuple(self.snapshot.media().items())
+
+    def digest(self, candidates):
+        return _artifact_digest(self.snapshot.candidates) if self.snapshot else ""
+
+    def commit(self, candidate):
+        assert self.snapshot is not None
+        finalize_master_audio_selection(
+            self.collection,
+            skip_manual_mastering=self.skip,
+            candidate_id=candidate.id,
+            source=self.source,
+            expected_artifact_digest=self.snapshot.manifest.artifact_digest,
+            main_repo_root=self.main,
+        )
+
+
 def review_and_finalize_master_audio(
     collection: Path,
     *,
@@ -71,60 +115,27 @@ def review_and_finalize_master_audio(
     now: datetime | None = None,
     timeout: float = 300,
 ) -> MasterAudioReviewResult:
-    """Resolve candidates once, optionally review them, then finalize one revalidated ID."""
-    instant = now or datetime.now(UTC)
-    snapshot = build_master_audio_review_snapshot(
-        collection,
-        skip_manual_mastering=skip_manual_mastering,
-        main_repo_root=main_repo_root,
-        now=instant,
-    )
-    candidate_ids = tuple(candidate.candidate_id for candidate in snapshot.candidates)
-    destination: Path | None = None
-    source: ReviewSource
-    selected_id: str
-    if skip_audio_approval:
-        if candidate_id is None and len(candidate_ids) > 1:
-            return _terminal_required(snapshot)
-        selected_id = candidate_id or candidate_ids[0]
-        source = "automatic" if candidate_id is None else "terminal"
-    elif transport == "terminal":
-        if candidate_id is None:
-            return _terminal_required(snapshot)
-        selected_id = candidate_id
-        source = "terminal"
-    else:
-        if candidate_id is not None:
-            raise ValidationError("candidate-idはterminal review専用です")
-        with SelectionBroker(snapshot.manifest) as broker:
-            destination = _display(collection, snapshot, broker.endpoint)
-            selection = broker.wait(timeout=timeout)
-        current = build_master_audio_review_snapshot(
-            collection,
-            skip_manual_mastering=skip_manual_mastering,
-            main_repo_root=main_repo_root,
-            now=instant,
-        )
-        _require_same_selection(snapshot, current, selection.candidate_id, selection.artifact_digest)
-        selected_id = selection.candidate_id
-        source = "web"
-
-    if selected_id not in candidate_ids:
-        raise ValidationError(f"候補IDがreview manifest allowlistにありません: {selected_id}")
-    finalize_master_audio_selection(
-        collection,
-        skip_manual_mastering=skip_manual_mastering,
-        candidate_id=selected_id,
-        source=source,
-        expected_artifact_digest=snapshot.manifest.artifact_digest,
-        main_repo_root=main_repo_root,
+    del now
+    automatic = skip_audio_approval and candidate_id is None
+    source_name: ReviewSource = "automatic" if automatic else ("terminal" if transport == "terminal" else "web")
+    source = _AudioSource(collection, skip_manual_mastering, main_repo_root, source_name)
+    if automatic:
+        initial = source.candidates()
+        if len(initial) > 1:
+            return MasterAudioReviewResult(
+                "terminal_required", source.digest(initial), candidates=tuple(c.id for c in initial)
+            )
+    outcome = review(
+        source,
+        transport,
+        automatic,
+        timeout,
+        candidate_id=candidate_id,
+        broker_factory=SelectionBroker,
+        open_file=open_local_file,
     )
     return MasterAudioReviewResult(
-        status="selected",
-        artifact_digest=snapshot.manifest.artifact_digest,
-        candidate_id=selected_id,
-        candidates=candidate_ids,
-        html_path=destination,
+        outcome.status, outcome.artifact_digest, outcome.candidate_id, outcome.candidates, outcome.html_path
     )
 
 
@@ -315,12 +326,6 @@ def _review_state(collection: Path) -> tuple[Path, str]:
     return root, raw_master
 
 
-def _collection_root(collection: Path) -> Path:
-    if collection.is_symlink() or not collection.is_dir():
-        raise ReviewError(f"collection directoryが不正です: {collection}")
-    return collection.resolve()
-
-
 def _require_audio_file(path: Path) -> None:
     if path.is_symlink() or not path.is_file() or path.suffix.lower() not in _AUDIO_EXTENSIONS:
         raise ReviewError(f"master audio fileが不正です: {path}")
@@ -362,57 +367,6 @@ def _selection_summary(collection: Path) -> str:
 def _artifact_digest(candidates: tuple[MasterAudioCandidate, ...]) -> str:
     payload = "\n".join(f"{candidate.candidate_id}:{candidate.digest}" for candidate in candidates)
     return hashlib.sha256(payload.encode()).hexdigest()
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def _terminal_required(snapshot: MasterAudioReviewSnapshot) -> MasterAudioReviewResult:
-    return MasterAudioReviewResult(
-        status="terminal_required",
-        artifact_digest=snapshot.manifest.artifact_digest,
-        candidates=tuple(candidate.candidate_id for candidate in snapshot.candidates),
-    )
-
-
-def _display(collection: Path, snapshot: MasterAudioReviewSnapshot, endpoint: str) -> Path:
-    destination = _collection_root(collection) / "tmp/reviews/master-audio.html"
-    media = snapshot.media()
-    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media)
-    publish_html_snapshot(
-        destination,
-        html,
-        lambda persisted: validate_review_html(
-            persisted,
-            manifest=snapshot.manifest,
-            endpoint=endpoint,
-            media=media,
-        ),
-    )
-    if not open_local_file(destination.resolve()):
-        raise ReviewError(f"browserでmaster audio review HTMLを開けません: {destination.resolve()}")
-    return destination.resolve()
-
-
-def _require_same_selection(
-    original: MasterAudioReviewSnapshot,
-    current: MasterAudioReviewSnapshot,
-    candidate_id: str,
-    artifact_digest: str,
-) -> None:
-    if original.manifest.artifact_digest != artifact_digest:
-        raise ReviewError("brokerが返したartifact digestがreview対象と一致しません")
-    if current.manifest.artifact_digest != artifact_digest:
-        raise ReviewError("review中に音源または検査結果が変わりました")
-    before = next((candidate for candidate in original.candidates if candidate.candidate_id == candidate_id), None)
-    after = next((candidate for candidate in current.candidates if candidate.candidate_id == candidate_id), None)
-    if before is None or after is None or before.digest != after.digest:
-        raise ReviewError("review中に選択候補が変わりました")
 
 
 def _adopt(state_path: Path, selected: str) -> None:

--- a/src/youtube_automation/application/master_video_review.py
+++ b/src/youtube_automation/application/master_video_review.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from youtube_automation.application.review_lifecycle import ReviewSource, review
+from youtube_automation.application.review_lifecycle import ReviewSource, review, sha256_file
 from youtube_automation.core.errors import ReviewError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
@@ -89,7 +89,7 @@ class _VideoSource(ReviewSource):
             self.presentation.overlays,
             self.presentation.full_output_outlook,
         )
-        digest = hashlib.sha256((self.path.read_bytes().hex() + "\0" + "\0".join(values)).encode()).hexdigest()
+        digest = hashlib.sha256((sha256_file(self.path) + "\0" + "\0".join(values)).encode()).hexdigest()
         return (
             ReviewCandidate(
                 cid,

--- a/src/youtube_automation/application/master_video_review.py
+++ b/src/youtube_automation/application/master_video_review.py
@@ -4,20 +4,18 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Literal
 
+from youtube_automation.application.review_lifecycle import ReviewSource, review
 from youtube_automation.core.errors import ReviewError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
-from youtube_automation.domains.documents.review import ReviewCandidate, SelectionManifest
-from youtube_automation.domains.documents.review_rendering import render_review_html, validate_review_html
+from youtube_automation.domains.documents.review import ReviewCandidate
 from youtube_automation.infrastructure.browser import open_local_file
 from youtube_automation.infrastructure.browser.selection_broker import SelectionBroker
-from youtube_automation.infrastructure.documents.publishing import publish_html_snapshot
-from youtube_automation.infrastructure.media.probe import VideoProbe, probe_video
+from youtube_automation.infrastructure.media.probe import probe_video
 
 VideoReviewKind = Literal["preview", "full"]
 ReviewTransport = Literal["web", "terminal"]
@@ -40,11 +38,88 @@ class MasterVideoReviewResult:
     html_path: Path | None = None
 
 
-@dataclass(frozen=True)
-class _VideoSnapshot:
-    manifest: SelectionManifest
-    path: Path
-    probe: VideoProbe
+class _VideoSource(ReviewSource):
+    def __init__(self, collection: Path, kind: VideoReviewKind, presentation: VideoReviewPresentation) -> None:
+        self.collection = collection
+        self.kind = kind
+        self.presentation = presentation
+        self.path: Path | None = None
+
+    @property
+    def artifact(self):
+        return "video"
+
+    @property
+    def html_path(self):
+        return self.collection.resolve() / f"tmp/reviews/master-video-{self.kind}.html"
+
+    @property
+    def compact_image_ids(self):
+        return frozenset()
+
+    def candidates(self):
+        root = self.collection.resolve()
+        _require_pending_state(root)
+        _validate_presentation(self.presentation)
+        suffix = "Preview" if self.kind == "preview" else "Master"
+        paths = tuple(
+            p.resolve() for p in (root / "01-master").glob(f"*-{suffix}.mp4") if p.is_file() and not p.is_symlink()
+        )
+        if len(paths) != 1:
+            raise ReviewError(f"{self.kind} master videoを一意に解決できません")
+        self.path = paths[0]
+        probe = probe_video(self.path)
+        if probe is None:
+            raise ReviewError(f"ffprobeでmaster videoを検証できません: {self.path}")
+        cid = f"{self.kind}:{self.path.name}"
+        label = (
+            f"preview（{probe.duration_seconds:.0f}秒短尺確認）"
+            if self.kind == "preview"
+            else "full master（完成動画）"
+        )
+        values = (
+            self.kind,
+            str(probe.duration_seconds),
+            str(probe.width),
+            str(probe.height),
+            probe.codec,
+            str(self.path.stat().st_size),
+            self.presentation.background_route,
+            self.presentation.effect,
+            self.presentation.overlays,
+            self.presentation.full_output_outlook,
+        )
+        digest = hashlib.sha256((self.path.read_bytes().hex() + "\0" + "\0".join(values)).encode()).hexdigest()
+        return (
+            ReviewCandidate(
+                cid,
+                label,
+                digest,
+                (
+                    ("区分", label),
+                    ("ファイル名", self.path.name),
+                    ("duration", f"{probe.duration_seconds:.2f}秒"),
+                    ("resolution", f"{probe.width} × {probe.height}"),
+                    ("codec", probe.codec),
+                    ("filesize", f"{self.path.stat().st_size} bytes"),
+                    ("背景経路", self.presentation.background_route),
+                    ("effect", self.presentation.effect),
+                    ("overlay", self.presentation.overlays),
+                    ("Full output outlook", self.presentation.full_output_outlook),
+                ),
+            ),
+        )
+
+    def media(self):
+        assert self.path is not None
+        return ((f"{self.kind}:{self.path.name}", self.path),)
+
+    def digest(self, candidates):
+        return hashlib.sha256("\n".join(f"{c.id}:{c.digest}" for c in candidates).encode()).hexdigest()
+
+    def commit(self, candidate):
+        if self.kind == "full":
+            _record_master_video(self.collection.resolve() / "workflow-state.json", candidate.id.split(":", 1)[1])
 
 
 def review_master_video(
@@ -55,144 +130,23 @@ def review_master_video(
     automatic: bool,
     transport: ReviewTransport,
     candidate_id: str | None,
-    now: datetime,
+    now,
     timeout: float,
 ) -> MasterVideoReviewResult:
-    """Review one fixed generated video and update state only for confirmed full output."""
-    snapshot = _build_snapshot(collection, kind, presentation, now)
-    allowed_id = snapshot.manifest.candidates[0].id
-    destination: Path | None = None
-    if automatic:
-        selected_id = allowed_id
-    elif transport == "terminal":
-        if candidate_id is None:
-            return MasterVideoReviewResult(
-                "terminal_required",
-                snapshot.manifest.artifact_digest,
-                candidates=(allowed_id,),
-            )
-        selected_id = candidate_id
-    else:
-        if candidate_id is not None:
-            raise ValidationError("candidate-idはterminal review専用です")
-        with SelectionBroker(snapshot.manifest) as broker:
-            destination = _display(collection, kind, snapshot, broker.endpoint)
-            selection = broker.wait(timeout=timeout)
-        current = _build_snapshot(collection, kind, presentation, now)
-        if (
-            selection.artifact_digest != snapshot.manifest.artifact_digest
-            or current.manifest.artifact_digest != snapshot.manifest.artifact_digest
-            or selection.candidate_id != allowed_id
-        ):
-            raise ReviewError("review中にmaster videoまたは表示条件が変わりました")
-        selected_id = selection.candidate_id
-    if selected_id != allowed_id:
-        raise ValidationError(f"候補IDがreview manifest allowlistにありません: {selected_id}")
-    current = _build_snapshot(collection, kind, presentation, now)
-    if current.manifest.artifact_digest != snapshot.manifest.artifact_digest:
-        raise ReviewError("master video確定前にartifact digestが変わりました")
-    if kind == "full":
-        _record_master_video(collection.resolve() / "workflow-state.json", current.path.name)
+    del now
+    source = _VideoSource(collection, kind, presentation)
+    outcome = review(
+        source,
+        transport,
+        automatic,
+        timeout,
+        candidate_id=candidate_id,
+        broker_factory=SelectionBroker,
+        open_file=open_local_file,
+    )
     return MasterVideoReviewResult(
-        "selected",
-        current.manifest.artifact_digest,
-        selected_id,
-        (allowed_id,),
-        destination,
+        outcome.status, outcome.artifact_digest, outcome.candidate_id, outcome.candidates, outcome.html_path
     )
-
-
-def _build_snapshot(
-    collection: Path,
-    kind: VideoReviewKind,
-    presentation: VideoReviewPresentation,
-    now: datetime,
-) -> _VideoSnapshot:
-    root = _collection_root(collection)
-    _require_pending_state(root)
-    _validate_presentation(presentation)
-    suffix = "Preview" if kind == "preview" else "Master"
-    candidates = tuple(
-        path.resolve()
-        for path in (root / "01-master").glob(f"*-{suffix}.mp4")
-        if path.is_file() and not path.is_symlink()
-    )
-    if len(candidates) != 1:
-        raise ReviewError(f"{kind} master videoを一意に解決できません")
-    path = candidates[0]
-    probe = probe_video(path)
-    if probe is None:
-        raise ReviewError(f"ffprobeでmaster videoを検証できません: {path}")
-    file_digest = _sha256(path)
-    candidate_id = f"{kind}:{path.name}"
-    detail_values = (
-        kind,
-        str(probe.duration_seconds),
-        str(probe.width),
-        str(probe.height),
-        probe.codec,
-        str(path.stat().st_size),
-        presentation.background_route,
-        presentation.effect,
-        presentation.overlays,
-        presentation.full_output_outlook,
-    )
-    candidate_digest = hashlib.sha256((file_digest + "\0" + "\0".join(detail_values)).encode()).hexdigest()
-    label = f"preview（{probe.duration_seconds:.0f}秒短尺確認）" if kind == "preview" else "full master（完成動画）"
-    candidate = ReviewCandidate(
-        candidate_id,
-        label,
-        candidate_digest,
-        details=(
-            ("区分", label),
-            ("ファイル名", path.name),
-            ("duration", f"{probe.duration_seconds:.2f}秒"),
-            ("resolution", f"{probe.width} × {probe.height}"),
-            ("codec", probe.codec),
-            ("filesize", f"{path.stat().st_size} bytes"),
-            ("背景経路", presentation.background_route),
-            ("effect", presentation.effect),
-            ("overlay", presentation.overlays),
-            ("Full output outlook", presentation.full_output_outlook),
-        ),
-    )
-    artifact_digest = hashlib.sha256(f"{candidate_id}:{candidate_digest}".encode()).hexdigest()
-    manifest = SelectionManifest.create(
-        artifact="video",
-        artifact_digest=artifact_digest,
-        candidates=(candidate,),
-        now=now,
-        lifetime=timedelta(minutes=5),
-    )
-    return _VideoSnapshot(manifest, path, probe)
-
-
-def _display(collection: Path, kind: VideoReviewKind, snapshot: _VideoSnapshot, endpoint: str) -> Path:
-    destination = _collection_root(collection) / f"tmp/reviews/master-video-{kind}.html"
-    media = {snapshot.manifest.candidates[0].id: snapshot.path}
-    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media)
-    publish_html_snapshot(
-        destination,
-        html,
-        lambda persisted: validate_review_html(
-            persisted,
-            manifest=snapshot.manifest,
-            endpoint=endpoint,
-            media=media,
-        ),
-    )
-    if not open_local_file(destination.resolve()):
-        raise ReviewError(f"browserでmaster video review HTMLを開けません: {destination.resolve()}")
-    return destination.resolve()
-
-
-def _collection_root(collection: Path) -> Path:
-    if collection.is_symlink() or not collection.is_dir():
-        raise ReviewError(f"collection directoryが不正です: {collection}")
-    master = collection / "01-master"
-    if master.is_symlink() or not master.is_dir():
-        raise ReviewError(f"01-master directoryが不正です: {master}")
-    return collection.resolve()
 
 
 def _require_pending_state(collection: Path) -> None:
@@ -223,14 +177,6 @@ def _record_master_video(state_path: Path, filename: str) -> None:
         state.record_master_video(filename)
 
     update_workflow_state(state_path, transition)
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as stream:
-        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
 
 
 __all__ = ["MasterVideoReviewResult", "VideoReviewPresentation", "review_master_video"]

--- a/src/youtube_automation/application/review_lifecycle.py
+++ b/src/youtube_automation/application/review_lifecycle.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Protocol
@@ -38,6 +39,9 @@ class ReviewSource(Protocol):
 
     def commit(self, candidate: ReviewCandidate) -> None: ...
 
+    @property
+    def compact_image_ids(self) -> frozenset[str]: ...
+
 
 def review(
     source: ReviewSource,
@@ -46,8 +50,12 @@ def review(
     timeout: float,
     *,
     candidate_id: str | None = None,
+    broker_factory: Callable[[SelectionManifest], SelectionBroker] | None = None,
+    open_file: Callable[[Path], bool] | None = None,
 ) -> ReviewOutcome:
     """Select and commit a candidate only if the source remains unchanged."""
+    broker_factory = broker_factory or SelectionBroker
+    open_file = open_file or open_local_file
     snapshot = _snapshot(source)
     candidate_ids = tuple(candidate.id for candidate in snapshot.manifest.candidates)
     if not automatic and transport == "terminal" and candidate_id is None:
@@ -61,8 +69,14 @@ def review(
         if selected_id not in candidate_ids:
             raise ReviewError(f"候補IDがreview manifest allowlistにありません: {selected_id}")
     else:
-        with SelectionBroker(snapshot.manifest) as broker:
-            destination = _display(source.html_path, snapshot, broker.endpoint)
+        with broker_factory(snapshot.manifest) as broker:
+            destination = _display(
+                source.html_path,
+                snapshot,
+                broker.endpoint,
+                getattr(source, "compact_image_ids", frozenset()),
+                open_file,
+            )
             selection = broker.wait(timeout=timeout)
         selected_id = selection.candidate_id
         if selection.artifact_digest != snapshot.manifest.artifact_digest:
@@ -83,7 +97,13 @@ def review(
 def preview(source: ReviewSource) -> ReviewOutcome:
     """Render one immutable source snapshot without committing a selection."""
     snapshot = _snapshot(source)
-    destination = _display(source.html_path, snapshot, None)
+    destination = _display(
+        source.html_path,
+        snapshot,
+        None,
+        getattr(source, "compact_image_ids", frozenset()),
+        open_local_file,
+    )
     return ReviewOutcome(
         "displayed",
         snapshot.manifest.artifact_digest,
@@ -117,18 +137,47 @@ def _same_selection(original: ReviewSnapshot, current: ReviewSnapshot, candidate
     return current_candidate
 
 
-def _display(destination: Path, snapshot: ReviewSnapshot, endpoint: str | None) -> Path:
+def _display(
+    destination: Path,
+    snapshot: ReviewSnapshot,
+    endpoint: str | None,
+    compact_image_ids: frozenset[str],
+    open_file: Callable[[Path], bool],
+) -> Path:
     media = dict(snapshot.media)
-    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media)
+    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media, compact_image_ids=compact_image_ids)
     publish_html_snapshot(
         destination,
         html,
-        lambda persisted: validate_review_html(persisted, manifest=snapshot.manifest, endpoint=endpoint, media=media),
+        lambda persisted: validate_review_html(
+            persisted, manifest=snapshot.manifest, endpoint=endpoint, media=media, compact_image_ids=compact_image_ids
+        ),
     )
     resolved = destination.resolve()
-    if not open_local_file(resolved):
+    if not open_file(resolved):
         raise ReviewError(f"browserでreview HTMLを開けません: {resolved}")
     return resolved
 
 
-__all__ = ["ReviewSource", "preview", "review"]
+def collection_root(collection: Path) -> Path:
+    """Resolve a review collection without accepting a symlink."""
+    if collection.is_symlink() or not collection.is_dir():
+        raise ReviewError(f"collection directoryが不正です: {collection}")
+    return collection.resolve()
+
+
+def sha256_file(path: Path) -> str:
+    """Return the digest used by all review source adapters."""
+    import hashlib
+
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise ReviewError(f"review fileを読み込めません: {path}: {error}") from error
+    return digest.hexdigest()
+
+
+__all__ = ["ReviewSource", "collection_root", "preview", "review", "sha256_file"]

--- a/src/youtube_automation/application/thumbnail_review.py
+++ b/src/youtube_automation/application/thumbnail_review.py
@@ -16,18 +16,18 @@ from typing import Literal
 
 from PIL import Image, UnidentifiedImageError
 
+from youtube_automation.application.review_lifecycle import ReviewSource, collection_root as _collection_root, review
+from youtube_automation.application.review_lifecycle import sha256_file as _sha256
 from youtube_automation.core.errors import ConfigError, ReviewError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.documents.review import ReviewCandidate, SelectionManifest
-from youtube_automation.domains.documents.review_rendering import render_review_html, validate_review_html
 from youtube_automation.domains.thumbnail.archive import (
     ThumbnailArchiveUpdate,
     archive_approved_thumbnail_transaction,
 )
 from youtube_automation.infrastructure.browser import open_local_file
 from youtube_automation.infrastructure.browser.selection_broker import SelectionBroker
-from youtube_automation.infrastructure.documents.publishing import publish_html_snapshot
 
 ThumbnailArtifact = Literal["thumbnail", "main"]
 ThumbnailReviewSource = Literal["web", "terminal", "automatic"]
@@ -85,6 +85,40 @@ class _Snapshot:
         return {candidate.candidate_id: candidate.image for candidate in self.candidates}
 
 
+class _ThumbnailSource(ReviewSource):
+    def __init__(self, collection: Path, artifact: ThumbnailArtifact, pattern: str | None) -> None:
+        self.collection, self.kind, self.pattern = collection, artifact, pattern
+        self.snapshot: _Snapshot | None = None
+
+    @property
+    def artifact(self):
+        return "thumbnail"
+
+    @property
+    def html_path(self):
+        return self.collection.resolve() / "tmp/reviews/thumbnail-selection.html"
+
+    @property
+    def compact_image_ids(self):
+        return frozenset(c.id for c in self.snapshot.manifest.candidates) if self.snapshot else frozenset()
+
+    def candidates(self):
+        self.snapshot = build_thumbnail_review_snapshot(
+            self.collection, self.kind, pattern=self.pattern, now=datetime.now(UTC)
+        )
+        return self.snapshot.manifest.candidates
+
+    def media(self):
+        assert self.snapshot is not None
+        return tuple(self.snapshot.media().items())
+
+    def digest(self, candidates):
+        return _artifact_digest(self.snapshot.candidates) if self.snapshot else ""
+
+    def commit(self, candidate):
+        pass
+
+
 def run_thumbnail_review(
     collection: Path,
     artifact: ThumbnailArtifact,
@@ -95,35 +129,19 @@ def run_thumbnail_review(
     timeout: float = 300,
     now: datetime | None = None,
 ) -> ThumbnailReviewResult:
-    """Review fixed local candidates and return only a broker-validated ID."""
+    del now
     if automatic:
         return ThumbnailReviewResult(status="skipped")
-    instant = now or datetime.now(UTC)
-    snapshot = build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=instant)
-    candidate_ids = tuple(candidate.candidate_id for candidate in snapshot.candidates)
-    if transport == "terminal":
-        return ThumbnailReviewResult(
-            status="terminal_required",
-            artifact_digest=snapshot.manifest.artifact_digest,
-            candidates=candidate_ids,
-        )
-
-    with SelectionBroker(snapshot.manifest) as broker:
-        destination = _display(collection, snapshot, broker.endpoint)
-        selection = broker.wait(timeout=timeout)
-    current = build_thumbnail_review_snapshot(collection, artifact, pattern=pattern, now=instant)
-    if current.manifest.artifact_digest != selection.artifact_digest:
-        raise ReviewError("review表示後に画像またはQA結果が変わりました。正規成果物は更新していません")
-    selected = next((item for item in current.candidates if item.candidate_id == selection.candidate_id), None)
-    original = next((item for item in snapshot.candidates if item.candidate_id == selection.candidate_id), None)
-    if selected is None or original is None or selected.digest != original.digest:
-        raise ReviewError("review表示後に候補digestが変わりました。正規成果物は更新していません")
+    outcome = review(
+        _ThumbnailSource(collection, artifact, pattern),
+        transport,
+        False,
+        timeout,
+        broker_factory=SelectionBroker,
+        open_file=open_local_file,
+    )
     return ThumbnailReviewResult(
-        status="selected",
-        artifact_digest=current.manifest.artifact_digest,
-        candidate_id=selected.candidate_id,
-        candidates=candidate_ids,
-        html_path=destination,
+        outcome.status, outcome.artifact_digest, outcome.candidate_id, outcome.candidates, outcome.html_path
     )
 
 
@@ -340,27 +358,6 @@ def _string_list_summary(value: object, name: str, path: Path) -> str:
     return " / ".join(item.strip() for item in value)
 
 
-def _display(collection: Path, snapshot: _Snapshot, endpoint: str) -> Path:
-    destination = _collection_root(collection) / "tmp" / "reviews" / "thumbnail-selection.html"
-    media = snapshot.media()
-    compact = frozenset(media)
-    html = render_review_html(snapshot.manifest, endpoint=endpoint, media=media, compact_image_ids=compact)
-    publish_html_snapshot(
-        destination,
-        html,
-        lambda persisted: validate_review_html(
-            persisted,
-            manifest=snapshot.manifest,
-            endpoint=endpoint,
-            media=media,
-            compact_image_ids=compact,
-        ),
-    )
-    if not open_local_file(destination.resolve()):
-        raise ReviewError(f"browserでthumbnail review HTMLを開けません: {destination.resolve()}")
-    return destination.resolve()
-
-
 def _target_path(collection: Path, candidate: ThumbnailReviewCandidate) -> Path:
     assets = collection / "10-assets"
     if candidate.artifact == "thumbnail":
@@ -405,26 +402,9 @@ def _restore_target(target: Path, original: bytes | None) -> None:
         temporary.unlink(missing_ok=True)
 
 
-def _collection_root(collection: Path) -> Path:
-    if collection.is_symlink() or not collection.is_dir():
-        raise ReviewError(f"collection directoryが不正です: {collection}")
-    return collection.resolve()
-
-
 def _artifact_digest(candidates: tuple[ThumbnailReviewCandidate, ...]) -> str:
     value = "\n".join(f"{candidate.candidate_id}:{candidate.digest}" for candidate in candidates)
     return hashlib.sha256(value.encode()).hexdigest()
-
-
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as stream:
-            for chunk in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(chunk)
-    except OSError as exc:
-        raise ReviewError(f"review fileを読み込めません: {path}: {exc}") from exc
-    return digest.hexdigest()
 
 
 __all__ = [

--- a/src/youtube_automation/application/thumbnail_review.py
+++ b/src/youtube_automation/application/thumbnail_review.py
@@ -16,7 +16,8 @@ from typing import Literal
 
 from PIL import Image, UnidentifiedImageError
 
-from youtube_automation.application.review_lifecycle import ReviewSource, collection_root as _collection_root, review
+from youtube_automation.application.review_lifecycle import ReviewSource, review
+from youtube_automation.application.review_lifecycle import collection_root as _collection_root
 from youtube_automation.application.review_lifecycle import sha256_file as _sha256
 from youtube_automation.core.errors import ConfigError, ReviewError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState

--- a/tests/application/test_master_video_review.py
+++ b/tests/application/test_master_video_review.py
@@ -64,6 +64,26 @@ def _presentation() -> master_video_review.VideoReviewPresentation:
     )
 
 
+def test_video_source_streams_file_digest_through_shared_helper(tmp_path: Path, monkeypatch) -> None:
+    collection = _collection(tmp_path)
+    video = collection / "01-master" / "Rain-Preview.mp4"
+    video.write_bytes(b"preview")
+    monkeypatch.setattr(master_video_review, "probe_video", _probe)
+    digested: list[Path] = []
+
+    def digest(path: Path) -> str:
+        digested.append(path)
+        return "a" * 64
+
+    monkeypatch.setattr(master_video_review, "sha256_file", digest)
+    monkeypatch.setattr(Path, "read_bytes", lambda _path: pytest.fail("video must not be read into memory"))
+
+    source = master_video_review._VideoSource(collection, "preview", _presentation())
+    source.candidates()
+
+    assert digested == [video.resolve()]
+
+
 def test_preview_review_plays_probe_and_composition_without_updating_state(tmp_path: Path, monkeypatch) -> None:
     collection = _collection(tmp_path)
     (collection / "01-master" / "Rain-Preview.mp4").write_bytes(b"preview")

--- a/tests/application/test_thumbnail_review.py
+++ b/tests/application/test_thumbnail_review.py
@@ -175,7 +175,7 @@ def test_changed_qa_after_display_rejects_selection_before_canonical_or_state_up
     monkeypatch.setattr(thumbnail_review, "SelectionBroker", MutatingBroker)
     monkeypatch.setattr(thumbnail_review, "open_local_file", lambda _path: True)
 
-    with pytest.raises(ReviewError, match="画像またはQA結果が変わりました"):
+    with pytest.raises(ReviewError, match="review中にartifactまたは候補実体が変わりました"):
         thumbnail_review.run_thumbnail_review(collection, "thumbnail", now=NOW)
     assert target.read_bytes() == b"existing"
     assert not (collection / "workflow-state.json").exists()

--- a/tests/commands/media/test_master_audio_review.py
+++ b/tests/commands/media/test_master_audio_review.py
@@ -35,3 +35,27 @@ def test_cli_passes_explicit_review_contract_to_application(tmp_path, monkeypatc
         "candidate_id": "worktree:final.wav",
         "main_repo_root": None,
     }
+
+
+def test_terminal_required_returns_exit_code_two(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(
+        master_audio_review,
+        "review_and_finalize_master_audio",
+        Mock(return_value=MasterAudioReviewResult(status="terminal_required", candidates=("worktree:final.wav",))),
+    )
+
+    assert (
+        master_audio_review.main(
+            [
+                "--collection",
+                str(tmp_path),
+                "--skip-manual-mastering",
+                "false",
+                "--skip-audio-approval",
+                "false",
+                "--transport",
+                "terminal",
+            ]
+        )
+        == 2
+    )

--- a/tests/commands/media/test_master_video_review.py
+++ b/tests/commands/media/test_master_video_review.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from argparse import Namespace
 from pathlib import Path
 
+import pytest
+
 from youtube_automation.application.master_video_review import MasterVideoReviewResult
 from youtube_automation.commands.media import master_video_review
 
@@ -32,3 +34,36 @@ def test_cli_passes_explicit_review_presentation_and_mode(monkeypatch, tmp_path:
     assert captured["candidate_id"] == "full:Rain-Master.mp4"
     assert captured["presentation"].background_route == "loop"
     assert '"candidate_id": "full:Rain-Master.mp4"' in capsys.readouterr().out
+
+
+@pytest.mark.parametrize("kind", ["preview", "full"])
+def test_terminal_required_returns_exit_code_two(monkeypatch, tmp_path: Path, kind: str) -> None:
+    monkeypatch.setattr(
+        master_video_review,
+        "review_master_video",
+        lambda *_args, **_kwargs: MasterVideoReviewResult(
+            "terminal_required", "a" * 64, candidates=(f"{kind}:Rain.mp4",)
+        ),
+    )
+
+    assert (
+        master_video_review.main(
+            [
+                "--collection",
+                str(tmp_path),
+                "--kind",
+                kind,
+                "--background-route",
+                "loop",
+                "--effect",
+                "none",
+                "--overlays",
+                "disabled",
+                "--full-output-outlook",
+                "stream copy",
+                "--transport",
+                "terminal",
+            ]
+        )
+        == 2
+    )

--- a/tests/commands/thumbnail/test_thumbnail_review.py
+++ b/tests/commands/thumbnail/test_thumbnail_review.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from youtube_automation.application.thumbnail_review import ThumbnailReviewResult
 from youtube_automation.commands.thumbnail import thumbnail_review
 
@@ -23,7 +25,10 @@ def test_automatic_skips_html_broker_and_existing_auto_owner_remains_canonical(
     assert "yt-thumbnail-auto-select" in capsys.readouterr().out
 
 
-def test_terminal_fallback_lists_allowlisted_ids_without_finalizing(tmp_path: Path, monkeypatch, capsys) -> None:
+@pytest.mark.parametrize("artifact", ["thumbnail", "main"])
+def test_terminal_fallback_lists_allowlisted_ids_without_finalizing(
+    tmp_path: Path, monkeypatch, capsys, artifact: str
+) -> None:
     monkeypatch.setattr(
         thumbnail_review,
         "run_thumbnail_review",
@@ -37,7 +42,7 @@ def test_terminal_fallback_lists_allowlisted_ids_without_finalizing(tmp_path: Pa
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("must not finalize")),
     )
 
-    result = thumbnail_review.main(["--collection", str(tmp_path), "--artifact", "main", "--transport", "terminal"])
+    result = thumbnail_review.main(["--collection", str(tmp_path), "--artifact", artifact, "--transport", "terminal"])
 
     assert result == 2
     assert '"candidate_id"' not in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- thumbnail / audio / video を source adapter 化
- 表示・再 snapshot 検証・digest と collection 解決を lifecycle に集約
- media review の TOCTOU ガード重複を削除

Closes #4432