### PR TITLE
issue 4510 pr auto review

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -54,6 +54,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # 既定の OIDC → Claude App トークン交換(id-token: write が必要で、App トークンは
+          # push 権限を持ちうる)を使わず、この workflow の read 権限に閉じたトークンで動かす
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
           plugins: mattpocock-skills@claude-plugins-official
           prompt: |

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,104 @@
+name: Code review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+# contents: read のままにする(レビューは提案のみで、PR ブランチへの push を機構的に禁止する)
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auth-check:
+    if: ${{ !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-review') }}
+    runs-on: ubuntu-latest
+    outputs:
+      available: ${{ steps.auth.outputs.available }}
+    steps:
+      - name: Check Claude authentication
+        id: auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -n "$CLAUDE_CODE_OAUTH_TOKEN" || -n "$ANTHROPIC_API_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::Code review skipped: neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is configured."
+          {
+            echo "## Code review"
+            echo
+            echo "⏭️ Skipped: neither \`CLAUDE_CODE_OAUTH_TOKEN\` nor \`ANTHROPIC_API_KEY\` is configured."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  review:
+    needs: auth-check
+    if: needs.auth-check.outputs.available == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Run Claude code review
+        id: review
+        uses: anthropics/claude-code-action@4a3947e8ca609a286ab07d4d048d9ec4016798c1 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          plugin_marketplaces: https://github.com/anthropics/claude-plugins-official.git
+          plugins: mattpocock-skills@claude-plugins-official
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            あなたはこの PR のマージ前レビューゲートです。コードの修正は一切行わず、
+            レビューコメントの投稿と structured output の報告だけを行ってください。
+
+            ## 手順
+            1. `gh pr view` / `gh pr diff` で PR の内容と base branch との差分を取得する
+            2. PR タイトルまたは commit subject 末尾の `(#N)` から起点 issue 番号を特定し、
+               `gh issue view N` で要件を読む。特定できなければ Spec 軸は「起点 issue 不明」と
+               コメントに明記して省略する
+            3. /mattpocock-skills:code-review スキルで差分を 2 軸レビューする:
+               Standards(このリポジトリの規約への準拠)/ Spec(起点 issue の要件との整合)
+            4. 同じ差分を simplify 観点(reuse / simplification / efficiency)でもレビューする。
+               改善提案はコメント内のコード例に留める
+            5. 指摘ごとに severity を付ける:
+               - critical: Spec 違反(起点 issue の要件を満たさない・壊す)、明白なバグ相当
+               - warning: Standards 違反(リポジトリ規約からの逸脱)
+               - warning / info: simplify 系の提案(critical にはしない)
+            6. 全指摘を 1 つのコメントに集約し、severity ごとの件数サマリを冒頭に置いて
+               `gh pr comment <N> --edit-last --create-if-none --body-file <file>` で投稿する
+            7. structured output の critical_count / warning_count / info_count に、
+               コメントへ書いた件数と一致する値を報告する
+
+            ## 禁止事項
+            - ファイルの編集・commit・push(このワークフローには push 権限が無い)
+            - 複数コメントの投稿(1 コメントに集約し、再実行時は既存コメントを更新する)
+          # takt が PR を大量生成するため、コスト対策として sonnet 系を既定にする
+          claude_args: |
+            --model sonnet
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
+            --json-schema '{"type":"object","properties":{"critical_count":{"type":"integer","minimum":0},"warning_count":{"type":"integer","minimum":0},"info_count":{"type":"integer","minimum":0}},"required":["critical_count","warning_count","info_count"]}'
+      - name: Fail on critical findings
+        env:
+          STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+        run: |
+          set -eu
+          critical=$(jq -r '.critical_count' <<<"$STRUCTURED_OUTPUT")
+          warning=$(jq -r '.warning_count' <<<"$STRUCTURED_OUTPUT")
+          info=$(jq -r '.info_count' <<<"$STRUCTURED_OUTPUT")
+          echo "critical=${critical} warning=${warning} info=${info}"
+          if [ "$critical" -gt 0 ]; then
+            echo "::error::Code review found ${critical} critical finding(s). See the review comment on the PR."
+            exit 1
+          fi

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -160,6 +160,16 @@ gh stack merge <stack番号|PR番号> --yes --squash
 - `gh stack sync` はローカルとリモートの stack が diverge していると、非対話環境では何も変更せず `ℹ Sync aborted` を出して **exit 0 で終わる**。成功と読み違えない。解消は `gh stack unstack` してから作り直す
 - `gh stack rebase` の conflict は exit 3。`git add` で解決を stage して `gh stack rebase --continue`、戻せなくなったら `--abort` で全 branch が rebase 前へ復元される
 
+## PR 自動コードレビュー(マージ前ゲート)
+
+draft でない PR の opened / ready_for_review / synchronize で `.github/workflows/code-review.yml` が発火し、claude-code-action が mattpocock code-review(Standards / Spec の 2 軸)+ simplify 観点(reuse / simplification / efficiency)で差分をレビューして severity 付きの集約コメントを投稿する。生成経路(takt / `/issue-direct` / 手動)によらず全 PR に同じゲートが効く。
+
+- **critical 指摘が 1 件以上あると `Code review` check が fail する**。warning / info のみなら success。`gh stack merge` の CI green 待ちにはこの check も含まれる
+- simplify 系の提案はコメントに載るだけで、CI が PR ブランチへ修正を push することはない(workflow は `contents: read`)
+- オプトアウトは PR に `skip-review` ラベルを付与する(誤検知が続く PR・機械生成の大量 PR 向け)。draft PR は最初から対象外
+- `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` がどちらも未設定の環境では fail せず skip される(evals.yml と同じ慣行)
+- 同一 PR への連続 push は進行中の run が cancel され、最新 commit のレビューだけが残る
+
 ## 環境
 
 親 checkout と新規 worktree の両方で devShell に入る。direnv があれば `direnv allow` で `.envrc` を allow し、なければ `nix develop` を使う。どちらも shellHook が `uv sync` を自動実行する。非対話 shell は `nix develop --command <command>` を使う。

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -1,0 +1,102 @@
+"""PR 自動コードレビューをマージ前ゲートとして安全に実行する契約。"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/code-review.yml"
+
+_PINNED_ACTION = re.compile(r"^anthropics/claude-code-action@[0-9a-f]{40}$")
+
+
+def _workflow() -> dict[str, object]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _review_step(review_job: dict[str, object]) -> dict[str, object]:
+    return next(step for step in review_job["steps"] if step.get("id") == "review")
+
+
+def test_review_fires_on_non_draft_pr_updates() -> None:
+    triggers = _triggers(_workflow())
+
+    assert set(triggers) == {"pull_request"}
+    assert triggers["pull_request"] == {"types": ["opened", "ready_for_review", "synchronize"]}
+
+
+def test_successive_pushes_cancel_the_in_progress_run() -> None:
+    concurrency = _workflow()["concurrency"]
+
+    assert "github.event.pull_request.number" in concurrency["group"]
+    assert concurrency["cancel-in-progress"] is True
+
+
+def test_draft_and_skip_review_label_opt_out_of_the_review() -> None:
+    gate = _workflow()["jobs"]["auth-check"]["if"]
+
+    assert gate == (
+        "${{ !github.event.pull_request.draft && !contains(github.event.pull_request.labels.*.name, 'skip-review') }}"
+    )
+
+
+def test_missing_auth_explicitly_skips_the_paid_review() -> None:
+    workflow = _workflow()
+    jobs = workflow["jobs"]
+    auth = jobs["auth-check"]
+    review = jobs["review"]
+    auth_step = auth["steps"][0]
+
+    assert auth["outputs"] == {"available": "${{ steps.auth.outputs.available }}"}
+    assert auth_step["env"] == {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+        "ANTHROPIC_API_KEY": "${{ secrets.ANTHROPIC_API_KEY }}",
+    }
+    auth_script = auth_step["run"]
+    assert "available=false" in auth_script
+    assert "::notice::" in auth_script
+    assert review["needs"] == "auth-check"
+    assert review["if"] == "needs.auth-check.outputs.available == 'true'"
+
+
+def test_review_installs_the_pinned_action_and_review_plugin() -> None:
+    step = _review_step(_workflow()["jobs"]["review"])
+
+    assert _PINNED_ACTION.match(step["uses"])
+    assert "mattpocock-skills@claude-plugins-official" in step["with"]["plugins"]
+
+
+def test_critical_findings_fail_the_check_via_structured_output() -> None:
+    review = _workflow()["jobs"]["review"]
+    claude_args = _review_step(review)["with"]["claude_args"]
+
+    assert "--json-schema" in claude_args
+    assert "critical_count" in claude_args
+
+    verdict = review["steps"][-1]
+    assert verdict["env"] == {"STRUCTURED_OUTPUT": "${{ steps.review.outputs.structured_output }}"}
+    assert "critical" in verdict["run"]
+    assert "exit 1" in verdict["run"]
+
+
+def test_review_cannot_push_to_the_pr_branch() -> None:
+    workflow = _workflow()
+
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "pull-requests": "write",
+        "issues": "read",
+    }
+    for job in workflow["jobs"].values():
+        assert "permissions" not in job

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -100,3 +100,8 @@ def test_review_cannot_push_to_the_pr_branch() -> None:
     }
     for job in workflow["jobs"].values():
         assert "permissions" not in job
+
+    # OIDC 経由の Claude App トークン(contents: write を持ちうる)ではなく、
+    # workflow スコープの GITHUB_TOKEN で動かすことを固定する
+    step = _review_step(workflow["jobs"]["review"])
+    assert step["with"]["github_token"] == "${{ secrets.GITHUB_TOKEN }}"

--- a/tests/repo/test_github_actions_pinning.py
+++ b/tests/repo/test_github_actions_pinning.py
@@ -20,6 +20,7 @@ _EXPECTED_ACTIONS = {
     "actions/cache": ("55cc8345863c7cc4c66a329aec7e433d2d1c52a9", "v6.1.0"),
     "actions/checkout": ("3d3c42e5aac5ba805825da76410c181273ba90b1", "v7.0.1"),
     "actions/setup-python": ("5fda3b95a4ea91299a34e894583c3862153e4b97", "v7.0.0"),
+    "anthropics/claude-code-action": ("4a3947e8ca609a286ab07d4d048d9ec4016798c1", "v1"),
     "astral-sh/setup-uv": ("c771a70e6277c0a99b617c7a806ffedaca235ff9", "v9.0.0"),
     "cachix/install-nix-action": ("630ae543ea3a38a9a4166f03376c02c50f408342", "v31.11.0"),
     "DeterminateSystems/nix-installer-action": ("ef8a148080ab6020fd15196c2084a2eea5ff2d25", "v22"),


### PR DESCRIPTION
## Summary

PR の opened / ready_for_review / synchronize で claude-code-action(SHA ピン留め、v1)を実行し、mattpocock code-review(Standards / Spec の 2 軸)+ simplify 観点(reuse / simplification / efficiency)のレビューを severity 付き集約コメントとして投稿する `.github/workflows/code-review.yml` を追加する。

- critical 指摘が 1 件以上あるときだけ check を fail させる(`--json-schema` の structured output を後続 step で判定)
- draft PR と `skip-review` ラベル付き PR は対象外。auth secrets が両方未設定なら fail ではなく skip(evals.yml の慣行)
- 同一 PR への連続 push は `concurrency` + `cancel-in-progress` で進行中 run を cancel
- workflow は `contents: read` のみで、simplify 提案が PR ブランチへ push される経路を機構的に塞ぐ
- コスト対策としてモデルは sonnet 系を既定にする
- 運用(check とラベル)を docs/takt-operations.md に 1 節追記、workflow 契約は `tests/repo/test_code_review_workflow.py` で機械担保、action pin は棚卸しカタログへ登録
- `skip-review` ラベルはリポジトリに新設済み

## 検証

- `uv run pytest tests/repo/test_code_review_workflow.py tests/repo/test_github_actions_pinning.py tests/repo/test_evals_workflow.py`(20 passed)
- `actionlint .github/workflows/code-review.yml`(pass)
- フルスイート 10002 passed / ruff check・format pass

Closes #4510