### PR TITLE
refactor(collections): commands と localserver の列挙を移行する (#4428)

### DIFF
--- a/changelog.d/4428-migrate-commands-localserver.changed.md
+++ b/changelog.d/4428-migrate-commands-localserver.changed.md
@@ -1,0 +1,1 @@
+- commands / uploads / localserver の collection 列挙を共通 inventory へ移行し、読取不能 state の warn&skip・除外記録・lenient 処理を caller ごとの明示選択として維持する（#4428）。

--- a/src/youtube_automation/commands/analytics/dashboard.py
+++ b/src/youtube_automation/commands/analytics/dashboard.py
@@ -19,7 +19,8 @@ from urllib.parse import unquote, urlsplit
 
 from youtube_automation.commands.analytics.analytics_system import AnalyticsSystem
 from youtube_automation.configuration.loader import load_config_from_path
-from youtube_automation.core.errors import ConfigError, DashboardChannelNotFoundError
+from youtube_automation.core.errors import ConfigError, DashboardChannelNotFoundError, WorkflowStateError
+from youtube_automation.domains.collections.inventory import iter_collections
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,
     load_channel_registry,
@@ -38,19 +39,16 @@ ALLOWED_REFRESH_DAYS = frozenset({7, 30, 90})
 
 def _build_channel_workflow_timing(channel: Path) -> dict[str, object] | None:
     try:
-        collection_states = (
-            state_path
-            for stage in ("planning", "live")
-            for state_path in (channel / "collections" / stage).glob("*/workflow-state.json")
-        )
-        if next(collection_states, None) is None:
+        records = iter_collections(channel)
+        # 初期化中断などで state 未作成のディレクトリしかない場合は、従来どおり collection なしと扱う。
+        if not any((record.directory / "workflow-state.json").is_file() for record in records):
             timing = build_workflow_timing(channel, None)
             if timing.get("status") == "in_progress":
                 return timing
             return {"status": "unavailable", "reason": "collection_missing", "collections": []}
         config = load_config_from_path(channel)
         return build_workflow_timing(channel, config.workflow.manual_baseline_minutes)
-    except (ConfigError, OSError, ValueError) as exc:
+    except (ConfigError, OSError, ValueError, WorkflowStateError) as exc:
         return {
             "status": "error",
             "collections": [],

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -978,7 +978,11 @@ def create_server(
             if ".." in cid:
                 self.send_error(404, "Not Found")
                 return
-            known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
+            try:
+                known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
+            except WorkflowStateError as exc:
+                self._send_json_error(500, str(exc))
+                return
             if cid not in known_ids:
                 self.send_error(404, "Not Found")
                 return
@@ -1189,7 +1193,11 @@ def create_server(
                     self.send_error(400, "Bad Request")
                     return
                 if collections_root is not None:
-                    known_collections = {coll.name: coll for coll in find_collection_dirs(collections_root)}
+                    try:
+                        known_collections = {coll.name: coll for coll in find_collection_dirs(collections_root)}
+                    except WorkflowStateError as exc:
+                        self._send_json_error(500, str(exc))
+                        return
                     coll_dir = known_collections.get(coll_id)
                     if coll_dir is None:
                         self.send_error(400, "Bad Request")
@@ -1245,7 +1253,10 @@ def create_server(
                 self._send_bytes(body, "application/json; charset=utf-8")
                 return
             if dir_mode:
-                self._serve_dir_mode()
+                try:
+                    self._serve_dir_mode()
+                except WorkflowStateError as exc:
+                    self._send_json_error(500, str(exc))
                 return
             if self.path == COMMUNITY_POSTS_ROUTE:
                 assert collection_dir is not None
@@ -1590,7 +1601,10 @@ def main() -> None:
     r2_handoff_requested = _r2_handoff_requested()
 
     # path が `*-collection/` を並べたディレクトリなら dir mode（#816）。
-    collection_dirs = find_collection_dirs(args.path)
+    try:
+        collection_dirs = find_collection_dirs(args.path)
+    except WorkflowStateError as exc:
+        parser.error(str(exc))
     lifecycle_root = _lifecycle_root(args.path)
     lifecycle_configuration = _configuration_fingerprint(
         path=args.path,

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -10,6 +10,7 @@ from datetime import date, datetime
 from pathlib import Path
 
 from youtube_automation.core.errors import AutomationError
+from youtube_automation.domains.collections.inventory import iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
@@ -45,12 +46,10 @@ def _find_channel_root(cwd: Path) -> Path | None:
 
 
 def _collection_paths(root: Path) -> list[Path]:
-    paths: list[Path] = []
-    for location in ("planning", "live"):
-        base = root / "collections" / location
-        if base.is_dir():
-            paths.extend(path.parent for path in base.glob("*/workflow-state.json") if path.is_file())
-    return paths
+    # state が実在する collection だけを従来どおり選択候補に残す。
+    return [
+        record.directory for record in iter_collections(root) if (record.directory / "workflow-state.json").is_file()
+    ]
 
 
 def _select_collection(paths: list[Path], command: str | None) -> Path | None:

--- a/src/youtube_automation/commands/uploads/wf_batch.py
+++ b/src/youtube_automation/commands/uploads/wf_batch.py
@@ -57,6 +57,7 @@ from youtube_automation.core.errors import (
     WorkflowStateError,
     WorkflowStateSectionTypeError,
 )
+from youtube_automation.domains.collections.inventory import UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import (
     WorkflowState,
 )
@@ -156,18 +157,18 @@ def discover_targets(planning_root: Path) -> tuple[list[WfBatchTarget], list[Exc
     """
     targets: list[WfBatchTarget] = []
     excluded: list[ExcludedCollection] = []
-    if not planning_root.is_dir():
+    if planning_root.name != "planning" or planning_root.parent.name != "collections":
         return targets, excluded
 
-    for coll in sorted(p for p in planning_root.iterdir() if p.is_dir()):
-        state_path = coll / "workflow-state.json"
-        if not state_path.is_file():
+    for record in iter_collections(planning_root.parent.parent, ("planning",)):
+        coll = record.directory
+        if isinstance(record.state, UnreadableWorkflowState):
+            state_path = coll / "workflow-state.json"
+            if not state_path.exists() and not state_path.is_symlink():
+                continue
+            excluded.append(ExcludedCollection(coll.name, f"workflow-state.json を読めません: {record.state.reason}"))
             continue
-        try:
-            state = _load_state(state_path)
-        except ValidationError as e:
-            excluded.append(ExcludedCollection(coll.name, f"workflow-state.json を読めません: {e}"))
-            continue
+        state = record.state.to_dict()
 
         assets = state.get("assets")
         if not isinstance(assets, dict):
@@ -454,7 +455,7 @@ def main(argv: list[str] | None = None) -> int:
             from_slug=args.from_slug,
             limit=args.limit,
         )
-    except (ValidationError, ConfigError) as e:
+    except (ValidationError, ConfigError, WorkflowStateError) as e:
         print(f"ERROR: {e}", file=sys.stderr)
         return 1
 

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import schedule
 
 from youtube_automation.configuration import channel_dir, load_config
-from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.youtube import (
     DAILY_BUCKET_LIMITS,
     UNIT_COSTS,
@@ -17,7 +16,8 @@ from youtube_automation.core.adapters.youtube import (
     complete_collection_quota_plan,
 )
 from youtube_automation.core.errors import ValidationError, WorkflowStateError
-from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
+from youtube_automation.domains.collections.inventory import UnreadableWorkflowState, iter_collections
+from youtube_automation.domains.collections.workflow_state import Stage
 from youtube_automation.domains.uploads._collection_uploader_constants import (
     ACTION_COMPLETE_COLLECTION_QUOTA_EXHAUSTED,
     ACTION_COMPLETE_COLLECTION_UPLOADED,
@@ -31,7 +31,6 @@ from youtube_automation.domains.uploads.preflight import ensure_collection_prefl
 from youtube_automation.domains.uploads.upload_journal import UploadJournal, UploadJournalOutcome
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 from youtube_automation.infrastructure.filesystem import (
-    list_directory,
     make_directory,
     path_exists,
     path_is_directory,
@@ -161,17 +160,10 @@ class CollectionUploader:
 
     # ─── コレクション検索 ───────────────────────────
 
-    def find_collections(self, stages: tuple[str, ...] = ("planning", "live")) -> list[Path]:
+    def find_collections(self, stages: tuple[Stage, ...] = ("planning", "live")) -> list[Path]:
         """コレクションを検索（指定ステージを探索）"""
-        collections = []
-        for stage in stages:
-            stage_dir = self.collections_root / stage
-            if path_exists(stage_dir):
-                collections.extend(
-                    d for d in list_directory(stage_dir) if path_is_directory(d) and not d.name.startswith(".")
-                )
-        collections.sort(key=lambda x: x.name)
-        return collections
+        # unreadable も明示名検索では従来どおり候補に残す。
+        return [record.directory for record in iter_collections(self.collections_root.parent, stages)]
 
     def find_collection(self, collection_name: str | None = None) -> Path | None:
         """名前指定なら全ステージ、未指定なら未公開の planning コレクションを検索する。"""
@@ -184,13 +176,16 @@ class CollectionUploader:
             return None
 
         candidates = []
-        for collection in self.find_collections(("planning",)):
-            state_path = CollectionPaths(collection).workflow_state_path
-            try:
-                state = read_workflow_state(state_path)
-            except WorkflowStateError as exc:
-                logger.warning(f"⚠️  workflow-state.json を読み取れないため候補から除外します: {state_path}: {exc}")
+        for record in iter_collections(self.collections_root.parent, ("planning",)):
+            collection = record.directory
+            if isinstance(record.state, UnreadableWorkflowState):
+                logger.warning(
+                    "⚠️  workflow-state.json を読み取れないため候補から除外します: %s: %s",
+                    record.state.path,
+                    record.state.reason,
+                )
                 continue
+            state = record.state
 
             upload = state.upload
             if state.phase == "mastered" and upload is not None and "video_id" in upload and upload.video_id is None:
@@ -388,7 +383,7 @@ class CollectionUploader:
 
         try:
             target_collection = self.find_collection()
-        except ValidationError as exc:
+        except (ValidationError, WorkflowStateError) as exc:
             logger.error(f"❌ 日次アップロードを実行しません: {exc}")
             return
 

--- a/src/youtube_automation/infrastructure/localserver/collections.py
+++ b/src/youtube_automation/infrastructure/localserver/collections.py
@@ -5,38 +5,58 @@ from __future__ import annotations
 from pathlib import Path
 
 from youtube_automation.core.errors import WorkflowStateError
-from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
+from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
+from youtube_automation.infrastructure.filesystem import list_directory, path_is_directory
 
 COLLECTION_DIR_SUFFIX = "-collection"
 
 
 def find_collection_dirs(root: Path) -> list[Path]:
     """Return direct ``*-collection`` children in deterministic name order."""
-    if not root.is_dir():
-        return []
-    directories = (path for path in root.iterdir() if path.is_dir() and path.name.endswith(COLLECTION_DIR_SUFFIX))
-    return sorted(directories, key=lambda path: path.name)
+    records = _records_for_stage_root(root)
+    if records is None:
+        # collection server は単独の任意 directory も公開 API として受け付ける。
+        # channel stage でない legacy root だけは inventory の対象外なので、既存の
+        # lenient な探索を filesystem adapter 経由で維持する。
+        if not path_is_directory(root):
+            return []
+        return sorted(
+            (
+                path
+                for path in list_directory(root)
+                if path_is_directory(path) and path.name.endswith(COLLECTION_DIR_SUFFIX)
+            ),
+            key=lambda path: path.name,
+        )
+    return [record.directory for record in records if record.directory.name.endswith(COLLECTION_DIR_SUFFIX)]
 
 
 def find_suno_collection_dirs(root: Path) -> list[Path]:
     """Return planning collections that do not have a completed live sibling."""
-    return [
-        collection
-        for collection in find_collection_dirs(root)
-        if not _is_live_complete_collection(root, collection.name)
-    ]
+    completed = _completed_live_collection_ids(root)
+    return [collection for collection in find_collection_dirs(root) if collection.name not in completed]
 
 
-def _is_live_complete_collection(root: Path, collection_id: str) -> bool:
+def _completed_live_collection_ids(root: Path) -> frozenset[str]:
     if root.name != "planning" or root.parent.name != "collections":
-        return False
-    state = _read_workflow_state_lenient(root.parent / "live" / collection_id / "workflow-state.json")
-    return state.get("phase") == "complete"
-
-
-def _read_workflow_state_lenient(path: Path) -> dict[str, object]:
+        return frozenset()
     try:
-        state = read_workflow_state_or_none(path)
+        records = iter_collections(root.parent.parent, ("live",))
     except WorkflowStateError:
-        return {}
-    return state.to_dict() if state is not None else {}
+        return frozenset()
+    completed: set[str] = set()
+    for record in records:
+        if isinstance(record.state, UnreadableWorkflowState):
+            continue
+        try:
+            if record.state.phase == "complete":
+                completed.add(record.directory.name)
+        except WorkflowStateError:
+            continue
+    return frozenset(completed)
+
+
+def _records_for_stage_root(root: Path) -> tuple[CollectionRecord, ...] | None:
+    if root.name not in {"planning", "live"} or root.parent.name != "collections":
+        return None
+    return iter_collections(root.parent.parent, (root.name,))

--- a/tests/commands/analytics/test_dashboard_server.py
+++ b/tests/commands/analytics/test_dashboard_server.py
@@ -9,7 +9,7 @@ from urllib.request import Request, urlopen
 
 import pytest
 
-from youtube_automation.commands.analytics.dashboard import create_server, main
+from youtube_automation.commands.analytics.dashboard import _build_channel_workflow_timing, create_server, main
 from youtube_automation.infrastructure.analytics.dashboard_publications import (
     build_dashboard_publications,
     save_dashboard_publications,
@@ -503,6 +503,29 @@ def test_server_isolates_corrupt_history_from_healthy_channel(tmp_path: Path) ->
         server.shutdown()
         thread.join(timeout=5)
         server.server_close()
+
+
+def test_workflow_timing_contains_inventory_hazard_as_channel_error(tmp_path: Path) -> None:
+    channel = _write_channel(tmp_path)
+    target = tmp_path / "outside"
+    target.mkdir()
+    (channel / "collections" / "planning" / "hazard").symlink_to(target, target_is_directory=True)
+
+    timing = _build_channel_workflow_timing(channel)
+
+    assert timing is not None
+    assert timing["status"] == "error"
+    assert timing["error"]["code"] == "workflow_timing_failed"
+
+
+def test_workflow_timing_treats_directories_without_state_as_missing_collections(tmp_path: Path) -> None:
+    channel = _write_channel(tmp_path)
+    for state_path in channel.glob("collections/*/*/workflow-state.json"):
+        state_path.unlink()
+
+    timing = _build_channel_workflow_timing(channel)
+
+    assert timing == {"status": "unavailable", "reason": "collection_missing", "collections": []}
 
 
 def test_server_exposes_workflow_timing_failure_reason(tmp_path: Path) -> None:

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -68,6 +68,7 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
     ChromeExtensionOrigin,
     resolve_unpacked_extension_origin,
 )
+from youtube_automation.infrastructure.localserver.collections import find_suno_collection_dirs
 
 extract_and_rename_music = partial(
     _extract_and_rename_music,
@@ -1045,6 +1046,21 @@ def test_embedded_discovery_registry_preserves_delete_behavior_on_collection_rou
 # ---------------------------------------------------------------------------
 
 
+def test_main_reports_inventory_hazard_as_cli_error(monkeypatch, capsys, tmp_path):
+    planning = tmp_path / "collections" / "planning"
+    planning.mkdir(parents=True)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (planning / "hazard").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setattr(sys, "argv", ["yt-collection-serve", str(planning)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 2
+    assert "symlink" in capsys.readouterr().err
+
+
 def test_help_flag_shows_usage_and_exits_zero(monkeypatch, capsys):
     """--help は argparse の usage を表示して exit 0 する."""
     monkeypatch.setattr(sys, "argv", ["yt-collection-serve", "--help"])
@@ -1739,17 +1755,30 @@ def test_find_collection_dirs_returns_only_collection_dirs_sorted(tmp_path):
     When find_collection_dirs を呼ぶ
     Then `*-collection` ディレクトリのみを名前昇順で返す。
     """
-    _make_collection(tmp_path, "20260602-clm-bbb-collection", entries=[])
-    _make_collection(tmp_path, "20260601-clm-aaa-collection", entries=[])
-    (tmp_path / "01-master").mkdir()  # collection 接尾辞でない dir は除外
-    (tmp_path / "notes.txt").write_text("x", encoding="utf-8")  # ファイルは除外
+    planning = tmp_path / "collections" / "planning"
+    _make_collection(planning, "20260602-clm-bbb-collection", entries=[])
+    _make_collection(planning, "20260601-clm-aaa-collection", entries=[])
+    (planning / "01-master").mkdir()  # collection 接尾辞でない dir は除外
+    (planning / "notes.txt").write_text("x", encoding="utf-8")  # ファイルは除外
 
-    found = find_collection_dirs(tmp_path)
+    found = find_collection_dirs(planning)
 
     assert [p.name for p in found] == [
         "20260601-clm-aaa-collection",
         "20260602-clm-bbb-collection",
     ]
+
+
+def test_find_suno_collection_dirs_keeps_planning_results_when_live_inventory_is_hazardous(tmp_path):
+    planning = tmp_path / "collections" / "planning"
+    collection = _make_collection(planning, "20260601-clm-demo-collection", entries=[])
+    live = tmp_path / "collections" / "live"
+    live.mkdir(parents=True)
+    target = tmp_path / "outside"
+    target.mkdir()
+    (live / "hazard").symlink_to(target, target_is_directory=True)
+
+    assert find_suno_collection_dirs(planning) == [collection.resolve()]
 
 
 def test_build_collections_index_reports_status_and_pattern_count(tmp_path):

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -134,6 +134,20 @@ def test_should_mark_real_asset_stages_from_workflow_state(
     assert "  ○  アップロード" in message
 
 
+def test_should_ignore_collection_directory_without_workflow_state(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    state = json.loads((_FIXTURES / "workflow-state-mastered.json").read_text(encoding="utf-8"))
+    _write_collection(tmp_path, "planning", "mastered-collection", state)
+    (tmp_path / "collections" / "planning" / "initialization-interrupted").mkdir()
+
+    message = _progress_message(tmp_path, capsys)
+
+    assert "  ✓  サムネイル" in message
+    assert "  ▸  動画化" in message
+
+
 def test_should_leave_source_and_later_stages_incomplete_without_raw_master(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/commands/uploads/test_wf_batch.py
+++ b/tests/commands/uploads/test_wf_batch.py
@@ -59,17 +59,17 @@ def _make_collection(
 
 class TestDiscoverTargets:
     def test_prepared_with_url_and_audio_is_target(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state())
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state())
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert [t.slug for t in targets] == ["001-a-collection"]
         assert excluded == []
 
     def test_missing_url_is_excluded_with_warning(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(url=None))
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(url=None))
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert len(excluded) == 1
@@ -77,64 +77,73 @@ class TestDiscoverTargets:
         assert "suno_playlist_url" in excluded[0].reason
 
     def test_missing_audio_is_excluded_with_warning(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(), audio_files=())
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(), audio_files=())
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert len(excluded) == 1
         assert "02-Individual-music" in excluded[0].reason
 
     def test_missing_url_and_audio_reports_both_reasons(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(url=None), audio_files=())
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(url=None), audio_files=())
 
-        _, excluded = wf_batch.discover_targets(tmp_path)
+        _, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert "suno_playlist_url" in excluded[0].reason
         assert "02-Individual-music" in excluded[0].reason
 
     def test_non_prepared_phase_is_silently_skipped(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(phase="mastered"))
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(phase="mastered"))
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert excluded == []
 
     def test_raw_master_recorded_is_silently_skipped(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(raw_master="master.mp3"))
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(raw_master="master.mp3"))
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert excluded == []
 
     def test_music_prompts_false_is_silently_skipped(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", _state(music_prompts=False))
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state(music_prompts=False))
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert excluded == []
 
     def test_broken_state_is_excluded_with_warning(self, tmp_path):
-        _make_collection(tmp_path, "001-a-collection", "{broken json")
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", "{broken json")
 
-        targets, excluded = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert "workflow-state.json" in excluded[0].reason
 
-    def test_targets_are_sorted_by_slug(self, tmp_path):
-        _make_collection(tmp_path, "002-b-collection", _state())
-        _make_collection(tmp_path, "001-a-collection", _state())
+    def test_missing_state_is_silently_skipped(self, tmp_path):
+        collection = tmp_path / "collections" / "planning" / "001-a-collection"
+        collection.mkdir(parents=True)
 
-        targets, _ = wf_batch.discover_targets(tmp_path)
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
+
+        assert targets == []
+        assert excluded == []
+
+    def test_targets_are_sorted_by_slug(self, tmp_path):
+        _make_collection(tmp_path / "collections" / "planning", "002-b-collection", _state())
+        _make_collection(tmp_path / "collections" / "planning", "001-a-collection", _state())
+
+        targets, _ = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert [t.slug for t in targets] == ["001-a-collection", "002-b-collection"]
 
     def test_missing_planning_root_returns_empty(self, tmp_path):
-        targets, excluded = wf_batch.discover_targets(tmp_path / "nope")
+        targets, excluded = wf_batch.discover_targets(tmp_path / "collections" / "planning")
 
         assert targets == []
         assert excluded == []
@@ -353,6 +362,17 @@ class TestMainDryRun:
         assert "002-b-collection" in captured.err
         assert "suno_playlist_url" in captured.err
         assert not (channel / "reports").exists()
+
+    def test_inventory_hazard_is_reported_as_cli_error(self, channel, capsys):
+        planning = channel / "collections" / "planning"
+        target = channel / "outside"
+        target.mkdir()
+        (planning / "hazard").symlink_to(target, target_is_directory=True)
+
+        rc = wf_batch.main(["--dry-run"])
+
+        assert rc == 1
+        assert "ERROR:" in capsys.readouterr().err
 
 
 class TestMainBatchRun:

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -718,6 +718,20 @@ class TestAutoDetectCollection:
         uploader.execute_next_step.assert_not_called()
         assert "-c で対象を明示してください" in caplog.text
 
+    def test_daily_check_skips_inventory_hazard_without_stopping_daemon(self, tmp_path, caplog):
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        planning = tmp_path / "collections" / "planning"
+        planning.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (planning / "hazard").symlink_to(outside, target_is_directory=True)
+        uploader.execute_next_step = MagicMock()
+
+        uploader._daily_check_and_upload()
+
+        uploader.execute_next_step.assert_not_called()
+        assert "symlink" in caplog.text
+
 
 class TestDefaultPublishTimeFallback:
     """#1054: schedule_config 未指定時に channel youtube.default_publish_time を使う。"""


### PR DESCRIPTION
## Summary
- commands / uploads / localserver の collection 列挙を共通 inventory 経由へ移行
- unreadable state に対する caller ごとの fail-open・除外記録・warn-and-skip 方針を維持
- 任意ディレクトリを受け取る localserver の互換経路を保持

Closes #4428