### PR TITLE
ci(changelog): 通常PRの直接編集を拒否する (#4525)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,7 @@ jobs:
           PR_LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           set -eu
           if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then
@@ -235,15 +236,27 @@ jobs:
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$changed"
+          if [[ "$HEAD_REF" == release/* ]]; then
+            if ! echo "$changed" | grep -q '^CHANGELOG\.md$'; then
+              echo "::error::Release PRs must update CHANGELOG.md."
+              exit 1
+            fi
+            echo "Release CHANGELOG update found"
+            exit 0
+          fi
+          if echo "$changed" | grep -q '^CHANGELOG\.md$'; then
+            echo "::error::Normal PRs must not edit CHANGELOG.md directly; add a fragment under changelog.d/."
+            exit 1
+          fi
           if ! echo "$changed" | grep -qE '^(src/youtube_automation/|\.claude/skills/|\.claude/CLAUDE\.template\.md$|pyproject\.toml$)'; then
             echo "No significant code changes, skipping CHANGELOG check"
             exit 0
           fi
-          if ! echo "$changed" | grep -qE '^(CHANGELOG\.md|changelog\.d/.+\.md)$'; then
-            echo "::error::Add a changelog fragment under changelog.d/ (or update CHANGELOG.md), or apply 'skip-changelog' label."
+          if ! echo "$changed" | grep -qE '^changelog\.d/.+\.md$'; then
+            echo "::error::Add a changelog fragment under changelog.d/, or apply 'skip-changelog' label."
             exit 1
           fi
-          echo "Changelog update found"
+          echo "Changelog fragment found"
 
   adr-numbering:
     needs: changes

--- a/changelog.d/4525-changelog-ci-enforcement.changed.md
+++ b/changelog.d/4525-changelog-ci-enforcement.changed.md
@@ -1,0 +1,1 @@
+- 通常 PR の `CHANGELOG.md` 直接編集を CI で拒否して `changelog.d/` fragment を必須化し、`release/*` の release prepare だけを例外として許可する（#4525）。

--- a/tests/repo/test_changelog_ci_contract.py
+++ b/tests/repo/test_changelog_ci_contract.py
@@ -41,8 +41,9 @@ def _build_ci_path_filter_pattern(gated_paths: tuple[str, ...]) -> str:
 _PATH_FILTER_PATTERN = _build_ci_path_filter_pattern(_CHANGELOG_GATED_PATHS)
 # push で CI を回す対象 branch。PR は stacked PR base でも発火するよう branch 制限しない。
 _PUSH_TRIGGER_BRANCHES = ["main"]
-_CHANGELOG_FILE_PATTERN = "^(CHANGELOG\\.md|changelog\\.d/.+\\.md)$"
+_CHANGELOG_FRAGMENT_PATTERN = "^changelog\\.d/.+\\.md$"
 _LABELS_JOIN_EXPRESSION = "${{ join(github.event.pull_request.labels.*.name, ',') }}"
+_HEAD_REF_EXPRESSION = "${{ github.head_ref }}"
 _PR_EVENT_GUARD = "github.event_name == 'pull_request'"
 _PR_TEMPLATE_TEXT = """## 概要
 
@@ -69,9 +70,11 @@ _EXPECTED_RUN_LINES = [
     "set -eu",
     'if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then',
     'changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")',
+    'if [[ "$HEAD_REF" == release/* ]]; then',
+    "if echo \"$changed\" | grep -q '^CHANGELOG\\.md$'; then",
     f"if ! echo \"$changed\" | grep -qE '{_PATH_FILTER_PATTERN}'; then",
-    f"if ! echo \"$changed\" | grep -qE '{_CHANGELOG_FILE_PATTERN}'; then",
-    'echo "Changelog update found"',
+    f"if ! echo \"$changed\" | grep -qE '{_CHANGELOG_FRAGMENT_PATTERN}'; then",
+    'echo "Changelog fragment found"',
 ]
 
 
@@ -112,6 +115,7 @@ def test_ci_workflow_changelog_job_uses_expected_environment_contract() -> None:
         "PR_LABELS": _LABELS_JOIN_EXPRESSION,
         "BASE_SHA": "${{ github.event.pull_request.base.sha }}",
         "HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+        "HEAD_REF": _HEAD_REF_EXPRESSION,
     }
 
 
@@ -135,11 +139,10 @@ def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
         assert expected_line in run_script
 
     assert _CHANGELOG_LABEL in run_script
-    assert _CHANGELOG_FILE_PATTERN in run_script
-    assert (
-        "::error::Add a changelog fragment under changelog.d/ (or update CHANGELOG.md), "
-        "or apply 'skip-changelog' label." in run_script
-    )
+    assert _CHANGELOG_FRAGMENT_PATTERN in run_script
+    assert "::error::Normal PRs must not edit CHANGELOG.md directly; add a fragment under changelog.d/." in run_script
+    assert "::error::Release PRs must update CHANGELOG.md." in run_script
+    assert "::error::Add a changelog fragment under changelog.d/, or apply 'skip-changelog' label." in run_script
 
 
 def test_ci_workflow_keeps_push_branch_allowlist() -> None:


### PR DESCRIPTION
## 概要

<!-- 何を、なぜ変更したか。issue があれば `Closes #N` -->

## 変更内容

<!-- 主要な変更点を箇条書きで -->

## チェックリスト

- [ ] `changelog.d/` に fragment を追加した（書き方: [`changelog.d/README.md`](../changelog.d/README.md)。通常 PR では `CHANGELOG.md` を直接編集しない）
  - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
- [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
  - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)
- [ ] 必要なテストを追加・更新した

## 関連

<!-- 関連 issue / PR / 参照ドキュメント -->