### PR TITLE
fix(ci): fragment変更の影響テストを限定する (#4526)

### DIFF
--- a/.github/scripts/select-affected-tests.py
+++ b/.github/scripts/select-affected-tests.py
@@ -37,6 +37,13 @@ PATH_TEST_MAP: Final = (
         ),
     ),
     ("CHANGELOG.md", ("tests/repo/test_changelog_ci_contract.py",)),
+    (
+        "changelog.d/",
+        (
+            "tests/commands/system/test_changelog_compile.py",
+            "tests/repo/test_changelog_ci_contract.py",
+        ),
+    ),
 )
 
 

--- a/changelog.d/4526-changelog-test-selection.fixed.md
+++ b/changelog.d/4526-changelog-test-selection.fixed.md
@@ -1,0 +1,1 @@
+- changelog fragment変更を影響テスト選択でchangelog契約テストへ限定し、未知path扱いによる全pytest誤実行を防ぐ（#4526）。

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -58,11 +58,13 @@ def _synthetic_repository(tmp_path: Path) -> Path:
     )
     _write(repository, "tests/repo/test_actions_parallel_workflows.py")
     _write(repository, "tests/repo/test_changelog_ci_contract.py")
+    _write(repository, "tests/commands/system/test_changelog_compile.py")
     _write(repository, "tests/repo/test_b6_integration_contract.py")
     _write(repository, "tests/repo/test_site_repository_contract.py")
     _write(repository, ".github/workflows/ci.yml")
     _write(repository, "docs/adr/0024-example.md")
     _write(repository, "CHANGELOG.md")
+    _write(repository, "changelog.d/4526-example.fixed.md")
     return repository
 
 
@@ -112,6 +114,10 @@ def test_workflow_adr_changelog_and_direct_test_use_explicit_mapping(tmp_path: P
         "tests/repo/test_site_repository_contract.py",
     )
     assert selector.select_targets(repository, ["CHANGELOG.md"]) == ("tests/repo/test_changelog_ci_contract.py",)
+    assert selector.select_targets(repository, ["changelog.d/4526-example.fixed.md"]) == (
+        "tests/commands/system/test_changelog_compile.py",
+        "tests/repo/test_changelog_ci_contract.py",
+    )
     assert selector.select_targets(repository, ["tests/repo/test_actions_parallel_workflows.py"]) == (
         "tests/repo/test_actions_parallel_workflows.py",
     )


### PR DESCRIPTION
## 概要

<!-- 何を、なぜ変更したか。issue があれば `Closes #N` -->

## 変更内容

<!-- 主要な変更点を箇条書きで -->

## チェックリスト

- [ ] `changelog.d/` に fragment を追加した（書き方: [`changelog.d/README.md`](../changelog.d/README.md)。通常 PR では `CHANGELOG.md` を直接編集しない）
  - 免除する場合は `skip-changelog` ラベルを付与（tests / docs / 内部リファクタのみ）
- [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
  - フォーマット: [docs/changelog-contract.md](../docs/changelog-contract.md)
- [ ] 必要なテストを追加・更新した

## 関連

<!-- 関連 issue / PR / 参照ドキュメント -->