### PR TITLE
[codex-cloud] focused testだけを実行してfull suiteをCIへ委ねる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,18 +30,17 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 - `config/channel/*.json` は責務別分割。必須ファイルに加え optional として `shorts.json` / `comments.json` / `pinned-comment.json` / `distrokid.json` / `community-draft.json` がある。一覧と構造は `CLAUDE.md`・`docs/architecture.md` を参照
 
-### Codex Cloud の検証
+### devShell と worktree
 
-この節は Codex Cloud の task 実行時だけに適用し、Cloud の setup / maintenance、ローカル開発、GitHub Actions には適用しない。Cloud の既存 setup / maintenance script は Nix closure と依存をキャッシュするためそのまま使い、環境変数 `UV_PYTHON=3.14` を設定する。
+- 対象 checkout（親 checkout / worktree のどちらも）で `nix develop` または direnv に入る。shellHook が `uv sync` を自動実行する。Codex Cloud task の例外は次節を正とする
+- 品質ゲート（ruff / CHANGELOG / any 型）はローカル git hook ではなく CI で担保される。詳細は `docs/development.md` の「品質ゲート（CI）」
+
+## Codex Cloud の検証
+
+この節は Codex Cloud の task 実行時だけに適用する。Cloud の setup / maintenance では既存の Nix script を使い、環境変数 `UV_PYTHON=3.14` を設定する。
 
 - setup 済み checkout では既存 `.venv` を使う。task 中に linked worktree を作った場合は、並列処理を始める前にその worktree で `uv sync --python 3.14 --frozen` を一度だけ完了させる
-- 変更した test file / node ID と、変更に直接必要な repository contract を focused test の対象にする。標準形は `uv run --no-sync pytest <targets>`
-- Python の静的検査は変更した path に限定し、`uv run --no-sync ruff check <paths>` を使う
+- 変更した test file / node ID と、変更に直接必要な `tests/repo/` の contract test を focused test の対象にする。標準形は `uv run --no-sync pytest <targets>`
 - 10,000 件超の full suite は GitHub Actions を正とし、Cloud では PR の CI 完了を確認する
 - CI failure の修正ループでは、失敗した test を Cloud で単独再現してから修正する
 - task 中は `nix develop` ではなく準備済みの `uv` 環境を使う。引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` は実行しない
-
-### devShell と worktree
-
-- Codex Cloud 以外の対象 checkout（親 checkout / worktree のどちらも）で `nix develop` または direnv に入る。shellHook が `uv sync` を自動実行する
-- 品質ゲート（ruff / CHANGELOG / any 型）はローカル git hook ではなく CI で担保される。詳細は `docs/development.md` の「品質ゲート（CI）」

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,10 +37,9 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 ## Codex Cloud の検証
 
-この節は Codex Cloud の task 実行時だけに適用する。Cloud の setup / maintenance では既存の Nix script を使い、環境変数 `UV_PYTHON=3.14` を設定する。
+この節は Codex Cloud の task 実行時だけに適用する。Cloud 設定画面で環境変数 `UV_PROJECT_ENVIRONMENT=/workspace/youtube-automation/.venv` を設定し、既存の Nix setup / maintenance script が同期した同じ環境を checkout と linked worktree から使う。task 中は準備済み環境を変更せず、`uv run --no-sync` で検証する。
 
-- setup 済み checkout では既存 `.venv` を使う。task 中に linked worktree を作った場合は、並列処理を始める前にその worktree で `uv sync --python 3.14 --frozen` を一度だけ完了させる
 - 変更した test file / node ID と、変更に直接必要な `tests/repo/` の contract test を focused test の対象にする。標準形は `uv run --no-sync pytest <targets>`
 - 10,000 件超の full suite は GitHub Actions を正とし、Cloud では PR の CI 完了を確認する
 - CI failure の修正ループでは、失敗した test を Cloud で単独再現してから修正する
-- task 中は `nix develop` ではなく準備済みの `uv` 環境を使う。引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` は実行しない
+- task 中は `nix develop`、`uv sync`、引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` を実行しない

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,14 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 ### Codex Cloud の検証
 
-この節は Codex Cloud にだけ適用し、ローカル開発と GitHub Actions には適用しない。Cloud 環境は Python 3.14、環境変数 `UV_PYTHON=3.14`、setup / maintenance script `uv sync --python 3.14 --frozen` で構成する。依存同期は setup / maintenance に任せ、task 中の検証コマンドは既存環境を変更しない `uv run --no-sync` を使う。
+この節は Codex Cloud の task 実行時だけに適用し、Cloud の setup / maintenance、ローカル開発、GitHub Actions には適用しない。Cloud の既存 setup / maintenance script は Nix closure と依存をキャッシュするためそのまま使い、環境変数 `UV_PYTHON=3.14` を設定する。
 
+- setup 済み checkout では既存 `.venv` を使う。task 中に linked worktree を作った場合は、並列処理を始める前にその worktree で `uv sync --python 3.14 --frozen` を一度だけ完了させる
 - 変更した test file / node ID と、変更に直接必要な repository contract を focused test の対象にする。標準形は `uv run --no-sync pytest <targets>`
 - Python の静的検査は変更した path に限定し、`uv run --no-sync ruff check <paths>` を使う
 - 10,000 件超の full suite は GitHub Actions を正とし、Cloud では PR の CI 完了を確認する
 - CI failure の修正ループでは、失敗した test を Cloud で単独再現してから修正する
-- Cloud では `nix develop`、引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` を実行しない
+- task 中は `nix develop` ではなく準備済みの `uv` 環境を使う。引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` は実行しない
 
 ### devShell と worktree
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,17 @@ This file provides guidance to Codex CLI (developers.openai.com/codex) when work
 
 - `config/channel/*.json` は責務別分割。必須ファイルに加え optional として `shorts.json` / `comments.json` / `pinned-comment.json` / `distrokid.json` / `community-draft.json` がある。一覧と構造は `CLAUDE.md`・`docs/architecture.md` を参照
 
+### Codex Cloud の検証
+
+この節は Codex Cloud にだけ適用し、ローカル開発と GitHub Actions には適用しない。Cloud 環境は Python 3.14、環境変数 `UV_PYTHON=3.14`、setup / maintenance script `uv sync --python 3.14 --frozen` で構成する。依存同期は setup / maintenance に任せ、task 中の検証コマンドは既存環境を変更しない `uv run --no-sync` を使う。
+
+- 変更した test file / node ID と、変更に直接必要な repository contract を focused test の対象にする。標準形は `uv run --no-sync pytest <targets>`
+- Python の静的検査は変更した path に限定し、`uv run --no-sync ruff check <paths>` を使う
+- 10,000 件超の full suite は GitHub Actions を正とし、Cloud では PR の CI 完了を確認する
+- CI failure の修正ループでは、失敗した test を Cloud で単独再現してから修正する
+- Cloud では `nix develop`、引数なしの `pytest`、全 test 指定、full collection に対する `pytest -n auto` を実行しない
+
 ### devShell と worktree
 
-- 対象 checkout（親 checkout / worktree のどちらも）で `nix develop` または direnv に入る。shellHook が `uv sync` を自動実行する
+- Codex Cloud 以外の対象 checkout（親 checkout / worktree のどちらも）で `nix develop` または direnv に入る。shellHook が `uv sync` を自動実行する
 - 品質ゲート（ruff / CHANGELOG / any 型）はローカル git hook ではなく CI で担保される。詳細は `docs/development.md` の「品質ゲート（CI）」

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ YouTube チャンネル運営を自動化するツールキット。`youtube-cha
 
 ## 非自明な規約・落とし穴
 
-- devShell 必須（direnv または `nix develop`。shellHook が `uv sync` を自動実行）。非対話 shell は `nix develop --command <cmd>`
+- devShell 必須（direnv または `nix develop`。shellHook が `uv sync` を自動実行）。非対話 shell は `nix develop --command <cmd>`。Codex Cloud task の例外は `AGENTS.md`「Codex Cloud の検証」を正とする
 - チャンネル固有値は `load_config` 経由でのみ取得（`config.meta.channel_name` 形式）。ハードコード禁止。新キー追加は dataclass（`configuration/<section>.py`）+ `loader.py::_build_*` + 必須なら `_REQUIRED_KEYS_BY_SECTION` の 3 点セット — 最後の登録を忘れやすい
 - 下流の `config/channel/*.json` は責務別分割。optional は shorts.json / comments.json / pinned-comment.json / distrokid.json / community-draft.json（全容は `docs/architecture.md`）
 - 本ファイルや README / ONBOARDING / AGENTS の実行契約は機械担保されている — 文言を変更・削除するときは `tests/test_*_contract.py` / `test_skill_docs_consistency.py` を確認


### PR DESCRIPTION
## Summary

- Codex Cloud の既存 Nix setup / maintenance は closure と依存のキャッシュ用として維持
- task 実行時は setup 済みの `uv` 環境を使用し、linked worktree は並列処理前に一度だけ同期
- Cloud の検証を `uv run --no-sync` による focused test / focused ruff に限定
- 10,000件超の full suite と最終判定を GitHub Actions に委譲

## Test plan

- `uv run --no-sync pytest tests/repo/test_skill_docs_consistency.py::test_common_docs_list_optional_channel_config_files -q`
- GitHub Actions の full suite

Closes #4536
