### PR TITLE
docs(plans): 第 6 回監査の記録とプラン 028〜033 を追加する

### DIFF
--- a/plans/028-delete-music-skill-stale-suno-prompts-fork.md
+++ b/plans/028-delete-music-skill-stale-suno-prompts-fork.md
@@ -1,0 +1,115 @@
+# Plan 028: music skill 内の stale fork `generate_suno_prompts.py` を削除する
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step の
+> Verify コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」
+> のいずれかが発生したら改善を試みず停止して報告する。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- .claude/skills/music/ src/youtube_automation/commands/suno/generate_suno_prompts.py CHANGELOG.md`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: 033 (soft — CHANGELOG は fragment 方式で書く。033 が未マージの場合のみ CHANGELOG.md 直接編集に fallback)
+- **Category**: tech-debt
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4460
+
+## Why this matters
+
+`.claude/skills/music/references/generate_suno_prompts.py` は、本来 symlink であるべきところが **19KB の通常ファイルとして commit された古い fork** で、`src/youtube_automation/commands/suno/generate_suno_prompts.py` から 95 行分乖離している（`f33df96b` の prompt 解決リファクタが反映されていない）。`.claude/skills/` は wheel に force-include されるため、この stale fork は下流チャンネルリポジトリ全部に配布される。skill 本文はすべて `uv run yt-generate-suno` を呼ぶためこのファイルを参照する経路はゼロだが、`references/` を探索したエージェントが直接実行すると**エラーなしで古い挙動の出力**を返す silent-wrong-output 経路になる。
+
+## Current state
+
+- `.claude/skills/music/references/generate_suno_prompts.py` — 削除対象。`ls -la` で通常ファイル（`-rw-r--r--`、19464 bytes）であることが確認できる。同ディレクトリの `finalize_master.py` は symlink（`lrwxr-xr-x` → `../../../../src/youtube_automation/commands/media/finalize_master.py`）で、これがこのリポジトリの正規パターン。references/ 配下の src 連携スクリプト 15 本はすべて symlink であり、この 1 本だけが実体コピー。
+- `src/youtube_automation/commands/suno/generate_suno_prompts.py` — 正規実装。`pyproject.toml` の `yt-generate-suno` entry point から到達し、`tests/commands/suno/test_generate_suno_prompts.py` 等 4 テストファイルが import する。**触らない**。
+- skill 側の呼び出しは CLI 経由のみ: `.claude/skills/music/references/prompt.md` に `uv run yt-generate-suno` が 9 箇所（29, 106, 115, 117, 174, 198, 204, 222, 252 行付近）。ファイルパス `references/generate_suno_prompts.py` への言及は skill 内・テスト内ともにゼロ（`git grep -n "references/generate_suno_prompts" -- .claude tests` が空であることを確認済み）。
+- リポジトリ規約: `.claude/skills/` を触る変更は `CHANGELOG.md` の `[Unreleased]` 追記が CI ゲートで必須。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| テスト（skill 配布契約） | `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py -x -q` | all pass |
+| テスト（suno 系） | `nix develop --command uv run pytest tests/commands/suno/ -q` | all pass |
+| skill lint | `nix develop --command uv run yt-skills lint` | exit 0 |
+| Ruff | `nix develop --command uv run ruff check .` | exit 0 |
+
+## Scope
+
+**In scope**（変更してよいのはこれだけ）:
+- `.claude/skills/music/references/generate_suno_prompts.py`（削除）
+- `CHANGELOG.md`（`[Unreleased]` 追記）
+
+**Out of scope**（触らない）:
+- `src/youtube_automation/commands/suno/generate_suno_prompts.py` — 正規実装。同期・編集不要。
+- `.claude/skills/music/` の他ファイル — symlink 化への置き換えも行わない（skill は CLI 経由で呼ぶ設計のため、リンクを増やす必要がない）。
+- `.agents/skills` — `.claude/skills` への symlink。個別操作不要。
+
+## Git workflow
+
+- 作業は issue 専用 linked worktree 上で行う（`$REPO_ROOT/.claude/worktrees/<slug>/`。メイン作業ツリーで直接ブランチを切らない）
+- Branch: `advisor/028-delete-music-suno-prompts-fork`
+- Commit: 日本語 Conventional Commits、1 branch 1 commit。例: `chore(skills): music references の stale な generate_suno_prompts fork を削除 (#<issue番号>)`（issue 未起票なら番号は省略可）
+- push / PR 作成はオペレーターの指示があるまで行わない
+
+## Steps
+
+### Step 1: fork ファイルを削除する
+
+```bash
+git rm .claude/skills/music/references/generate_suno_prompts.py
+```
+
+**Verify**: `git status --short` → `D  .claude/skills/music/references/generate_suno_prompts.py` のみ（＋後続の CHANGELOG）
+
+### Step 2: 参照が残っていないことを確認する
+
+**Verify**: `git grep -n "references/generate_suno_prompts" -- .claude tests docs src` → ヒット 0 件
+
+### Step 3: CHANGELOG に追記する
+
+エントリ文面:
+
+```
+- music skill の references から stale な generate_suno_prompts.py の実体コピーを削除（正規経路は yt-generate-suno CLI）
+```
+
+**Plan 033（issue #4483、changelog fragment 基盤）が main にマージ済みの場合**（`test -d changelog.d` で判定）: `CHANGELOG.md` は編集せず、`changelog.d/4460-delete-suno-prompts-fork.removed.md` を新規作成して上の bullet を書く。未マージの場合のみ、従来どおり `CHANGELOG.md` の `## [Unreleased]` に追記する。
+
+**Verify**: fragment 方式なら `test -f changelog.d/4460-delete-suno-prompts-fork.removed.md` → exit 0（`git diff CHANGELOG.md` は空）。直接編集なら `git diff CHANGELOG.md` → 上記 1 行の追加のみ
+
+### Step 4: テストと lint を通す
+
+**Verify**:
+- `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py tests/commands/suno/ -q` → all pass
+- `nix develop --command uv run yt-skills lint` → exit 0
+
+## Test plan
+
+新規テストは不要（削除のみ）。既存の skill 配布契約テスト `tests/repo/test_skills_sync_installed_wheel.py` と suno 系テスト全部がグリーンであることが回帰確認になる。
+
+## Done criteria
+
+- [ ] `.claude/skills/music/references/generate_suno_prompts.py` が存在しない（`test ! -e` で確認）
+- [ ] `git grep -n "references/generate_suno_prompts"` が 0 件
+- [ ] `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py tests/commands/suno/ -q` が exit 0
+- [ ] `nix develop --command uv run yt-skills lint` が exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] In scope 外のファイルに変更がない（`git status`）
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- `.claude/skills/music/references/generate_suno_prompts.py` が symlink になっている（既に誰かが修正済み — この plan は不要）。
+- `git grep` で skill 本文・テストのどこかがこのファイルパスを参照している（前提が崩れている）。
+- `test_skills_sync_installed_wheel.py` が「ファイル数」や「manifest 一致」で fail し、その fixture / 期待値の更新が必要になった場合 — 期待値をどう更新すべきか判断がいるので報告する。
+
+## Maintenance notes
+
+- 今後 `references/` に src 連携スクリプトを置くときは**必ず symlink** にする（実体コピーはこの障害の再発）。レビュー時は `git diff --stat` でファイルモード `120000`（symlink）を確認するとよい。
+- `uv run yt-skills lint` には「未参照 references ファイル検知」が無いため、この類の残骸は機械検出されない（第 6 回監査の残課題として plans/README.md に記載）。

--- a/plans/029-delete-video-validator-cluster.md
+++ b/plans/029-delete-video-validator-cluster.md
@@ -1,0 +1,166 @@
+# Plan 029: 到達不能な video_validator クラスタと B3 facade 2 本を削除する
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step の
+> Verify コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」
+> のいずれかが発生したら改善を試みず停止して報告する。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- src/youtube_automation/commands/analytics/video_validator.py src/youtube_automation/domains/media/video_validator.py src/youtube_automation/domains/media/video.py src/youtube_automation/domains/media/audio.py tests/commands/analytics/test_video_validator.py tests/repo/test_cli_harness_gate.py tests/test_b3_domain_migration_contract.py`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW–MED（downstream import の可能性のみ。in-repo 到達経路はゼロ）
+- **Depends on**: 033 (soft — CHANGELOG は fragment 方式で書く。033 が未マージの場合のみ CHANGELOG.md 直接編集に fallback)
+- **Category**: tech-debt
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4461
+
+## Why this matters
+
+`video_validator` クラスタ（CLI 1 本 + domain 実装 + facade、計 446 行）は、`pyproject.toml` のどの `yt-*` entry point からも、skill・doc・workflow のどこからも呼べない。唯一の消費者は自分専用のテスト 278 行で、CI で毎回実行・カバレッジ計上・リファクタ追従コストを払い続けている。同型の B3 期 facade `domains/media/audio.py`（6 行）も、消費者は migration 契約テストの列挙のみ。「テストだけが延命させている dead code」を削除し、契約テストの凍結リストからも外す。
+
+## Current state
+
+削除対象 4 + テスト 1:
+
+- `src/youtube_automation/commands/analytics/video_validator.py` — `main()` と `if __name__ == "__main__"` を持つ CLI だが、`pyproject.toml [project.scripts]` に対応する `yt-*` が無く、`src/youtube_automation/entrypoints.py` の文字列 dispatch にも現れない（`git grep -n "video_validator" src/youtube_automation/entrypoints.py` → 0 件を確認済み）。冒頭:
+  ```python
+  """ffprobe adapter and command entry point for video validation."""
+  ...
+  from youtube_automation.domains.media.video_validator import VideoValidator
+  ```
+- `src/youtube_automation/domains/media/video_validator.py` — `VideoValidator`（377 行）。importer は上の dead CLI と `domains/media/video.py` の 2 つだけ。
+- `src/youtube_automation/domains/media/video.py` — 6 行の facade。全文:
+  ```python
+  """Video domain public surface."""
+
+  from youtube_automation.domains.media.video_type import VideoType, VideoTypeConfig
+  from youtube_automation.domains.media.video_validator import VideoValidator
+
+  __all__ = ["VideoType", "VideoTypeConfig", "VideoValidator"]
+  ```
+  src 内 importer ゼロ。参照は `tests/test_b3_domain_migration_contract.py` の列挙のみ。
+- `src/youtube_automation/domains/media/audio.py` — 6 行の facade。全文:
+  ```python
+  """Provider-neutral audio formats and billing units."""
+
+  from youtube_automation.domains.media.audio_formats import AUDIO_EXTS
+  from youtube_automation.domains.media.audio_units import unit_for_audio
+
+  __all__ = ["AUDIO_EXTS", "unit_for_audio"]
+  ```
+  同じく参照は `tests/test_b3_domain_migration_contract.py` のみ。re-export 元の `audio_formats.py` / `audio_units.py` は現役（**触らない**）。
+- `tests/commands/analytics/test_video_validator.py` — 278 行。唯一の behavioral consumer。丸ごと削除。
+
+編集が必要な契約テスト 2:
+
+- `tests/repo/test_cli_harness_gate.py:26` — `LEGACY_CLI_ALLOWLIST` に `"youtube_automation.commands.analytics.video_validator",` の行がある。この 1 行を削除。
+- `tests/test_b3_domain_migration_contract.py:54,57` — 凍結モジュールリストに `"youtube_automation.domains.media.audio",` と `"youtube_automation.domains.media.video",` がある。この 2 行を削除。
+
+注意（誤読しやすい点）:
+- `src/youtube_automation/domains/media/audio_formats.py:4` の docstring に「`video_validator`（個別動画と音声ファイル数の整合性チェック）」という**言及**があるが、import ではない。docstring のこの言及行は削除後に整合するよう文言を調整してよい（それ以外は触らない）。
+- `domains/media/video_type.py`（`VideoType`）は多数の現役 importer を持つ。**削除しない**。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 対象テスト | `nix develop --command uv run pytest tests/repo/test_cli_harness_gate.py tests/test_b3_domain_migration_contract.py tests/domains/media/ -q` | all pass |
+| import 健全性 | `nix develop --command uv run python -c "import youtube_automation.domains.media.video_type"` | exit 0 |
+| Ruff | `nix develop --command uv run ruff check src tests` | exit 0 |
+| 全体（時間があれば） | `nix develop --command uv run pytest -q` | all pass |
+
+## Scope
+
+**In scope**:
+- 削除: `src/youtube_automation/commands/analytics/video_validator.py`, `src/youtube_automation/domains/media/video_validator.py`, `src/youtube_automation/domains/media/video.py`, `src/youtube_automation/domains/media/audio.py`, `tests/commands/analytics/test_video_validator.py`
+- 編集: `tests/repo/test_cli_harness_gate.py`（1 行削除）, `tests/test_b3_domain_migration_contract.py`（2 行削除）, `src/youtube_automation/domains/media/audio_formats.py`（docstring の言及調整のみ・任意）, `CHANGELOG.md`
+
+**Out of scope**:
+- `src/youtube_automation/domains/media/video_type.py`, `audio_formats.py` の実装, `audio_units.py` — 現役。
+- `src/youtube_automation/domains/uploads/descriptions_md.py` — 同類の疑いだが別判断（第 6 回監査で未選択。この plan で触らない）。
+- `pyproject.toml` — video_validator の entry point はもともと存在しないので変更不要。
+
+## Git workflow
+
+- issue 専用 linked worktree 上で作業（`$REPO_ROOT/.claude/worktrees/<slug>/`）
+- Branch: `advisor/029-delete-video-validator-cluster`
+- Commit: `refactor(analytics): 到達不能な video_validator クラスタと B3 facade を削除 (#<issue番号>)`（1 branch 1 commit）
+- push / PR 作成はオペレーター指示があるまで行わない
+
+## Steps
+
+### Step 1: 削除前の到達不能性を再確認する
+
+**Verify**:
+- `git grep -ln "video_validator" -- src tests pyproject.toml` → ヒットは Current state に列挙した 5 ファイル（+ `audio_formats.py` の docstring）のみ
+- `git grep -ln "domains.media.video\b" -- src` と `git grep -ln "domains.media.audio\b" -- src` → いずれも 0 件（tests のみ）
+
+### Step 2: 5 ファイルを削除する
+
+```bash
+git rm src/youtube_automation/commands/analytics/video_validator.py \
+       src/youtube_automation/domains/media/video_validator.py \
+       src/youtube_automation/domains/media/video.py \
+       src/youtube_automation/domains/media/audio.py \
+       tests/commands/analytics/test_video_validator.py
+```
+
+**Verify**: `git status --short` → 上記 5 件の `D` のみ
+
+### Step 3: 契約テストの列挙から外す
+
+- `tests/repo/test_cli_harness_gate.py` から `"youtube_automation.commands.analytics.video_validator",` の 1 行を削除
+- `tests/test_b3_domain_migration_contract.py` から `"youtube_automation.domains.media.audio",` と `"youtube_automation.domains.media.video",` の 2 行を削除
+
+**Verify**: `nix develop --command uv run pytest tests/repo/test_cli_harness_gate.py tests/test_b3_domain_migration_contract.py -q` → all pass
+
+### Step 4: 残存参照を掃く
+
+`git grep -n "video_validator\|VideoValidator" -- src tests docs .claude` を実行。ヒットが `audio_formats.py` の docstring だけなら、その言及を現状に合う文言へ修正（または該当句を削除）する。
+
+**Verify**: 上記 grep の残ヒットが 0 件（docstring 修正後）
+
+### Step 5: CHANGELOG 追記とテスト
+
+エントリ文面:
+
+```
+- 到達不能だった video_validator（CLI + domain 実装 + facade）と B3 facade domains/media/{video,audio}.py を削除
+```
+
+**Plan 033（issue #4483）が main にマージ済みの場合**（`test -d changelog.d` で判定）: `CHANGELOG.md` は編集せず、`changelog.d/4461-delete-video-validator.removed.md` を新規作成して上の bullet を書く。未マージの場合のみ `CHANGELOG.md` の `[Unreleased]` に追記する。
+
+**Verify**:
+- `nix develop --command uv run pytest tests/ -q -x --ignore=tests/repo` → all pass（時間短縮のため。可能なら ignore なしの全体を実行）
+- `nix develop --command uv run pytest tests/repo -q` → all pass
+- `nix develop --command uv run ruff check src tests` → exit 0
+
+## Test plan
+
+新規テストは不要（削除のみ）。回帰確認は Step 3 / Step 5 の契約テスト＋全体スイート。削除により `tests/contracts/architecture/test_repository_reorganization_contract.py` が fail した場合は、そのファイル内で `video_validator` を指す mapping 行を確認して同様に削除する（Step 3 と同じ性質の列挙更新。ただし `utils/comments/codex_generator.py` など**他モジュールの mapping は触らない**）。
+
+## Done criteria
+
+- [ ] 5 ファイルが存在しない
+- [ ] `git grep -n "VideoValidator" -- src tests` が 0 件
+- [ ] `nix develop --command uv run pytest -q` が exit 0（全体）
+- [ ] `nix develop --command uv run ruff check src tests` が exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] In scope 外の変更がない（`git status`）
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- Step 1 の grep で Current state に無い importer が見つかった（この plan 作成後に新しい消費者が生えた）。
+- `test_b3_domain_migration_contract.py` の列挙削除で、リスト以外のロジック（例: 「削除済みモジュールは import 不可であること」を別途 assert する節）に矛盾が出た場合 — その契約の意図判断が必要なので報告する。
+- 全体テストで、この plan が触っていない領域の fail が 2 回連続で再現した。
+
+## Maintenance notes
+
+- `VideoValidator` は「動画と音声ファイル数の整合性チェック」の実装だった。将来同機能が必要になったら git 履歴（この commit の親）から復元し、その際は必ず `yt-*` entry point として登録して skill から呼ぶこと（到達経路のない CLI を作らない）。
+- downstream チャンネルリポジトリが `domains.media.video_validator` を直接 import している可能性は理論上あるが、downstream 向け import 契約リスト（`tests/repo/test_skills_sync_installed_wheel.py` の `legacy_modules`）に含まれていないため保証対象外。リリースノートに削除を明記すれば十分。

--- a/plans/030-delete-codex-generator.md
+++ b/plans/030-delete-codex-generator.md
@@ -1,0 +1,150 @@
+# Plan 030: 構築経路が封鎖済みの CodexGenerator を削除する
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step の
+> Verify コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」
+> のいずれかが発生したら改善を試みず停止して報告する。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- src/youtube_automation/application/comments/ tests/application/comments/ tests/contracts/architecture/test_repository_reorganization_contract.py`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: 033 (soft — CHANGELOG は fragment 方式で書く。033 が未マージの場合のみ CHANGELOG.md 直接編集に fallback)
+- **Category**: tech-debt
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4462
+
+## Why this matters
+
+`CodexGenerator`（subprocess で `codex exec --json` を叩くコメント返信生成器、122 行）は、factory と replier の両方が provider='codex' を **ConfigError で拒否する**ため、プロダクションでは構築不可能。つまり「監査済みフロー（--export-candidates / --agent-replies-file）に一本化する」という設計判断が既に下りていて、この class は取り残された残骸である。放置すると、将来の貢献者が factory の分岐を「直して」**未監査の自動返信経路を再有効化する footgun** になる。テストごと削除し、封鎖が意図であることをコードに残す。
+
+## Current state
+
+- `src/youtube_automation/application/comments/codex_generator.py` — 削除対象。冒頭:
+  ```python
+  """Codex CLI によるコメント返信生成."""
+  ...
+  class CodexGenerator:
+      """codex exec --json でコメント返信を生成する."""
+  ```
+  src 内 importer ゼロ（`git grep -ln "codex_generator" src/` → 自ファイルのみを確認済み）。
+- `src/youtube_automation/application/comments/generator_factory.py:27` 付近 — codex 分岐は raise（**このガードは残す**）:
+  ```python
+  if config.provider == PROVIDER_CODEX:
+      raise ConfigError(
+          "comments.generator.provider='codex' は直接生成に使用できません。"
+          "--export-candidates と --agent-replies-file の監査済みフローを使用してください"
+  ```
+- `src/youtube_automation/application/comments/replier.py:177` 付近 — 同趣旨の第 2 ガード（**残す**）。
+- テスト側の参照:
+  - `tests/application/comments/test_comments_generator.py:1` — docstring `"""GeminiGenerator / CodexGenerator の単体テスト."""`
+  - 同 `:10` — `from youtube_automation.application.comments.codex_generator import CodexGenerator`
+  - 同 `:250-` — `# ─── CodexGenerator ───` 区切り以下の `class TestCodexGenerator:` 一式（削除対象）
+  - `tests/application/comments/test_comments_generator_factory.py:38` — `assert not hasattr(comments_api, "CodexGenerator")` は**不在を assert する**テストなので削除後も通る（触らない）。
+  - `tests/application/comments/test_comments_replier.py` — `codex` provider の**拒否挙動**をテストしている可能性が高い。拒否テストはガードの検証なので残す。`CodexGenerator` 自体を import している行だけが削除対象。
+- `tests/contracts/architecture/test_repository_reorganization_contract.py:117` — 移行 mapping:
+  ```python
+  "src/youtube_automation/utils/comments/codex_generator.py": "src/youtube_automation/application/comments/codex_generator.py",
+  ```
+  削除後は移行先が存在しなくなるため、この mapping 行の扱いをテストの仕組みに合わせて更新する（Step 3）。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| comments テスト | `nix develop --command uv run pytest tests/application/comments/ -q` | all pass |
+| 契約テスト | `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py -q` | all pass |
+| Ruff | `nix develop --command uv run ruff check src tests` | exit 0 |
+
+## Scope
+
+**In scope**:
+- 削除: `src/youtube_automation/application/comments/codex_generator.py`
+- 編集: `tests/application/comments/test_comments_generator.py`（TestCodexGenerator 一式と import・docstring）、`tests/application/comments/test_comments_replier.py`（CodexGenerator の import 行のみ、あれば）、`tests/contracts/architecture/test_repository_reorganization_contract.py`（mapping 1 行）、`src/youtube_automation/application/comments/generator_factory.py`（コメント 1 行追加のみ）、`CHANGELOG.md`
+
+**Out of scope**:
+- `generator_factory.py` / `replier.py` の **raise ガード本体** — これは意図された UX。削除・緩和しない。
+- `PROVIDER_CODEX` 定数と、codex provider の**拒否**を検証するテスト — config 値としての 'codex' は引き続き受け付けて拒否メッセージを出す仕様なので残す。
+- `prompt_safety.py` / `generator.py`（`ReplyContext`）— 現役の共有モジュール。
+
+## Git workflow
+
+- issue 専用 linked worktree 上で作業（`$REPO_ROOT/.claude/worktrees/<slug>/`）
+- Branch: `advisor/030-delete-codex-generator`
+- Commit: `refactor(comments): 構築経路封鎖済みの CodexGenerator を削除 (#<issue番号>)`（1 branch 1 commit）
+- push / PR 作成はオペレーター指示があるまで行わない
+
+## Steps
+
+### Step 1: 本体を削除する
+
+```bash
+git rm src/youtube_automation/application/comments/codex_generator.py
+```
+
+**Verify**: `git grep -ln "codex_generator" src/` → 0 件
+
+### Step 2: テストを整理する
+
+- `tests/application/comments/test_comments_generator.py`: `class TestCodexGenerator:` 一式（`# ─── CodexGenerator ───` 区切り以下）と 10 行目の import を削除。1 行目の docstring を `"""GeminiGenerator の単体テスト."""` に修正。
+- `tests/application/comments/test_comments_replier.py`: `CodexGenerator` / `codex_generator` を import している行があれば削除。**codex provider が ConfigError で拒否されることを検証するテストは残す**。
+
+**Verify**: `nix develop --command uv run pytest tests/application/comments/ -q` → all pass
+
+### Step 3: reorganization 契約の mapping を更新する
+
+`tests/contracts/architecture/test_repository_reorganization_contract.py` を読み、mapping がどう検証されているか確認する（旧パス不在 + 新パス存在の assert が典型）。テスト内に「移行後にさらに削除されたモジュール」を表す仕組み（removed 系リスト等）があればそちらへ移し、無ければ 117 行の mapping エントリを削除して、削除の経緯をエントリ跡に 1 行コメントで残す。
+
+**Verify**: `nix develop --command uv run pytest tests/contracts/architecture/test_repository_reorganization_contract.py -q` → all pass
+
+### Step 4: 封鎖意図をコメントで固定する
+
+`generator_factory.py` の codex 分岐 raise の直前に 1 行コメントを追加:
+
+```python
+# codex は監査済み export/replies フロー専用（直接生成の実装は #<この変更の issue/PR 番号> で削除済み）
+```
+
+**Verify**: `nix develop --command uv run ruff check src` → exit 0
+
+### Step 5: CHANGELOG 追記と全体確認
+
+エントリ文面:
+
+```
+- 構築経路が封鎖済みだった CodexGenerator（comments 直接生成の codex 実装）を削除。codex provider は従来どおり --export-candidates / --agent-replies-file へ誘導
+```
+
+**Plan 033（issue #4483）が main にマージ済みの場合**（`test -d changelog.d` で判定）: `CHANGELOG.md` は編集せず、`changelog.d/4462-delete-codex-generator.removed.md` を新規作成して上の bullet を書く。未マージの場合のみ `CHANGELOG.md` の `[Unreleased]` に追記する。
+
+**Verify**: `nix develop --command uv run pytest tests/ -q` → all pass
+
+## Test plan
+
+新規テストは不要。既存の「codex provider は ConfigError で拒否される」テスト（`tests/application/comments/test_comments_replier.py` / factory テスト）が守るべき挙動の回帰テストとして機能し続ける。`test_comments_generator_factory.py:38` の `not hasattr` assert は削除後の状態と整合する。
+
+## Done criteria
+
+- [ ] `src/youtube_automation/application/comments/codex_generator.py` が存在しない
+- [ ] `git grep -n "CodexGenerator" -- src tests` のヒットが「拒否テスト・不在 assert・コメント」以外に無い
+- [ ] `nix develop --command uv run pytest tests/ -q` が exit 0
+- [ ] `nix develop --command uv run ruff check src tests` が exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] In scope 外の変更がない
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- `git grep -ln "codex_generator" src/` が自ファイル以外を返す（新しい消費者が生えた）。
+- factory / replier の codex 分岐が raise 以外に変わっている（封鎖が解除されている — この plan の前提が崩れているので、削除ではなく再設計判断が必要）。
+- Step 3 で reorganization 契約テストの構造が「mapping 1 行の削除」で済まない複雑さだった場合（例: 受け入れ済みの別 receipt との突き合わせがある）。
+
+## Maintenance notes
+
+- 将来 codex による直接生成を復活させたい場合は、git 履歴から class を戻すのではなく、**なぜ封鎖したか**（未監査自動返信の防止。監査フローは export→人手/エージェント確認→replies-file）を先に再評価すること。
+- レビューでは「拒否ガードとその検証テストが残っていること」を必ず確認する。

--- a/plans/031-remove-suno-helper-popup-remnants.md
+++ b/plans/031-remove-suno-helper-popup-remnants.md
@@ -1,0 +1,153 @@
+# Plan 031: suno-helper の廃止済み popup 残骸を物理削除し README を実態に合わせる
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step の
+> Verify コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」
+> のいずれかが発生したら改善を試みず停止して報告する。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- extensions/suno-helper/entrypoints/popup extensions/suno-helper/tests/popup-entrypoint.test.tsx extensions/suno-helper/wxt.config.ts extensions/README.md extensions/suno-helper/README.md`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: 033 (soft — CHANGELOG は fragment 方式で書く。033 が未マージの場合のみ CHANGELOG.md 直接編集に fallback)
+- **Category**: tech-debt
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4463
+
+## Why this matters
+
+suno-helper の popup は #892 で廃止され、`wxt.config.ts` の `filterEntrypoints` が build から除外している。コード上のコメントに「物理削除は後続 PR に委ねる」と明記されたまま、その後続 PR が来ないまま約 2000 PR 経過した。dead な React entry + HTML + CSS が毎 CI で typecheck / lint され、**dead code の起動だけを assert する 44 行のテスト**まで維持されている。さらに `extensions/README.md` と `extensions/suno-helper/README.md` が popup を現役サーフェスとして説明しており、新規貢献者・エージェントの mental model を汚染している。明示的に先送りされた削除を完了させる。
+
+## Current state
+
+- `extensions/suno-helper/wxt.config.ts:38-42` — 廃止の根拠と残置の経緯:
+  ```ts
+  // popup 廃止 (#892 要件5): popup entrypoint を build 対象から外し manifest の default_popup を未指定化する。
+  // これにより action クリックで chrome.action.onClicked が発火し overlay 表示を toggle できる。
+  // popup のソース (entrypoints/popup/) はファイルとして残置し、物理削除は後続 PR に委ねる (order.md スコープ外)。
+  // suno-bridge は MAIN world の fetch 観測 bridge (#948)。
+  filterEntrypoints: ["background", "content", "overlay", "suno-bridge"],
+  ```
+- 削除対象（tracked 4 ファイル）:
+  - `extensions/suno-helper/entrypoints/popup/index.html`
+  - `extensions/suno-helper/entrypoints/popup/main.tsx`（`../../components/App` を StrictMode で mount するだけの 17 行）
+  - `extensions/suno-helper/entrypoints/popup/style.css`
+  - `extensions/suno-helper/tests/popup-entrypoint.test.tsx`（`vi.mock("../components/App")` して popup main が mount することだけを検証）
+- README の stale 記述（修正対象）:
+  - `extensions/README.md:20` — `entrypoints/          # background / content / popup`
+  - `extensions/README.md:21` — `components/           # popup の React UI`
+  - `extensions/suno-helper/README.md:16` — `| `entrypoints/popup/` | popup の HTML / エントリ（React + Tailwind） |`
+  - `extensions/suno-helper/README.md:17` — `| `components/` | popup UI（`App.tsx` / ...）|`
+  - `extensions/suno-helper/README.md:24,28,101` — 本文中の「popup に理由を表示」等の記述（実際の表示先は overlay）。
+- `components/App.tsx` は overlay entrypoint から現役で使われている（**削除しない**）。`extensions/suno-helper/tests/popup-compatibility.test.ts`（4495 行）は名前に popup とあるが **App = overlay UI の behavioral テスト**であり現役（**削除しない**。rename は本 plan のスコープ外）。
+- リポジトリ規約: extensions のツールチェーンは pnpm + nix devShell（`.#extensions`）。CI は `.github/workflows/extensions.yml` の suno ジョブが `check`（ultracite）/ `compile` / `test` / `build` / `audit`（fallow）を回す。
+
+## Commands you will need
+
+すべて `extensions/suno-helper/` で実行（`nix develop .#extensions --command` プレフィックス必須。依存が無ければ最初に install）:
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Install | `nix develop .#extensions --command pnpm install --frozen-lockfile` | exit 0 |
+| Lint/format | `nix develop .#extensions --command pnpm check` | exit 0 |
+| Typecheck | `nix develop .#extensions --command pnpm compile` | exit 0 |
+| Unit tests | `nix develop .#extensions --command pnpm test` | all pass |
+| Build | `nix develop .#extensions --command pnpm build` | exit 0 |
+
+## Scope
+
+**In scope**:
+- 削除: `extensions/suno-helper/entrypoints/popup/`（3 ファイル）、`extensions/suno-helper/tests/popup-entrypoint.test.tsx`
+- 編集: `extensions/suno-helper/wxt.config.ts`（コメントのみ）、`extensions/README.md`、`extensions/suno-helper/README.md`、`CHANGELOG.md`
+
+**Out of scope**:
+- `extensions/suno-helper/components/App.tsx` と `tests/popup-compatibility.test.ts` — App は overlay の現役 UI。誤名テストの rename は別課題（第 6 回監査の未選択 finding）。
+- `filterEntrypoints` の値そのもの — `["background", "content", "overlay", "suno-bridge"]` は変更しない（popup は元から含まれていない）。
+- distrokid-helper / community-helper — popup を持ったことがない。
+
+## Git workflow
+
+- issue 専用 linked worktree 上で作業（`$REPO_ROOT/.claude/worktrees/<slug>/`）
+- Branch: `advisor/031-remove-suno-popup-remnants`
+- Commit: `chore(extensions): suno-helper の廃止済み popup ソースを物理削除 (#<issue番号>)`（1 branch 1 commit）
+- push / PR 作成はオペレーター指示があるまで行わない
+
+## Steps
+
+### Step 1: popup ソースとテストを削除する
+
+```bash
+git rm -r extensions/suno-helper/entrypoints/popup
+git rm extensions/suno-helper/tests/popup-entrypoint.test.tsx
+```
+
+**Verify**: `git ls-files extensions/suno-helper/entrypoints/` → `background.ts` / `content.ts` / overlay 系 / `suno-bridge` 系のみ（popup が無い）
+
+### Step 2: wxt.config.ts のコメントを更新する
+
+38-40 行の 3 行コメントを、現状を表す形に縮める（例）:
+
+```ts
+// popup は #892 要件5 で廃止済み（ソースも削除済み）。action クリックは chrome.action.onClicked で overlay を toggle する。
+```
+
+`filterEntrypoints` の配列は変更しない。
+
+**Verify**: `git diff extensions/suno-helper/wxt.config.ts` → コメント行のみの変更
+
+### Step 3: README 2 本を実態に合わせる
+
+- `extensions/README.md:20-21` を `entrypoints/  # background / content / overlay` / `components/  # overlay の React UI` の趣旨に修正。
+- `extensions/suno-helper/README.md:16-17` の表から `entrypoints/popup/` 行を削除し、`components/` の説明を overlay UI に修正。24 / 28 / 101 行の「popup に表示」を「overlay に表示」へ修正（機能説明は変えない。表示先の名称だけ直す）。
+
+**Verify**: `git grep -n "popup" extensions/README.md extensions/suno-helper/README.md` → 残るのは「popup は廃止済み」という説明文脈のみ（現役サーフェスとしての記述ゼロ）
+
+### Step 4: ツールチェーンを全部通す
+
+**Verify**（すべて `extensions/suno-helper/` で）:
+- `pnpm check` → exit 0
+- `pnpm compile` → exit 0
+- `pnpm test` → all pass（popup-entrypoint 分のテスト数が減る）
+- `pnpm build` → exit 0（出力 `.output/` に popup が無いこと）
+
+### Step 5: CHANGELOG 追記
+
+エントリ文面:
+
+```
+- suno-helper: #892 で廃止済みだった popup のソース残骸（entrypoints/popup/ とそのテスト）を物理削除し、README の popup 記述を overlay に更新
+```
+
+**Plan 033（issue #4483）が main にマージ済みの場合**（`test -d changelog.d` で判定）: `CHANGELOG.md` は編集せず、`changelog.d/4463-remove-suno-popup.removed.md` を新規作成して上の bullet を書く。未マージの場合のみ `CHANGELOG.md` の `[Unreleased]` に追記する。
+
+**Verify**: fragment 方式なら `test -f changelog.d/4463-remove-suno-popup.removed.md` → exit 0。直接編集なら `git diff CHANGELOG.md` → 追記のみ
+
+## Test plan
+
+新規テストは不要（build 対象外コードの削除）。`pnpm test` のグリーンと、`pnpm build` の成功（manifest に `default_popup` が無いことは既存 CI の manifest チェックが担保）で回帰確認とする。
+
+## Done criteria
+
+- [ ] `git ls-files extensions/suno-helper/entrypoints/popup/` が空
+- [ ] `extensions/suno-helper/tests/popup-entrypoint.test.tsx` が存在しない
+- [ ] README 2 本に popup を現役とする記述が無い
+- [ ] `pnpm check` / `pnpm compile` / `pnpm test` / `pnpm build` がすべて exit 0（suno-helper）
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] In scope 外の変更がない
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- `wxt.config.ts` の `filterEntrypoints` に `"popup"` が復活している（popup が再有効化された — 削除してはならない）。
+- `pnpm test` で popup 以外のテストが fail し、原因がこの削除に見えない場合（環境問題の可能性。2 回試して報告）。
+- README 修正中に、popup を前提とする**別の現役ドキュメント**（例: docs/ 配下の拡張ガイド）への波及が見つかった場合 — スコープ拡大の判断が要るので報告する。
+
+## Maintenance notes
+
+- `tests/popup-compatibility.test.ts`（4495 行）と distrokid/community の同名テストは overlay UI のテストなのに popup の名を冠したまま。次の整理候補（rename + 分割）は plans/README.md の未選択 findings に記録済み。
+- レビューでは「App.tsx / overlay 系に一切手が入っていないこと」を確認する。

--- a/plans/032-sweep-unreferenced-small-artifacts.md
+++ b/plans/032-sweep-unreferenced-small-artifacts.md
@@ -1,0 +1,191 @@
+# Plan 032: 参照ゼロの小粒残骸を一括掃除する（shim / fixture / bench / 設定ファイル）
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step は互いに
+> 独立しており、1 つが STOP になっても他は続行してよい（最後に STOP 分を報告）。
+> 各 step の Verify コマンドを実行し、期待結果を確認してから次へ進む。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- src/youtube_automation/infrastructure/legacy_utils/image_provider tests/fixtures bench/bench_real_apis.py extensions/suno-helper/.prettierignore extensions/distrokid-helper/.prettierignore extensions/.fallow-dupes-baseline.json .gitignore`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致の step は STOP（他の step は続行可）。
+
+## Status
+
+- **Priority**: P2
+- **Effort**: S
+- **Risk**: LOW
+- **Depends on**: 033 (soft — CHANGELOG は fragment 方式で書く。033 が未マージの場合のみ CHANGELOG.md 直接編集に fallback)。Plan 028-031 と競合ファイルなし・並列実行可
+- **Category**: tech-debt
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4464
+
+## Why this matters
+
+第 6 回監査（未参照ファイル特化）で見つかった、**参照ゼロが機械的に証明できる小粒の残骸** 6 群をまとめて始末する。個々は小さいが、(a) CPython の import 機構上決して実行されない 5 本の shim、(b) 廃止済み設定スキーマを「正」に見せる fixture、(c) 実行経路のない bench オーケストレータ、(d) 存在しないツール（prettier）の設定 2 本、(e) 削除済みファイルを指し続ける重複検知 baseline、(f) commit された runtime lock ファイル — はいずれも「読んだ人を誤誘導する」タイプの残骸で、放置コストが削除コストを上回る。
+
+## Current state
+
+### A. `legacy_utils/image_provider` の兄弟 shim 5 本（src — CHANGELOG 必要）
+
+- `src/youtube_automation/infrastructure/legacy_utils/image_provider/__init__.py` は canonical（`infrastructure.media.image_provider`）を import し、**末尾で 5 つのサブモジュール名を `sys.modules` に直接エイリアス登録する**:
+  ```python
+  sys.modules[f"{__name__}.composition"] = composition
+  sys.modules[f"{__name__}.config"] = config
+  sys.modules[f"{__name__}.gemini"] = gemini
+  sys.modules[f"{__name__}.openai"] = openai
+  sys.modules[f"{__name__}.prompt_schema"] = prompt_schema
+  ```
+  （この `__init__.py` は**残す**。）
+- 同ディレクトリの `composition.py` / `config.py` / `gemini.py` / `openai.py` / `prompt_schema.py` は各自 `sys.modules[__name__] = _canonical` を行う独立 shim だが、CPython はサブモジュール import 時に**親パッケージを先に import し、`sys.modules` に名前があればそれを返す**ため、親 `__init__` が上のエイリアスを張った時点でこの 5 ファイルは決して読まれない。削除対象。
+- downstream 互換契約は `tests/repo/test_skills_sync_installed_wheel.py:260-266` の `legacy_modules` タプルで、`"youtube_automation.utils.image_provider"`（**パッケージ**）だけを import する。兄弟ファイルのパスを参照するテストは無い（`git grep -n "legacy_utils/image_provider" tests/ src/` → shim 自身以外 0 件を確認済み）。
+- 注意: `tests/contracts/architecture/test_repository_reorganization_contract.py:132-133` の mapping は旧 `utils/image_provider/*` → **canonical の `infrastructure/media/image_provider/*`** を指しており、legacy shim は指していない。この削除で fail しないはず（fail したら STOP）。
+
+### B. 廃止スキーマの fixture ディレクトリ（tests のみ）
+
+- `tests/fixtures/skill_config_verify/` の 5 ファイル（`config/channel_config.json`, `config/skills/{benchmark,description,loop-video,masterup}.yaml`）。リポジトリ全体で `skill_config_verify` への参照は CHANGELOG の履歴記述 1 件のみ（`git grep -ln "skill_config_verify"` → `CHANGELOG.md` のみを確認済み）。encode している単一ファイル `channel_config.json` 形式は、現行の `config/channel/*.json` 分割形式（`examples/channel_config.example/` 参照）で置換済み。
+
+### C. commit された runtime lock ファイル（tests のみ）
+
+- `tests/fixtures/sample_channel/data/quota_costs.json.lock` — 1 byte。`infrastructure/file_lock.py` が実行時に作る類のファイルで、参照ゼロ。untrack して ignore する。
+
+### D. bench の孤児オーケストレータ（bench のみ）
+
+- `bench/bench_real_apis.py` — docstring は「通常は `bench/main.py` が呼び出す」と主張するが、`bench/main.py` は自前の `REAL_API_BENCHES` リストを持ち import しない。`bench/README.md` の同梱ベンチ表にも無い。唯一の言及は `bench/bench_strategic_analytics.py:7` の docstring（「bench_real_apis には含めず」— 削除後も文意が通るので修正不要）。
+
+### E. prettier 不在の `.prettierignore` 2 本（extensions のみ）
+
+- `extensions/suno-helper/.prettierignore` と `extensions/distrokid-helper/.prettierignore`（8 行、byte 一致）。extensions 配下のどの package.json にも `prettier` は無く、フォーマットは ultracite（Oxfmt）。community-helper（最新）は持っていない。
+- **注意**: `dashboard/` と `audio-studio/` の `.prettierrc` / `.prettierignore` は prettier を実際に使うので**触らない**。
+
+### F. fallow baseline の亡霊エントリ（extensions のみ）
+
+- `extensions/.fallow-dupes-baseline.json` の `clone_groups` 先頭 5 エントリが、#2246 の shared-ui 統合で削除済みのパスを指す:
+  - `distrokid-helper/components/ui/button.tsx|suno-helper/components/ui/button.tsx`
+  - `distrokid-helper/components/ui/card.tsx|suno-helper/components/ui/card.tsx`
+  - `distrokid-helper/entrypoints/popup/style.css|suno-helper/components/theme.css`（2 エントリ）
+  - （`suno-helper/components/theme.css` 自体の存在は Step 6 で確認すること）
+- `extensions/.fallowrc.json` は `"gate": "new-only"` + `"dupesBaseline"` でこのファイルを許容重複の定義として使う。存在しないパスのエントリは gate の判定に寄与しない亡霊。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| Python テスト | `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py tests/contracts/ -q` | all pass |
+| import 実証 | `nix develop --command uv run python -c "import youtube_automation.utils.image_provider.composition as m; print(m.__file__)"` | canonical 側のパス（`infrastructure/media/image_provider/composition.py`）が出力される |
+| Ruff | `nix develop --command uv run ruff check src tests bench` | exit 0 |
+| fallow audit | `cd extensions/suno-helper && nix develop .#extensions --command pnpm install --frozen-lockfile && nix develop .#extensions --command pnpm run audit` | exit 0 |
+
+## Scope
+
+**In scope**:
+- 削除: A の shim 5 本、B の fixture 5 本、D の `bench/bench_real_apis.py`、E の `.prettierignore` 2 本
+- untrack: C の `quota_costs.json.lock`（+ `.gitignore` に 1 行）
+- 編集: `extensions/.fallow-dupes-baseline.json`（亡霊エントリ削除）、`src/.../legacy_utils/image_provider/__init__.py`（コメント 1 行追加のみ）、`CHANGELOG.md`
+
+**Out of scope**:
+- `legacy_utils/image_provider/__init__.py` のエイリアス実装本体 — downstream 契約の生命線。
+- `dashboard/` / `audio-studio/` の prettier 設定 — 現役。
+- `bench/` の他ファイル・`bench/main.py` — 現役（bench/ 全体の去就は別判断）。
+- `examples/minimax-music-engine.example.json` — 参照ゼロだが「削除 vs README から掲載」の判断待ち（plans/README.md の未選択 findings 参照）。この plan では触らない。
+
+## Git workflow
+
+- issue 専用 linked worktree 上で作業（`$REPO_ROOT/.claude/worktrees/<slug>/`）
+- Branch: `advisor/032-sweep-unreferenced-artifacts`
+- Commit: `chore: 参照ゼロの残骸を一括削除（legacy shim / fixture / bench / prettier 設定 / fallow baseline） (#<issue番号>)`（1 branch 1 commit）
+- push / PR 作成はオペレーター指示があるまで行わない
+
+## Steps
+
+### Step 1: shim 削除前に import 実証を取る
+
+**Verify**: `nix develop --command uv run python -c "import youtube_automation.utils.image_provider.composition as m; print(m.__file__)"` → 出力パスが `infrastructure/media/image_provider/composition.py`（= 兄弟 shim は経由していない証拠）
+
+### Step 2: 兄弟 shim 5 本を削除し、エイリアスの所在をコメントで固定する
+
+```bash
+git rm src/youtube_automation/infrastructure/legacy_utils/image_provider/{composition,config,gemini,openai,prompt_schema}.py
+```
+
+`__init__.py` の `sys.modules[...]` ブロック直前に 1 行コメントを追加:
+
+```python
+# サブモジュールのエイリアスはこの __init__ に集約する（per-file shim は import 機構上実行されないため置かない）
+```
+
+**Verify**: Step 1 と同じコマンド → 同じ出力。さらに `nix develop --command uv run pytest tests/repo/test_skills_sync_installed_wheel.py tests/contracts/ -q` → all pass
+
+### Step 3: fixture と lock ファイルを始末する
+
+```bash
+git rm -r tests/fixtures/skill_config_verify
+git rm --cached tests/fixtures/sample_channel/data/quota_costs.json.lock
+```
+
+`.gitignore` の Python セクションに追記: `*.json.lock`
+
+**Verify**: `git grep -ln "skill_config_verify" -- tests src` → 0 件。`git status --porcelain | grep quota_costs` → untracked にも現れない（ignore が効いている）
+
+### Step 4: bench の孤児を削除する
+
+```bash
+git rm bench/bench_real_apis.py
+```
+
+**Verify**: `git grep -n "bench_real_apis" -- bench .github docs` → 残るのは `bench/bench_strategic_analytics.py:7` の docstring 言及のみ（文意が通るので放置可）
+
+### Step 5: prettierignore を削除する
+
+```bash
+git rm extensions/suno-helper/.prettierignore extensions/distrokid-helper/.prettierignore
+```
+
+**Verify**: `git ls-files "extensions/*/.prettierignore"` → 0 件（dashboard / audio-studio は対象外なので `git ls-files "*/.prettierignore"` に残ってよい）
+
+### Step 6: fallow baseline の亡霊エントリを除去する
+
+`extensions/.fallow-dupes-baseline.json` の `clone_groups` から、**パイプ区切りのどちらかのパスが存在しない**エントリを削除する。機械的に判定すること（各エントリの `path:lines` からパス部分を取り、`test -e extensions/<path>` で確認）。現時点で該当するのは Current state F の 5 エントリだが、必ず実測で決める。
+
+**Verify**:
+- baseline 内の全エントリのパスが `test -e` で存在する
+- `cd extensions/suno-helper && nix develop .#extensions --command pnpm run audit` → exit 0
+
+### Step 7: CHANGELOG 追記と全体確認
+
+エントリ文面（A が src を触るためゲート対象）:
+
+```
+- legacy_utils/image_provider の実行されない per-file shim 5 本を削除（エイリアスは __init__ に集約済み）。あわせて参照ゼロの fixture・bench オーケストレータ・prettier 設定・fallow baseline の亡霊エントリを掃除
+```
+
+**Plan 033（issue #4483）が main にマージ済みの場合**（`test -d changelog.d` で判定）: `CHANGELOG.md` は編集せず、`changelog.d/4464-sweep-unreferenced.removed.md` を新規作成して上の bullet を書く。未マージの場合のみ `CHANGELOG.md` の `[Unreleased]` に追記する。
+
+**Verify**: `nix develop --command uv run pytest tests/ -q` → all pass。`nix develop --command uv run ruff check src tests bench` → exit 0
+
+## Test plan
+
+新規テストは不要（全項目が削除または設定整理）。守るべき挙動は Step 1 / Step 2 の import 実証と downstream 契約テスト（`test_skills_sync_installed_wheel.py`）、および Step 6 の fallow audit グリーンで担保する。
+
+## Done criteria
+
+- [ ] A の 5 shim / B の 5 fixture / D / E の計 13 ファイルが tracked から消えている
+- [ ] `git check-ignore tests/fixtures/sample_channel/data/quota_costs.json.lock` → exit 0
+- [ ] `uv run python -c "import youtube_automation.utils.image_provider.composition"` が成功する
+- [ ] `nix develop --command uv run pytest tests/ -q` が exit 0
+- [ ] fallow baseline の全エントリのパスが実在し、`pnpm run audit` が exit 0
+- [ ] `CHANGELOG.md` の `[Unreleased]` に追記がある
+- [ ] In scope 外の変更がない
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- Step 1 の import 実証で shim 側のパスが出力される（親 `__init__` のエイリアスが変更されている — 前提崩れ）。
+- Step 2 後に `tests/contracts/architecture/test_repository_reorganization_contract.py` が fail する（mapping が legacy shim を指すよう変わっている）。
+- Step 6 で、存在しないパスのエントリを消すと fallow が**新規重複**として現存コードを報告し、その triage が必要になった場合（grandfathering の再判断はオペレーター事項）。
+- `pnpm install` が lockfile 不整合で fail（環境問題。報告）。
+
+## Maintenance notes
+
+- 今後 `legacy_utils/` に互換 shim を足すときは per-file ではなく `__init__.py` のエイリアス集約方式に従う。
+- fallow baseline は clone group 内のファイルを削除・移動したら**必ず再生成 or 手動除去**する（`extensions/CLAUDE.md` への明文化は未選択 finding として plans/README.md に記録済み）。
+- `bench/` ディレクトリ全体（perf #131 の時限計測フェーズ産、CI 非接続、`bench_strategic_analytics.py` は `time.sleep` を計測している）の去就は別判断として残っている。

--- a/plans/033-changelog-fragments.md
+++ b/plans/033-changelog-fragments.md
@@ -1,0 +1,187 @@
+# Plan 033: changelog fragment 基盤を導入し CHANGELOG の並列マージコンフリクトを解消する
+
+> **Executor instructions**: この plan を上から順に実行すること。各 step の
+> Verify コマンドを実行し、期待結果を確認してから次へ進む。「STOP conditions」
+> のいずれかが発生したら改善を試みず停止して報告する。完了したら
+> `plans/README.md` の本 plan の Status 行を更新する。
+>
+> **Drift check (最初に実行)**: `git diff --stat 0030e636..HEAD -- .github/workflows/ci.yml .github/PULL_REQUEST_TEMPLATE.md tests/repo/test_changelog_ci_contract.py .claude/settings.json .claude/skills/automation-release/ docs/changelog-contract.md docs/development.md pyproject.toml src/youtube_automation/entrypoints.py`
+> in-scope ファイルに変更があれば「Current state」の excerpt と実物を突き合わせ、
+> 不一致なら STOP。
+
+## Status
+
+- **Priority**: P1
+- **Effort**: M
+- **Risk**: MED（リリースパイプラインの契約に触れる。ただし変更は `[Unreleased]` の書き溜め方に閉じ、リリース済み section 以降の下流契約は不変）
+- **Depends on**: none（028〜032 より**先に**実行する。028〜032 は本 plan の完了後、CHANGELOG 直接編集の代わりに fragment を使う）
+- **Category**: dx
+- **Planned at**: commit `0030e636`, 2026-08-22
+- **Issue**: https://github.com/daiki-beppu/youtube-automation/issues/4483
+
+## Why this matters
+
+現行の CHANGELOG 運用は「src/ 等を触る全 PR が `CHANGELOG.md` の `[Unreleased]` 先頭に 1 行足す」設計で、並列 PR が必ず同一ファイルの同一領域を編集するため、マージのたびに conflict → rebase の直列化が起きる。takt の並列駆動と構造的に噛み合わない。towncrier 型の fragment 方式（1 PR = 1 新規ファイルを `changelog.d/` に追加、リリース時にコンパイル）に切り替えると、conflict が原理的に消える。site（リリースノート静的サイト）と下流 `/automation --update` はリリース済み version section / GitHub Release body しか読まないため影響ゼロ — 変更は `[Unreleased]` を直接見る 5 消費者（CI ゲート / 契約テスト / PR テンプレート / settings hook / automation-release 昇格手順）に閉じる。
+
+## Current state
+
+- `CHANGELOG.md` — Keep a Changelog 1.1.0 準拠。`## [Unreleased]` が常に先頭、サブセクションは `### Added / Changed / Deprecated / Removed / Fixed / Security / Migration`（契約: `docs/changelog-contract.md`）。
+- `.github/workflows/ci.yml:217-246` — `changelog` job。`skip-changelog` ラベルで免除、対象パス regex `^(src/youtube_automation/|\.claude/skills/|\.claude/CLAUDE\.template\.md$|pyproject\.toml$)` に diff が触れたら `^CHANGELOG\.md$` の diff を要求:
+  ```bash
+  if ! echo "$changed" | grep -q '^CHANGELOG\.md$'; then
+    echo "::error::CHANGELOG.md must be updated under [Unreleased]. Add an entry or apply 'skip-changelog' label."
+    exit 1
+  fi
+  ```
+- `tests/repo/test_changelog_ci_contract.py` — この job を**行単位で固定**する契約テスト。`_CHANGELOG_GATED_PATHS`（ゲート対象パスの単一ソース）、`_CHANGELOG_FILE_PATTERN = "^CHANGELOG\\.md$"`、`_EXPECTED_RUN_LINES`、エラー文言、そして **`_PR_TEMPLATE_TEXT` が `.github/PULL_REQUEST_TEMPLATE.md` と byte 一致することも assert している**。CI 側を変えたらこのテストの定数を同時に変える必要がある。
+- `.github/PULL_REQUEST_TEMPLATE.md:11-12` — チェックリスト「`CHANGELOG.md::[Unreleased]` にエントリを追加した / 免除する場合は `skip-changelog` ラベル」。
+- `.claude/settings.json:43` — PostToolUse hook がゲート対象パス編集時に「CHANGELOG.md [Unreleased] に追記すること」と stderr で注意喚起する。
+- `.claude/skills/automation-release/references/changelog-promotion.md` — prepare Phase 1-4 の `[Unreleased]` → `[VER]` 昇格手順（3 段階: 新セクション挿入 → 内容移動 → リンク参照追記）。`references/prepare-checklist.md` にチェックリストがある。
+- `docs/changelog-contract.md` — CHANGELOG / Release body の**インターフェース契約**。パース側は (1) prepare の `### Migration` warning 検証（`[Unreleased]` 配下）、(2) 下流 `/automation --update`（Release body → リリース済み section fallback）、(3) libecity digest。**(2)(3) はリリース済み section しか読まないため本 plan の影響外**。
+- `docs/development.md:275` 付近 — 品質ゲートは CI 一元担保（lefthook 廃止済み）の記述。
+- 新規 CLI の規約（`CLAUDE.md`）: `yt-*` プレフィックスで `pyproject.toml::[project.scripts]` に登録、実装は `src/youtube_automation/commands/` 配下、`entrypoints.py` の文字列 dispatch に追加、引数は `choices=` / `help=` で自己記述。既存例: `src/youtube_automation/commands/system/` 配下の `preflight.py` 等。
+- 例外は `core/errors.py` のドメイン例外を使う（生 `Exception` を catch しない）。パッケージ内 import は fully-qualified 固定。
+
+## 設計（この plan で確定済みの判断）
+
+- **fragment 置き場**: リポジトリルート `changelog.d/`。`README.md`（書き方ガイド）を常駐させ、コンパイラは `README.md` を無視する。
+- **ファイル名**: `<issue番号>-<slug>.<type>.md`。`<type>` ∈ `added | changed | fixed | removed | deprecated | security | migration`（changelog-contract のサブセクション名の小文字）。issue 番号が無い場合は PR 番号または日付 slug。例: `4460-delete-suno-prompts-fork.chore.md` は**不可**（`chore` は type に無い）→ `4460-delete-suno-prompts-fork.removed.md`。
+- **fragment の中身**: CHANGELOG に載せたい bullet 行そのもの（`- ` 始まり、複数行可、日本語・技術ログのトーン）。
+- **コンパイル**: 新 CLI `yt-changelog-compile`。動作: `changelog.d/*.md`（README 除く）を type 別に集約し、`CHANGELOG.md` の `## [Unreleased]` 配下へ契約順（Added → Changed → Deprecated → Removed → Fixed → Security → Migration）の `### <Type>` 見出しの下に追記して fragment を削除する。既存の `### <Type>` 見出しがあればそこへ追記、無ければ作る。fragment ゼロなら何もせず exit 0（冪等）。`--dry-run` で書き込みなしのプレビュー。
+- **Migration の契約は不変**: `migration` type の fragment は `### Migration` の `サマリ:` 配下 bullet としてのみ追記する。`所要時間の目安` / `local fix 衝突注意` の行は従来どおりリリース prepare 時に人手（automation-release）で整える。
+- **CI ゲートは OR 判定（後方互換）**: 「`changelog.d/` に新規ファイル追加 **または** `CHANGELOG.md` に diff」で pass。移行期間中の in-flight PR（例: plans 028〜032 起票分）を壊さない。
+- **リリースフローへの組み込み**: `/automation-release` prepare の昇格手順の**前**に `uv run yt-changelog-compile` を 1 step 追加。コンパイル後は従来手順のまま昇格するため、リリース済み section・Release body・`docs/release-notes/`・site の形は一切変わらない。
+
+## Commands you will need
+
+| Purpose | Command | Expected on success |
+|---------|---------|---------------------|
+| 単体テスト | `nix develop --command uv run pytest tests/commands/system/ tests/repo/test_changelog_ci_contract.py -q` | all pass |
+| CLI 動作確認 | `nix develop --command uv run yt-changelog-compile --dry-run` | exit 0、fragment 一覧 or 「対象なし」表示 |
+| Ruff | `nix develop --command uv run ruff check src tests` | exit 0 |
+| 契約テスト全体 | `nix develop --command uv run pytest tests/repo/ -q` | all pass |
+| workflow YAML 検証 | `nix develop --command uv run python -c "import yaml,io;yaml.safe_load(open('.github/workflows/ci.yml'))"` | exit 0 |
+
+## Scope
+
+**In scope**:
+- 新規: `changelog.d/README.md`、`src/youtube_automation/commands/system/changelog_compile.py`、`tests/commands/system/test_changelog_compile.py`
+- 編集: `pyproject.toml`（[project.scripts] に `yt-changelog-compile`）、`src/youtube_automation/entrypoints.py`（dispatch 追加）、`.github/workflows/ci.yml`（changelog job の判定）、`tests/repo/test_changelog_ci_contract.py`（定数・期待行・PR テンプレート本文）、`.github/PULL_REQUEST_TEMPLATE.md`（チェックリスト文言）、`.claude/settings.json`（hook 文言）、`.claude/skills/automation-release/references/changelog-promotion.md` と `references/prepare-checklist.md`（compile step 追加）、`docs/changelog-contract.md`（fragment 節の追加）、`docs/development.md`（ゲート説明の更新）、`changelog.d/4483-changelog-fragments.changed.md`（dogfood — 本変更自身のエントリを fragment で書く）
+
+**Out of scope**:
+- `CHANGELOG.md` のリリース済み section・リンク参照定義 — 一切触らない。
+- `docs/release-notes/` / `site/` — 影響ゼロ（リリース済み section しか読まない）。触らない。
+- `/automation --update`（下流追従）と libecity digest の抽出ロジック — Release body / リリース済み section 消費のため不変。
+- `skip-changelog` ラベルの意味・免除条件 — 変えない。
+- towncrier 等の外部ツール導入 — しない（契約書式が特殊なため自前の薄い実装。依存も増やさない）。
+
+## Git workflow
+
+- issue 専用 linked worktree 上で作業（`$REPO_ROOT/.claude/worktrees/<slug>/`）
+- Branch: `advisor/033-changelog-fragments`
+- Commit: `feat(dx): changelog fragment 基盤を導入し並列 PR の CHANGELOG conflict を解消 (#<issue番号>)`（1 branch 1 commit）
+- push / PR 作成はオペレーター指示があるまで行わない
+
+## Steps
+
+### Step 1: fragment ディレクトリと書き方ガイドを作る
+
+`changelog.d/README.md` を新規作成。内容: 上の「設計」節のファイル名規約・type 一覧・中身の書式・「リリース時に `yt-changelog-compile` が `[Unreleased]` へ集約して削除する」ことを簡潔に記す（`docs/changelog-contract.md` へのリンク付き）。
+
+**Verify**: `test -f changelog.d/README.md` → exit 0
+
+### Step 2: コンパイラ CLI を実装する
+
+`src/youtube_automation/commands/system/changelog_compile.py` を新規作成:
+
+- `main()` + argparse。`--dry-run`（書き込みなしでプレビュー）、`--changelog`（既定 `CHANGELOG.md`）、`--fragments-dir`(既定 `changelog.d`)。`help=` で自己記述。
+- 処理: fragments-dir の `*.md`（`README.md` 除外）を `<name>.<type>.md` としてパースし、type を `{added, changed, deprecated, removed, fixed, security, migration}` で検証（不正 type は `ConfigError` 系のドメイン例外で明示 fail）。type 別に本文を集約し、`## [Unreleased]` 配下の対応する `### <Type>` 見出しへ追記（見出しが無ければ契約順の位置に作る）。`migration` は `### Migration` の `サマリ:` 配下へ bullet 追記のみ。成功したら fragment ファイルを削除。fragment ゼロなら「no fragments」を表示して exit 0。
+- `pyproject.toml` の `[project.scripts]` に `yt-changelog-compile = "youtube_automation.entrypoints:yt_changelog_compile"` を追加し、`entrypoints.py` に既存エントリと同形式の dispatch 関数を追加する（既存の `yt_preflight` 等の実装形式を踏襲）。
+
+**Verify**: `nix develop --command uv run yt-changelog-compile --dry-run` → exit 0
+
+### Step 3: 単体テストを書く
+
+`tests/commands/system/test_changelog_compile.py` を新規作成（既存の `tests/commands/system/` のテストを構造の手本にする）。tmp_path に CHANGELOG と fragments を作って検証:
+
+1. added/fixed 混在の fragment 2 本 → `[Unreleased]` の正しい見出し配下に追記され fragment が消える
+2. 既存 `### Fixed` 見出しがある場合 → 重複見出しを作らず追記
+3. `migration` fragment → `### Migration` の `サマリ:` 配下にのみ追記（所要時間行を生成しない）
+4. fragment ゼロ → CHANGELOG 不変・exit 0
+5. 不正 type（`foo.chore.md`）→ ドメイン例外で fail
+6. `--dry-run` → CHANGELOG・fragment とも不変
+7. 冪等性: 2 回目の実行で変化なし
+8. `README.md` が無視される
+
+**Verify**: `nix develop --command uv run pytest tests/commands/system/test_changelog_compile.py -q` → 8 テスト pass
+
+### Step 4: CI ゲートを OR 判定へ変更する
+
+`.github/workflows/ci.yml` の changelog job の run スクリプトで、`^CHANGELOG\.md$` 単独チェックを次に置換:
+
+```bash
+if ! echo "$changed" | grep -qE '^(CHANGELOG\.md|changelog\.d/.+\.md)$'; then
+  echo "::error::Add a changelog fragment under changelog.d/ (or update CHANGELOG.md), or apply 'skip-changelog' label."
+  exit 1
+fi
+```
+
+（`changelog.d/README.md` 自体の編集もマッチするが許容 — 誤 pass の実害は無い。）
+
+**Verify**: workflow YAML 検証コマンド → exit 0
+
+### Step 5: 契約テストと PR テンプレートを同期する
+
+- `tests/repo/test_changelog_ci_contract.py`: `_CHANGELOG_FILE_PATTERN` を新 regex に、`_EXPECTED_RUN_LINES` とエラー文言 assert を Step 4 の実体に合わせて更新。`_CHANGELOG_GATED_PATHS`（対象パス）は**変えない**。
+- `.github/PULL_REQUEST_TEMPLATE.md`: チェックリスト 1 項目目を「`changelog.d/` に fragment を追加した（書き方: `changelog.d/README.md`。`CHANGELOG.md` 直接編集も可）」の趣旨に更新。
+- 同テストの `_PR_TEMPLATE_TEXT` を**新テンプレートと byte 一致**するよう更新（このテストはテンプレート全文を固定している）。
+
+**Verify**: `nix develop --command uv run pytest tests/repo/test_changelog_ci_contract.py -q` → all pass
+
+### Step 6: settings hook と automation-release 手順を更新する
+
+- `.claude/settings.json:43` の hook 文言を「`changelog.d/` に fragment（`<issue>-<slug>.<type>.md`）を追加すること（CHANGELOG.md 直接編集も可、skip-changelog で escape 可）」の趣旨へ変更（hook の構造・対象パスは変えない）。
+- `.claude/skills/automation-release/references/changelog-promotion.md`: 昇格手順の前に「Step 0: `uv run yt-changelog-compile` を実行し fragment を `[Unreleased]` へ集約する（fragment ゼロなら no-op）。実行後 `changelog.d/` に `README.md` 以外が残っていないことを確認」を追加。
+- `references/prepare-checklist.md`: 対応するチェック項目を追加。
+
+**Verify**: `nix develop --command uv run pytest tests/repo/ -q` → all pass（automation-release 系の契約テストが文言を pin している場合はここで検出される — fail したら該当テストの期待値を実文言に同期）
+
+### Step 7: ドキュメントと dogfood エントリ
+
+- `docs/changelog-contract.md`: 「fragment 運用（書き溜め方）」の節を追加 — `[Unreleased]` の実体は変わらず、書き込み経路が fragment 経由になること、パース側 3 者への影響なしを明記。
+- `docs/development.md`: 品質ゲート節の CHANGELOG 記述を fragment 前提に更新。
+- `changelog.d/4483-changelog-fragments.changed.md` を作成し、本変更自身のエントリを fragment として書く（CHANGELOG.md は直接編集しない — これが新ゲートの初回実証になる）。
+
+**Verify**:
+- `nix develop --command uv run yt-changelog-compile --dry-run` → 作った fragment 1 本がプレビューに出る（**実行はしない** — コンパイルはリリース時）
+- `nix develop --command uv run pytest tests/ -q` → all pass
+- `nix develop --command uv run ruff check src tests` → exit 0
+
+## Test plan
+
+Step 3 の単体テスト 8 本 + Step 5 の契約テスト同期が本体。既存の `tests/repo/` 全体（automation-release / skill docs 整合系の契約テスト群）のグリーンで、文言 pin の取りこぼしを検出する。site / 下流への無影響は「リリース済み section を触らない」ことが構造的保証なので、`tests/repo/test_site_repository_contract.py` を含む repo テスト全体が通れば十分。
+
+## Done criteria
+
+- [ ] `changelog.d/README.md` が存在し、`yt-changelog-compile` が pyproject / entrypoints に登録されている
+- [ ] `nix develop --command uv run yt-changelog-compile --dry-run` が exit 0
+- [ ] ci.yml の changelog job が fragment OR CHANGELOG.md の OR 判定になっている
+- [ ] `nix develop --command uv run pytest tests/ -q` が exit 0（新規 8 テスト含む）
+- [ ] `.github/PULL_REQUEST_TEMPLATE.md` と `_PR_TEMPLATE_TEXT` が byte 一致
+- [ ] 本変更自身のエントリが `changelog.d/` の fragment として存在する（CHANGELOG.md の `[Unreleased]` は未編集）
+- [ ] `CHANGELOG.md` のリリース済み section に diff が無い（`git diff CHANGELOG.md` が空）
+- [ ] In scope 外の変更がない
+- [ ] `plans/README.md` の Status 行を更新した
+
+## STOP conditions
+
+- `tests/repo/test_changelog_ci_contract.py` の構造が Current state の記述（定数群 + `_PR_TEMPLATE_TEXT` byte 一致 assert）と大きく異なる（契約の作り直しが挟まった可能性 — 前提再確認が必要）。
+- automation-release 系の契約テストが changelog-promotion.md の**手順構造そのもの**を固定していて、Step 0 追加が「期待値の同期」で済まない場合。
+- `docs/changelog-contract.md` のパース側に、`[Unreleased]` を機械パースする**第 4 の消費者**が見つかった場合（本 plan の影響範囲分析が崩れる）。
+- fragment の type 体系が Keep a Changelog のサブセクションと一致しない要求が判明した場合。
+
+## Maintenance notes
+
+- **後続の plans 028〜032**（issue #4460〜#4464）は、本 plan マージ後は CHANGELOG.md 直接編集の代わりに `changelog.d/<issue>-<slug>.<type>.md` を追加する（各 plan にその旨の条件分岐を記載済み）。これで 5 本が完全並列でマージ可能になる。
+- OR 判定（CHANGELOG.md 直接編集も pass）は移行期の互換措置。fragment 運用が定着したら、直接編集 pass を落として fragment 必須へ絞る後続変更を検討する（その際は本 plan の Step 4/5 と同じ 2 ファイル同期）。
+- レビューで見るべき点: (1) コンパイラが `[Unreleased]` **以外**の section に書き込まないこと、(2) Migration の契約必須要素（所要時間行等）を生成**しない**こと（それは prepare の人手領分）、(3) `_PR_TEMPLATE_TEXT` の byte 一致。

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,14 +1,75 @@
 # Implementation Plans
 
-このリポジトリの規約: 作業は必ず worktree 上で行う（`$REPO_ROOT/.worktrees/<slug>/`）。`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml` を触るプランは `CHANGELOG.md` の `[Unreleased]` 追記が必須（lefthook pre-push + CI ゲート）。docs / tests のみの変更はゲート対象外。
+このリポジトリの規約: 作業は必ず worktree 上で行う（`$REPO_ROOT/.claude/worktrees/<slug>/`）。`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml` を触るプランは `CHANGELOG.md` の `[Unreleased]` 追記が必須（CI ゲート。lefthook は issue #2534 で廃止済み — ローカル git hook は無い）。docs / tests のみの変更はゲート対象外。
 
 Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJECTED (with one-line rationale)
 
-## 第 6 回監査（開発並列性、2026-08-22）
+## 第 6 回監査（未参照ファイル・不要ファイル特化、2026-08-22、基準 commit `0030e636`）
 
-| Plan | Title | Priority | Effort | Depends on | Issue | Status |
-|------|-------|----------|--------|------------|-------|--------|
-| 033 | changelog fragment 基盤を導入し CHANGELOG の並列マージコンフリクトを解消 | P1 | M | — | [#4483](https://github.com/daiki-beppu/youtube-automation/issues/4483) | DONE |
+フォーカス指定 /improve（「いらないファイル、参照されていないファイルがないか監査」）。並列 4 subagent（Python 本体 / skills・.takt / docs・ルート / TypeScript 表示層）→ 全 findings を advisor が実読 vet。Python 側は AST import graph（450 モジュール全数、entrypoints の文字列 dispatch 込み）で機械的に到達可能性を判定。
+総評: **完全孤児ファイルは少数**（.takt / site / .github scripts / evals / dashboard / audio-studio はゼロ）だが、**「契約テストだけが延命させている dead code」が主要パターン**として広範に存在する（video_validator クラスタ、CodexGenerator、B3/B4 facade、skill references の test-only 契約スクリプト群、b6 receipt の 47 doc パス存在ロック）。非対話実行のため、レバレッジ上位 5 件を既定選択として plan 化した（028〜032）。
+
+### Execution order & status
+
+| Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
+|------|-------|----------|--------|------------|-------|-----|--------|
+| 033 | changelog fragment 基盤（`changelog.d/` + `yt-changelog-compile`）を導入し CHANGELOG の並列マージ conflict を解消 | P1 | M | — | [#4483](https://github.com/daiki-beppu/youtube-automation/issues/4483) | — | DONE |
+| 028 | music skill 内の stale fork `generate_suno_prompts.py`（19KB・95 行乖離・wheel 配布に混入）を削除 | P1 | S | 033 (soft) | [#4460](https://github.com/daiki-beppu/youtube-automation/issues/4460) | — | TODO |
+| 029 | 到達不能な video_validator クラスタ（446 行 + テスト 278 行）と B3 facade `domains/media/{video,audio}.py` を削除 | P1 | S | 033 (soft) | [#4461](https://github.com/daiki-beppu/youtube-automation/issues/4461) | — | TODO |
+| 030 | 構築経路が封鎖済みの CodexGenerator（未監査自動返信の footgun）を削除 | P1 | S | 033 (soft) | [#4462](https://github.com/daiki-beppu/youtube-automation/issues/4462) | — | TODO |
+| 031 | suno-helper の廃止済み popup 残骸（#892 の「後続 PR」約 2000 PR 分未着手）を物理削除し README を実態に合わせる | P1 | S | 033 (soft) | [#4463](https://github.com/daiki-beppu/youtube-automation/issues/4463) | — | TODO |
+| 032 | 参照ゼロの小粒残骸一括掃除（legacy image_provider shim ×5 / 廃止スキーマ fixture / bench_real_apis / .prettierignore ×2 / fallow baseline 亡霊 / commit 済み .lock） | P2 | S | 033 (soft) | [#4464](https://github.com/daiki-beppu/youtube-automation/issues/4464) | — | TODO |
+
+### Dependency notes
+
+- **033 はマージ済み**（オペレーター決定 2026-08-22 の「033 を最初に」を完了）。028〜032 は CHANGELOG.md 直接編集の代わりに `changelog.d/<issue>-<slug>.<type>.md` の fragment を追加する（各 plan の CHANGELOG step に条件分岐を記載済み）ため、**5 本が完全並列でマージ可能**
+- 033 の site（リリースノート静的サイト）/ 下流 `/automation --update` への影響はゼロを確認済み — site は `docs/release-notes/*.md` のみを読み（`git grep CHANGELOG site/` → 0 件）、release notes の生成契約はリリース済み version section を入力とし `[Unreleased]` を混ぜない（release-notes-authoring.md:9）。下流は GitHub Release body → リリース済み section fallback。fragment 化が変えるのは `[Unreleased]` への書き溜め経路だけ
+- 028〜032 は触るファイルが完全に非重複。並列実行可
+- 031 / 032 は extensions 側で `pnpm install` が必要（nix devShell `.#extensions`）
+
+### Findings considered and rejected（再監査不要）
+
+- **shadcn skill の `agents/openai.yml` / `evals.json` / `assets/*.png` が未参照**: by design。upstream verbatim vendoring（`skills-lock.json` の computedHash + `test_official_shadcn_skill_is_copied_without_symlinks` が保護）で、dev-only-skills のため wheel にも載らない
+- **`extensions/shared/origin.ts` の production importer ゼロ**: by design。`collection_serve.py::is_origin_allowed` の契約パリティミラーで、ファイル自身のコメントが「CORS はサーバー担保のためクライアント消費者は存在し得ない」と明記済み
+- **`src/youtube_automation/{dashboard_dist,audio_studio_dist}` の commit 済みビルド成果物**: by design。sdist force-include のための追跡で、CI（dashboard.yml / audio-studio.yml）が `pnpm build` 後の `git diff --exit-code` で鮮度を機械担保。基準 commit 時点で同期確認済み
+- **extensions の oxlint / ultracite devDependencies が 3 重定義**: 正当。各 helper のコピーは PATH 上のバイナリ提供、`extensions/package.json` は `oxlint.config.ts` の resolve 用（package.json の description に明記あり）
+- **test 専用 export ~170 シンボル（shared/dom.ts の SELECTORS 等）**: house style。セレクタ定数は変更検知契約（distrokid-helper README 161-169 行に明文化）
+- **dashboard / audio-studio 間の shadcn 5 ファイル byte 一致重複**: 統合は ADR-0013 / ADR-0028 の shared-ui import 禁止に抵触。~200 行の生成 scaffolding に新共有パッケージ + ADR 改訂は見合わない
+- **`.takt/` / `site/` / `.github/scripts/` / `evals/` の孤児疑い**: 全ファイル到達可能を確認（workflow 7 / steps 11 / facets 42 全参照、site は operatorDocMap と blume.config で全消費、.github scripts 6 本全 CI 接続、evals 12 ファイル全使用）
+- **`skills-lock.json` に first-party skill が無い**: by design。外部 vendored skill（shadcn）専用の lock で、契約テストが `set(lock["skills"]) == {"shadcn"}` を assert 済み
+- **`examples/channel_config.example/` ほか examples 14 ファイル**: 全て README / ONBOARDING / docs / tests から参照あり。孤児は minimax-music-engine.example.json のみ（下記・未選択）
+
+### 監査で plan 化を見送った残課題（ユーザー判断待ち）
+
+**削除系（判断が要るもの）**:
+- **b6 receipt の存在ロック解除 + audits raw/ 7 ファイル削除**（M、MED リスク）— `test_b6_integration_contract.py:287-290` が receipt の全 `exact_new_owner`（doc 47 パス含む）の存在を恒久 assert しており、docs/ の約 45% が削除不能。双子の `skills-operational-risk-audit/raw` は削除済み（同テスト :452 で不在 assert）なのに `skills-generalization-consistency/raw/`（中間 scratch 1,736 行）だけ残存。ロック解除が今後の docs 掃除全部の前提
+- **`docs/release-skill-update-253.md` 削除**（S）— 別リポジトリ（dotfiles）の skill 本文の手渡しコピー。参照ゼロ。dotfiles 側の反映確認後に削除
+- **`.codex/takt-open-issues-execution-notes.md`**（S、要 issue 確認）— 2026-07-14 の作業メモ（マシン固有絶対パス入り）が `test_b6_integration_contract.py:113` の legacy-27 として CI 固定されている。merge disposition の完了確認後に削除
+- **`examples/minimax-music-engine.example.json`**（S）— 参照ゼロ。削除か README/ONBOARDING への掲載 + スキーマ検証テスト追加かの二択
+- **references/ の vestigial symlink 5 本**（M、MED リスク）— `get_channel_status.py`（配布テンプレが「廃止」と明言）/ `fetch_benchmark_comments.py` / `finalize_master.py` / `compare_thumbnails.py` / `setup/generate_image.py`。契約テスト（`test_analytics_consolidation.py:91` 等）が存在を凍結しており、downstream 互換 shim か否かの意図確認が先
+- **`bench/` ディレクトリ全体の去就**（S〜M）— perf #131 時限計測フェーズ産・CI 非接続。`bench_strategic_analytics.py` は `time.sleep` を計測しており実コードを測っていない。032 は孤児 1 本のみ削除、残りは「削除 or CI smoke 接続」の判断待ち
+- **`domains/uploads/descriptions_md.py`**（S-M、MED リスク）— 現役 `load_description_document` と重複する第 2 実装。B4 契約テストが「public owner」と assert しており契約変更を伴う
+- **4 CLI（yt-ad-coverage / yt-document-review / yt-media-acceptance / yt-workspace-status）**— skill / doc / workflow から参照ゼロ。power-user 用か忘れ物かの判断待ち（keeper は SKILL.md へ配線、残りは削除）
+- **legacy_utils の未契約 shim 3 本（cli_arguments / genai_client / setup_directory_contract）**— downstream 契約リスト外。`profile` / `worktree` の削除前例に倣い「契約に載せる or removed へ」の判断待ち
+
+**修正系（stale 参照・誤名）**:
+- **ADR 7 本の stale Status 行**（S）— 0002〜0006 / 0015 / 0017 / 0018 が「`feat/ts-rewrite` で進行中」のまま（ブランチも packages/ も消滅、ADR-0021 が supersede）。`superseded by ADR-0021` へ status 修正（削除はしない）
+- **`docs/strategy/growth-gap-analysis.md:19` の消滅パス `utils/reporting_api.py`**（S）— reorganization の rename 漏れ 1 箇所
+- **popup-compatibility テスト 3 本の誤名 rename**（S）— 計 6,021 行が overlay UI のテストなのに popup 名。suno 側 4,495 行の god-file 分割は別途 L
+- **`docs/roadmap.html`**（S）— 公開向け移行アナウンスが site の配信経路（operatorDocMap / site.yml paths）に未接続。publish or delete の二択
+
+**構造系（再発防止・仕組み）**:
+- **docs/ index（`docs/README.md`）新設**（S）— 106 doc 中 41 本がどこからも到達不能（現行 wf アーキテクチャの設計記録 `2026-08-10-wf-skills-takt-migration.md` 含む）。index + 「全 doc が index に載る」契約テストで将来の orphan 化を構造的に防げる
+- **fallow audit の distrokid / community CI ジョブ展開**（S、初回 triage 必要）— dead code gate が suno の PR 時のみ実行。TS 側残骸（031 の popup 等）が生き延びた根本原因
+- **`yt-skills lint` に未参照 references ファイル検知が無い**— skills 側残骸（028 の fork 等）が蓄積する根本原因。lint への検査追加は S-M
+- **`infra/terraform/r2/` の配線**（M）— ADR-0024 のデータプレーンを provision する module が doc / skill / CI から完全孤立。同梱の `r2.tftest.hcl` は一度も実行されていない。`test_terraform_bootstrap.py` 型の parse 契約 + architecture.md からのリンクを推奨
+- **shared-ui barrel の未使用 export ~10 本 trim**（S）— ScrollBar / SelectLabel / fieldVariants / AlertDialogPortal 等は全 extension で参照ゼロ、`Label` は「export があるから存在するテスト」のみが消費
+- **skills の test-only 契約スクリプト群の配線 or 降格**（S〜M）— `validate_experiments.py`（参照完全ゼロ。双子の validate_insights は 6 箇所でゲート）/ `master-audio-review.md`（どの SKILL.md からも不到達）/ `freshness_action.py` / `persona_flow.py` / `market_research_contract.py`（いずれもテストのみが実行、skill 本文は不参照 — CI は通るが実行時に契約が効いていない）
+- **overlay bootstrap の 3 拡張重複統合**（M）— 5 ファミリ × 3 拡張がブランド定数以外同一で、import パス表記（`wxt/utils/storage` vs `@wxt-dev/storage`）の乖離が既に発生
+- **icon-assets.test.ts 3 本 byte 一致 / overlay.css 2 本 byte 一致の共通化**（S）
+- **extensions/{lint,compile}-bench.sh の docs/investigations/scripts/ への移設**（S）— 完了済み調査の再現スクリプトがツールチェーン最前列に残置
+
+**ローカル残骸（repo 外・オペレーター向けメモ、plan 不要）**: 追跡外で ignore されていないファイルはゼロ（作業ツリー健全）。gitignore/exclude 済みのローカル成果物として `utils/`（空ディレクトリ）、`dist/`、`reports/`（256KB）、`.tmp/`（7.3MB）、`execution-notes.md`、`issue-{2050,2053,2166}-implementation-spec.md` が残っており、不要なら手動削除してよい
 
 ## 第 5 回監査（セキュリティ専門監査、2026-07-21、基準 commit `37b362ce`）
 


### PR DESCRIPTION
## 概要

第 6 回監査（未参照ファイル・不要ファイル特化、2026-08-22、基準 commit `0030e636`）の記録とプラン 028〜033 を `plans/` へ追加する。

- `plans/README.md`: upstream の簡素版「第 6 回監査」セクションを詳細版へ統合。実行順テーブル（028〜033）、rejected findings、plan 化を見送った残課題、冒頭の規約行の追従（worktree 置き場 `.claude/worktrees/`、lefthook 廃止 #2534）を含む
- `plans/028〜032`: 監査で plan 化した削除系 5 本（それぞれ #4460〜#4464 に対応、Status: TODO）
- `plans/033`: changelog fragments 基盤（#4483）。マージ済みのため Status: DONE で記録

## 関連 issue

- #4460 / #4461 / #4462 / #4463 / #4464（プラン 028〜032）
- #4483（プラン 033、実装済み）

docs のみの変更のため CHANGELOG ゲート対象外（skip-changelog）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)