### PR TITLE
fix(ci): レビューコメント投稿を workflow step の upsert に決定論化する (#4539)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -63,35 +63,63 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            あなたはこの PR のマージ前レビューゲートです。コードの修正は一切行わず、
-            レビューコメントの投稿と structured output の報告だけを行ってください。
+            あなたはこの PR のマージ前レビューゲートです。コードの修正・コメント投稿は一切行わず、
+            レビュー結果を structured output で報告することだけがあなたの仕事です。
+            (PR へのコメント投稿は後続の workflow step が structured output から行います)
 
             ## 手順
             1. `gh pr view` / `gh pr diff` で PR の内容と base branch との差分を取得する
             2. PR タイトルまたは commit subject 末尾の `(#N)` から起点 issue 番号を特定し、
                `gh issue view N` で要件を読む。特定できなければ Spec 軸は「起点 issue 不明」と
-               コメントに明記して省略する
+               レポートに明記して省略する
             3. /mattpocock-skills:code-review スキルで差分を 2 軸レビューする:
                Standards(このリポジトリの規約への準拠)/ Spec(起点 issue の要件との整合)
             4. 同じ差分を simplify 観点(reuse / simplification / efficiency)でもレビューする。
-               改善提案はコメント内のコード例に留める
+               改善提案はレポート内のコード例に留める
             5. 指摘ごとに severity を付ける:
                - critical: Spec 違反(起点 issue の要件を満たさない・壊す)、明白なバグ相当
                - warning: Standards 違反(リポジトリ規約からの逸脱)
                - warning / info: simplify 系の提案(critical にはしない)
-            6. 全指摘を 1 つのコメントに集約し、severity ごとの件数サマリを冒頭に置いて
-               `gh pr comment <N> --edit-last --create-if-none --body-file <file>` で投稿する
-            7. structured output の critical_count / warning_count / info_count に、
-               コメントへ書いた件数と一致する値を報告する
+            6. structured output で結果を返す:
+               - report_markdown: 全指摘を集約した Markdown レポート。冒頭に severity ごとの
+                 件数サマリ、続けて severity 順に各指摘(対象ファイル・内容・修正案)を書く
+               - critical_count / warning_count / info_count: report_markdown に書いた
+                 件数と一致する値
 
             ## 禁止事項
             - ファイルの編集・commit・push(このワークフローには push 権限が無い)
-            - 複数コメントの投稿(1 コメントに集約し、再実行時は既存コメントを更新する)
+            - `gh pr comment` 等でのコメント投稿(投稿は workflow step の責務)
           # takt が PR を大量生成するため、コスト対策として sonnet 系を既定にする
           claude_args: |
             --model sonnet
-            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*)"
-            --json-schema '{"type":"object","properties":{"critical_count":{"type":"integer","minimum":0},"warning_count":{"type":"integer","minimum":0},"info_count":{"type":"integer","minimum":0}},"required":["critical_count","warning_count","info_count"]}'
+            --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git merge-base:*)"
+            --json-schema '{"type":"object","properties":{"report_markdown":{"type":"string"},"critical_count":{"type":"integer","minimum":0},"warning_count":{"type":"integer","minimum":0},"info_count":{"type":"integer","minimum":0}},"required":["report_markdown","critical_count","warning_count","info_count"]}'
+      - name: Post review comment
+        if: steps.review.outputs.structured_output != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -eu
+          marker='<!-- code-review-workflow -->'
+          {
+            echo "$marker"
+            echo
+            jq -r '.report_markdown' <<<"$STRUCTURED_OUTPUT"
+          } > "$RUNNER_TEMP/review-comment.md"
+          comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].id // empty")
+          if [ -n "$comment_id" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" \
+              -F "body=@$RUNNER_TEMP/review-comment.md" > /dev/null
+            echo "updated comment ${comment_id}"
+          else
+            gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+              -F "body=@$RUNNER_TEMP/review-comment.md" > /dev/null
+            echo "created a new comment"
+          fi
       - name: Fail on critical findings
         env:
           STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -83,11 +83,39 @@ def test_critical_findings_fail_the_check_via_structured_output() -> None:
 
     assert "--json-schema" in claude_args
     assert "critical_count" in claude_args
+    assert "report_markdown" in claude_args
 
     verdict = review["steps"][-1]
     assert verdict["env"] == {"STRUCTURED_OUTPUT": "${{ steps.review.outputs.structured_output }}"}
     assert "critical" in verdict["run"]
     assert "exit 1" in verdict["run"]
+
+
+def _allowed_tools(claude_args: str) -> list[str]:
+    line = next(part for part in claude_args.splitlines() if part.startswith("--allowedTools"))
+    return line.removeprefix("--allowedTools").strip().strip('"').split(",")
+
+
+def test_review_comment_is_upserted_by_a_workflow_step_not_by_claude() -> None:
+    review = _workflow()["jobs"]["review"]
+    steps = review["steps"]
+
+    # Claude にはコメント投稿系コマンドを許可しない(投稿経路は workflow step に一本化)
+    tools = _allowed_tools(_review_step(review)["with"]["claude_args"])
+    assert not [tool for tool in tools if tool.startswith("Bash(gh pr comment")]
+    assert not [tool for tool in tools if tool.startswith("Bash(gh api")]
+
+    post = next(step for step in steps if step.get("name") == "Post review comment")
+    assert post["if"] == "steps.review.outputs.structured_output != ''"
+    assert post["env"]["STRUCTURED_OUTPUT"] == "${{ steps.review.outputs.structured_output }}"
+    script = post["run"]
+    assert "<!-- code-review-workflow -->" in script
+    assert "report_markdown" in script
+    assert "PATCH" in script
+
+    # critical 判定で fail する前に、指摘本文が必ず PR へ投稿される
+    assert steps.index(post) < steps.index(steps[-1])
+    assert steps[-1]["run"].find("exit 1") != -1
 
 
 def test_review_cannot_push_to_the_pr_branch() -> None:


### PR DESCRIPTION
## Summary

PR 自動コードレビュー(#4510)で 2 回目以降のレビューコメントが投稿されない問題の修正。

- 原因: Claude に `gh pr comment --body-file` を指示しつつ Write 系ツールを許可していないため本文ファイルを作れず、代替のコマンド置換形式も allowedTools の prefix マッチで拒否されていた(permission_denials_count: 14)
- レビュー本文を `--json-schema` の `report_markdown` として受け取り、workflow の「Post review comment」step がマーカー `<!-- code-review-workflow -->` 付きコメントを `gh api` で upsert(既存あれば PATCH)する。コメントは常に 1 件に保たれ、critical 判定 step より先に必ず投稿される
- allowedTools から `Bash(gh pr comment:*)` を削除し(投稿経路を workflow step に一本化)、読み取り専用の `git status` / `git branch` / `git rev-parse` / `git merge-base` を追加
- 契約テストに upsert step とツール制約を固定

## 検証

- `uv run pytest tests/repo/test_code_review_workflow.py tests/repo/test_github_actions_pinning.py`(17 passed)
- actionlint pass / フルスイート 10006 passed
- 本 PR 自体で 2 回レビューを走らせ、コメントが 1 件のまま更新されることを確認する(受け入れ基準)

Closes #4539