### PR TITLE
ci(autofix): claude-code-action による CI 失敗の自動修正 workflow を追加する (#4533)

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -1,0 +1,162 @@
+name: CI autofix
+
+# PR をゲートする workflow の失敗を claude-code-action が診断し、修正 commit を
+# PR ブランチへ push する post-push の保険。ローカルで green にする一次経路
+# (takt の ci_verify / issue-direct の fix ループ)を置き換えるものではない
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Dashboard
+      - Extensions
+      - Audio Studio
+      - Release notes site
+    types: [completed]
+
+# GITHUB_TOKEN の push は pull_request: synchronize を発火させないため、push は
+# claude-code-action 既定の OIDC → Claude App トークン交換(id-token: write)で行う。
+# contents: read は「GITHUB_TOKEN では push できない」ことの機械担保でもある
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  actions: read
+  id-token: write
+
+# 複数ゲートが同じ commit で同時に失敗しても修正は 1 本に絞る。進行中の修正は
+# 殺さず(cancel-in-progress: false)、後続は queue され gate の head_sha 照合で skip される
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-latest
+    outputs:
+      proceed: ${{ steps.decide.outputs.proceed }}
+      pr_number: ${{ steps.decide.outputs.pr_number }}
+    steps:
+      - name: Check Claude authentication
+        id: auth
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          if [[ -n "$CLAUDE_CODE_OAUTH_TOKEN" || -n "$ANTHROPIC_API_KEY" ]]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "available=false" >> "$GITHUB_OUTPUT"
+          echo "::notice::CI autofix skipped: neither CLAUDE_CODE_OAUTH_TOKEN nor ANTHROPIC_API_KEY is configured."
+      - name: Decide fix eligibility
+        id: decide
+        if: steps.auth.outputs.available == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          set -eu
+          skip() {
+            echo "::notice::CI autofix skipped: $1"
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          }
+
+          pr="$(gh pr list --repo "$REPO" --state open --head "$HEAD_BRANCH" \
+            --json number,isDraft,labels,headRefOid --jq '.[0]')"
+          [ -n "$pr" ] || skip "no open PR for branch ${HEAD_BRANCH}"
+
+          [ "$(jq -r '.isDraft' <<<"$pr")" = "false" ] || skip "PR is draft"
+          if jq -e '.labels[] | select(.name == "skip-autofix")' <<<"$pr" >/dev/null; then
+            skip "PR has the skip-autofix label"
+          fi
+          # 失敗した commit から head が進んでいたら、新しい push の CI に判定を譲る
+          [ "$(jq -r '.headRefOid' <<<"$pr")" = "$FAILED_HEAD_SHA" ] \
+            || skip "branch moved past the failed commit"
+
+          number="$(jq -r '.number' <<<"$pr")"
+          echo "pr_number=${number}" >> "$GITHUB_OUTPUT"
+
+          # 修正試行は PR あたり 1 回。commit body の [ci-autofix] マーカーで判定し、
+          # 2 回目以降の失敗はコメント報告のみ(コスト暴走・修正ループ防止)
+          if gh pr view "$number" --repo "$REPO" --json commits \
+            --jq '.commits[].messageBody' | grep -qF '[ci-autofix]'; then
+            {
+              echo "## CI autofix"
+              echo
+              echo "⏭️ 自動修正 commit の push 後も CI が失敗しています。"
+              echo "自動修正は PR あたり 1 回までのため、以降は人間の対応が必要です。"
+              echo
+              echo "失敗した run: ${FAILED_RUN_URL}"
+            } > /tmp/autofix-limit-comment.md
+            gh pr comment "$number" --repo "$REPO" --edit-last --create-if-none \
+              --body-file /tmp/autofix-limit-comment.md
+            skip "autofix already attempted on PR #${number}"
+          fi
+
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+
+  autofix:
+    needs: gate
+    if: needs.gate.outputs.proceed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+      - name: Run Claude autofix
+        id: autofix
+        uses: anthropics/claude-code-action@4a3947e8ca609a286ab07d4d048d9ec4016798c1 # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ needs.gate.outputs.pr_number }}
+            FAILED WORKFLOW: ${{ github.event.workflow_run.name }}
+            FAILED RUN ID: ${{ github.event.workflow_run.id }}
+
+            あなたはこの PR の CI 失敗を修正する自動修正ゲートです。checkout 済みの
+            作業ツリーは PR の head ブランチです。
+
+            ## 手順
+            1. `gh run view <FAILED RUN ID> --log-failed` で失敗ログを取得し、失敗した
+               check と根本原因を特定する
+            2. `gh pr view` / `gh pr diff` で PR の変更内容と意図を把握する。PR タイトル
+               末尾の `(#N)` から起点 issue を特定できれば `gh issue view N` で要件も読む
+            3. 根本原因を修正する。症状 → 根本原因 → 同型箇所 → 修正の順で考え、
+               指摘行だけの表面的な patch にしない
+            4. 修正を 1 commit にまとめて PR ブランチへ push する
+
+            ## commit 規約
+            - 日本語 Conventional Commits + タイトル末尾に `(#N)`(起点 issue 番号。
+              不明なら PR 番号)
+            - commit body の末尾に `[ci-autofix]` の 1 行を必ず入れる(再修正防止マーカー)
+
+            ## push してはならないケース
+            次の場合は修正せず、診断コメントを
+            `gh pr comment <PR NUMBER> --body-file <file>` で投稿して正常終了する:
+            - issue の要件と CI の期待が矛盾しており、どちらが正か判断できない
+            - 失敗が PR の変更と無関係(インフラ・flaky・外部サービス起因)
+            - 修正に secret・環境設定・リポジトリ外の操作が必要
+
+            ## 禁止事項
+            - テストの削除・スキップ・期待値の書き換えで CI を黙らせること(テストが
+              間違っていることを issue の要件から示せる場合のみテストを直してよい)
+            - リポジトリの規約(CLAUDE.md)に反する修正で green にすること
+            - 複数 commit・複数回の push・force push
+            - CI 失敗と無関係な変更の混入
+          # pytest 失敗の診断・修正はレビューより難易度が高いため、
+          # sonnet 既定の code-review.yml とは別判断で opus を使う
+          claude_args: |
+            --model opus
+            --allowedTools "Edit,Write,Bash(uv run ruff:*),Bash(uv run pytest:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh run view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*)"

--- a/changelog.d/4533-ci-autofix-workflow.added.md
+++ b/changelog.d/4533-ci-autofix-workflow.added.md
@@ -1,0 +1,1 @@
+- PR ゲート CI の失敗を claude-code-action が診断して修正 commit を push する自動修正 workflow（`ci-autofix.yml`）を追加する（#4533）。

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -170,6 +170,17 @@ draft でない PR の opened / ready_for_review / synchronize で `.github/work
 - `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` がどちらも未設定の環境では fail せず skip される(evals.yml と同じ慣行)
 - 同一 PR への連続 push は進行中の run が cancel され、最新 commit のレビューだけが残る
 
+## CI 失敗の自動修正(post-push の保険)
+
+PR をゲートする 5 workflow(CI / Dashboard / Extensions / Audio Studio / Release notes site)のいずれかが PR で失敗すると、`.github/workflows/ci-autofix.yml` が `workflow_run` で発火し、claude-code-action が失敗ログを診断して修正 commit を PR ブランチへ push する。ローカルで green にする一次経路(takt の `ci_verify` / `/issue-direct` の fix ループ)はそのままに、push 後に発生した回帰への保険として重ねる。
+
+- **push は claude-code-action 既定の OIDC → Claude GitHub App トークン交換で行う**(`id-token: write`)。App トークンの push は `pull_request: synchronize` を発火させ、修正 commit の CI が自動で再検証される。code-review.yml が `contents: read` + 明示 `GITHUB_TOKEN` でレビューに閉じるのと対で、push 経路は本 workflow だけが持つ
+- **修正試行は PR あたり 1 回。** commit body の `[ci-autofix]` マーカーで判定し、2 回目以降の失敗はコメント報告のみ(コスト暴走・修正ループ防止)
+- 修正不能・修正すべきでない(仕様矛盾・flaky・インフラ起因)と判断した場合は push せず診断コメントを投稿して正常終了する
+- オプトアウトは PR に `skip-autofix` ラベルを付与する(`skip-review` と独立制御)。draft PR・fork からの PR は最初から対象外
+- `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` がどちらも未設定の環境では fail せず skip される(code-review.yml と同じ慣行)
+- モデルは opus(pytest 失敗の診断・修正はレビューより難易度が高く、sonnet 既定の code-review.yml とは別判断)
+
 ## 環境
 
 親 checkout と新規 worktree の両方で devShell に入る。direnv があれば `direnv allow` で `.envrc` を allow し、なければ `nix develop` を使う。どちらも shellHook が `uv sync` を自動実行する。非対話 shell は `nix develop --command <command>` を使う。

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -1,0 +1,151 @@
+"""CI 失敗の自動修正を post-push の保険ゲートとして安全に実行する契約。"""
+
+from __future__ import annotations
+
+import re
+
+import yaml
+
+from tests.helpers.paths import REPO_ROOT
+
+WORKFLOW_PATH = REPO_ROOT / ".github/workflows/ci-autofix.yml"
+WORKFLOWS_DIR = REPO_ROOT / ".github/workflows"
+
+# PR をゲートする workflow だけが対象(evals / release-extensions は schedule / tag トリガー)
+WATCHED_WORKFLOWS = ["CI", "Dashboard", "Extensions", "Audio Studio", "Release notes site"]
+
+_PINNED_ACTION = re.compile(r"^anthropics/claude-code-action@[0-9a-f]{40}$")
+
+
+def _workflow() -> dict[str, object]:
+    workflow = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def _triggers(workflow: dict[str, object]) -> dict[str, object]:
+    triggers = workflow.get("on", workflow.get(True))
+    assert isinstance(triggers, dict)
+    return triggers
+
+
+def _decide_step(gate_job: dict[str, object]) -> dict[str, object]:
+    return next(step for step in gate_job["steps"] if step.get("id") == "decide")
+
+
+def _autofix_step(autofix_job: dict[str, object]) -> dict[str, object]:
+    return next(step for step in autofix_job["steps"] if step.get("id") == "autofix")
+
+
+def test_autofix_fires_when_a_pr_gate_workflow_fails() -> None:
+    triggers = _triggers(_workflow())
+
+    assert set(triggers) == {"workflow_run"}
+    assert triggers["workflow_run"] == {
+        "workflows": WATCHED_WORKFLOWS,
+        "types": ["completed"],
+    }
+
+
+def test_watched_workflow_names_match_existing_workflow_files() -> None:
+    names = set()
+    for path in WORKFLOWS_DIR.glob("*.yml"):
+        definition = yaml.safe_load(path.read_text(encoding="utf-8"))
+        names.add(definition.get("name"))
+
+    # 対象 workflow の rename で autofix が黙って発火しなくなる drift を検出する
+    assert set(WATCHED_WORKFLOWS) <= names
+
+
+def test_gate_only_processes_failed_pr_runs_from_the_same_repo() -> None:
+    gate = _workflow()["jobs"]["gate"]["if"]
+
+    assert "github.event.workflow_run.conclusion == 'failure'" in gate
+    assert "github.event.workflow_run.event == 'pull_request'" in gate
+    # fork からの PR は対象外
+    assert "github.event.workflow_run.head_repository.full_name == github.repository" in gate
+
+
+def test_missing_auth_explicitly_skips_the_paid_fix() -> None:
+    gate = _workflow()["jobs"]["gate"]
+    auth_step = gate["steps"][0]
+
+    assert auth_step["env"] == {
+        "CLAUDE_CODE_OAUTH_TOKEN": "${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}",
+        "ANTHROPIC_API_KEY": "${{ secrets.ANTHROPIC_API_KEY }}",
+    }
+    auth_script = auth_step["run"]
+    assert "available=false" in auth_script
+    assert "::notice::" in auth_script
+    assert _decide_step(gate)["if"] == "steps.auth.outputs.available == 'true'"
+
+
+def test_draft_skip_label_and_stale_head_opt_out_of_the_fix() -> None:
+    workflow = _workflow()
+    decide_script = _decide_step(workflow["jobs"]["gate"])["run"]
+
+    assert "isDraft" in decide_script
+    assert "skip-autofix" in decide_script
+    # 失敗した commit から head が進んでいたら、新しい push の CI に判定を譲る
+    assert "headRefOid" in decide_script
+    assert "FAILED_HEAD_SHA" in decide_script
+
+    autofix = workflow["jobs"]["autofix"]
+    assert autofix["needs"] == "gate"
+    assert autofix["if"] == "needs.gate.outputs.proceed == 'true'"
+
+
+def test_fix_attempts_are_limited_to_one_per_pr() -> None:
+    workflow = _workflow()
+    decide_script = _decide_step(workflow["jobs"]["gate"])["run"]
+
+    # 自動修正 commit のマーカーを検出したら再修正せずコメント報告のみ
+    assert "[ci-autofix]" in decide_script
+    assert "gh pr comment" in decide_script
+
+    prompt = _autofix_step(workflow["jobs"]["autofix"])["with"]["prompt"]
+    assert "[ci-autofix]" in prompt
+
+
+def test_fix_pushes_via_app_token_to_retrigger_ci() -> None:
+    workflow = _workflow()
+
+    # GITHUB_TOKEN の push は pull_request: synchronize を発火させないため、
+    # 既定の OIDC → Claude App トークン交換(id-token: write)で push する。
+    # contents: read は「GITHUB_TOKEN では push できない」ことの機械担保でもある
+    assert workflow["permissions"] == {
+        "contents": "read",
+        "pull-requests": "write",
+        "issues": "read",
+        "actions": "read",
+        "id-token": "write",
+    }
+    for job in workflow["jobs"].values():
+        assert "permissions" not in job
+
+    step = _autofix_step(workflow["jobs"]["autofix"])
+    assert "github_token" not in step["with"]
+
+
+def test_autofix_installs_the_pinned_action_with_opus() -> None:
+    step = _autofix_step(_workflow()["jobs"]["autofix"])
+
+    assert _PINNED_ACTION.match(step["uses"])
+    assert "--model opus" in step["with"]["claude_args"]
+
+
+def test_autofix_can_edit_files_and_run_project_quality_gates() -> None:
+    claude_args = _autofix_step(_workflow()["jobs"]["autofix"])["with"]["claude_args"]
+
+    assert "Edit" in claude_args
+    assert "Write" in claude_args
+    assert "Bash(uv run ruff:*)" in claude_args
+    assert "Bash(uv run pytest:*)" in claude_args
+
+
+def test_concurrent_failures_for_one_branch_do_not_stack_fixes() -> None:
+    concurrency = _workflow()["concurrency"]
+
+    assert "github.event.workflow_run.head_branch" in concurrency["group"]
+    # 進行中の修正を途中で殺さない。2 本目以降は queue され、gate の head_sha 照合で skip される
+    assert concurrency["cancel-in-progress"] is False


### PR DESCRIPTION
## Summary

PR をゲートする 5 workflow（CI / Dashboard / Extensions / Audio Studio / Release notes site）が PR で失敗したとき、`workflow_run` で発火する `.github/workflows/ci-autofix.yml` を追加する。claude-code-action（opus）が失敗ログを取得・診断し、修正 commit を PR ブランチへ push する。code-review.yml（read-only レビュー）の姉妹ゲートとして、push 権限を本 workflow だけに閉じる。

- push は claude-code-action 既定の OIDC → Claude App トークン交換（`id-token: write`）。App トークンの push が `pull_request: synchronize` を発火させ、修正後の CI が自動で再検証される。GITHUB_TOKEN の `contents` は read のままにして「GITHUB_TOKEN では push できない」ことを機械担保
- 修正試行は PR あたり 1 回。commit body の `[ci-autofix]` マーカーで判定し、2 回目以降の失敗はコメント報告のみ
- gate job で draft PR / fork PR / `skip-autofix` ラベル / 失敗 commit から head が進んだ PR を決定的に除外し、Claude の起動前にコストを止める
- 認証 secret 未設定の環境は code-review.yml と同じく notice を出して skip（要件 7）
- 契約は `tests/repo/test_ci_autofix_workflow.py`（9 テスト）で固定。対象 workflow 名の rename drift を検出するテストを含む
- `skip-autofix` ラベルはリポジトリに作成済み
- 運用は `docs/takt-operations.md` に「CI 失敗の自動修正(post-push の保険)」として追記

## 検証

- `uv run ruff check .` exit 0
- フルテストスイート 10015 passed / 4 skipped
- 受け入れ基準のうち「実 PR で修正 commit の push → CI 再実行 → green を観測」は、`workflow_run` が default branch 上の workflow 定義でのみ発火する GitHub 仕様のため **merge 後にのみ検証可能**。merge 後の初回失敗 PR で観測する

Closes #4533

🤖 Generated with [Claude Code](https://claude.com/claude-code)