### PR TITLE
fix(ci): fragmentの影響テストをMarkdownに限定する (#4526)

### DIFF
--- a/.github/scripts/select-affected-tests.py
+++ b/.github/scripts/select-affected-tests.py
@@ -38,7 +38,7 @@ PATH_TEST_MAP: Final = (
     ),
     ("CHANGELOG.md", ("tests/repo/test_changelog_ci_contract.py",)),
     (
-        "changelog.d/",
+        "changelog.d/*.md",
         (
             "tests/commands/system/test_changelog_compile.py",
             "tests/repo/test_changelog_ci_contract.py",
@@ -94,7 +94,11 @@ def _validate_path(repository: Path, changed: str) -> bool:
 
 def _mapped_tests(changed: str) -> tuple[str, ...] | None:
     for pattern, targets in PATH_TEST_MAP:
-        if (pattern.endswith("/") and changed.startswith(pattern)) or changed == pattern:
+        if (
+            ("*" in pattern and PurePosixPath(changed).match(pattern))
+            or (pattern.endswith("/") and changed.startswith(pattern))
+            or changed == pattern
+        ):
             return targets
     return None
 

--- a/.github/scripts/select-affected-tests.py
+++ b/.github/scripts/select-affected-tests.py
@@ -27,6 +27,12 @@ FAIL_SAFE_EXACT: Final = frozenset(
     }
 )
 FAIL_SAFE_PREFIXES: Final = ("tests/helpers/", "tests/fixtures/")
+CHANGELOG_FRAGMENT_PREFIX: Final = "changelog.d/"
+CHANGELOG_FRAGMENT_SUFFIX: Final = ".md"
+CHANGELOG_FRAGMENT_TESTS: Final = (
+    "tests/commands/system/test_changelog_compile.py",
+    "tests/repo/test_changelog_ci_contract.py",
+)
 PATH_TEST_MAP: Final = (
     (".github/workflows/", ("tests/repo/test_actions_parallel_workflows.py",)),
     (
@@ -37,13 +43,6 @@ PATH_TEST_MAP: Final = (
         ),
     ),
     ("CHANGELOG.md", ("tests/repo/test_changelog_ci_contract.py",)),
-    (
-        "changelog.d/*.md",
-        (
-            "tests/commands/system/test_changelog_compile.py",
-            "tests/repo/test_changelog_ci_contract.py",
-        ),
-    ),
 )
 
 
@@ -93,12 +92,10 @@ def _validate_path(repository: Path, changed: str) -> bool:
 
 
 def _mapped_tests(changed: str) -> tuple[str, ...] | None:
+    if changed.startswith(CHANGELOG_FRAGMENT_PREFIX) and changed.endswith(CHANGELOG_FRAGMENT_SUFFIX):
+        return CHANGELOG_FRAGMENT_TESTS
     for pattern, targets in PATH_TEST_MAP:
-        if (
-            ("*" in pattern and PurePosixPath(changed).match(pattern))
-            or (pattern.endswith("/") and changed.startswith(pattern))
-            or changed == pattern
-        ):
+        if (pattern.endswith("/") and changed.startswith(pattern)) or changed == pattern:
             return targets
     return None
 

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -66,6 +66,7 @@ def _synthetic_repository(tmp_path: Path) -> Path:
     _write(repository, "CHANGELOG.md")
     _write(repository, "changelog.d/4526-example.fixed.md")
     _write(repository, "changelog.d/notes.txt")
+    _write(repository, "some/other/changelog.d/4526-example.fixed.md")
     return repository
 
 
@@ -120,6 +121,7 @@ def test_workflow_adr_changelog_and_direct_test_use_explicit_mapping(tmp_path: P
         "tests/repo/test_changelog_ci_contract.py",
     )
     assert selector.select_targets(repository, ["changelog.d/notes.txt"]) is None
+    assert selector.select_targets(repository, ["some/other/changelog.d/4526-example.fixed.md"]) is None
     assert selector.select_targets(repository, ["tests/repo/test_actions_parallel_workflows.py"]) == (
         "tests/repo/test_actions_parallel_workflows.py",
     )

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -65,6 +65,7 @@ def _synthetic_repository(tmp_path: Path) -> Path:
     _write(repository, "docs/adr/0024-example.md")
     _write(repository, "CHANGELOG.md")
     _write(repository, "changelog.d/4526-example.fixed.md")
+    _write(repository, "changelog.d/notes.txt")
     return repository
 
 
@@ -118,6 +119,7 @@ def test_workflow_adr_changelog_and_direct_test_use_explicit_mapping(tmp_path: P
         "tests/commands/system/test_changelog_compile.py",
         "tests/repo/test_changelog_ci_contract.py",
     )
+    assert selector.select_targets(repository, ["changelog.d/notes.txt"]) is None
     assert selector.select_targets(repository, ["tests/repo/test_actions_parallel_workflows.py"]) == (
         "tests/repo/test_actions_parallel_workflows.py",
     )


### PR DESCRIPTION
## Summary
- `changelog.d/*.md` を changelog compile / CI 契約テストへ明示 mapping
- 非 Markdown の fragment ディレクトリ変更は ALL fail-safe を維持

Closes #4526