### PR TITLE
feat: レビュー指摘をCI autofixの対象にする (#4550)

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -11,6 +11,7 @@ on:
       - Extensions
       - Audio Studio
       - Release notes site
+      - Code review
     types: [completed]
 
 # GITHUB_TOKEN の push は pull_request: synchronize を発火させないため、push は
@@ -32,7 +33,8 @@ concurrency:
 jobs:
   gate:
     if: >-
-      github.event.workflow_run.conclusion == 'failure' &&
+      (github.event.workflow_run.name == 'Code review' ||
+       github.event.workflow_run.conclusion == 'failure') &&
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-latest
@@ -60,8 +62,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          FAILED_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          FAILED_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SOURCE_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          SOURCE_RUN_URL: ${{ github.event.workflow_run.html_url }}
+          SOURCE_WORKFLOW: ${{ github.event.workflow_run.name }}
         run: |
           set -eu
           skip() {
@@ -79,11 +82,40 @@ jobs:
             skip "PR has the skip-autofix label"
           fi
           # 失敗した commit から head が進んでいたら、新しい push の CI に判定を譲る
-          [ "$(jq -r '.headRefOid' <<<"$pr")" = "$FAILED_HEAD_SHA" ] \
-            || skip "branch moved past the failed commit"
+          [ "$(jq -r '.headRefOid' <<<"$pr")" = "$SOURCE_HEAD_SHA" ] \
+            || skip "branch moved past the source commit"
 
           number="$(jq -r '.number' <<<"$pr")"
           echo "pr_number=${number}" >> "$GITHUB_OUTPUT"
+
+          # Code review は warning / info だけなら success になるため conclusion ではなく、
+          # marker 付き集約コメント冒頭の severity 件数で修正要否を決める。
+          if [ "$SOURCE_WORKFLOW" = "Code review" ]; then
+            if jq -e '.labels[] | select(.name == "skip-review")' <<<"$pr" >/dev/null; then
+              skip "PR has the skip-review label"
+            fi
+            marker='<!-- code-review-workflow -->'
+            review_comment="$(gh api "repos/${REPO}/issues/${number}/comments" --paginate \
+              --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].body // empty")"
+            [ -n "$review_comment" ] || skip "code review comment was not found"
+
+            # report_markdown 冒頭のサマリだけを対象にし、指摘本文に含まれる
+            # severity 名・行番号を件数と誤認しない。
+            summary="$(awk '/^---[[:space:]]*$/{exit} {print}' <<<"$review_comment")"
+            severity_count() {
+              # 表・箇条書き・太字・括弧と、3 severity を 1 行に連結する形式を
+              # 許容する。severity と件数の間は空白・記号だけに限定する。
+              grep -ioE "${1}[[:space:][:punct:]]*[0-9]+" <<<"$summary" \
+                | head -n 1 | grep -oE '[0-9]+' | head -n 1
+            }
+            critical_count="$(severity_count critical)"
+            warning_count="$(severity_count warning)"
+            info_count="$(severity_count info)"
+            [ -n "$critical_count" ] && [ -n "$warning_count" ] && [ -n "$info_count" ] \
+              || skip "code review severity summary could not be parsed"
+            [ "$((critical_count + warning_count + info_count))" -gt 0 ] \
+              || skip "code review reported no findings"
+          fi
 
           # 修正試行は PR あたり 1 回。commit body の [ci-autofix] マーカーで判定し、
           # 2 回目以降の失敗はコメント報告のみ(コスト暴走・修正ループ防止)
@@ -92,10 +124,10 @@ jobs:
             {
               echo "## CI autofix"
               echo
-              echo "⏭️ 自動修正 commit の push 後も CI が失敗しています。"
+              echo "⏭️ 自動修正 commit の push 後に、CI 失敗またはレビュー指摘が発生しています。"
               echo "自動修正は PR あたり 1 回までのため、以降は人間の対応が必要です。"
               echo
-              echo "失敗した run: ${FAILED_RUN_URL}"
+              echo "起点 run: ${SOURCE_RUN_URL}"
             } > /tmp/autofix-limit-comment.md
             gh pr comment "$number" --repo "$REPO" --edit-last --create-if-none \
               --body-file /tmp/autofix-limit-comment.md
@@ -122,19 +154,22 @@ jobs:
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ needs.gate.outputs.pr_number }}
-            FAILED WORKFLOW: ${{ github.event.workflow_run.name }}
-            FAILED RUN ID: ${{ github.event.workflow_run.id }}
+            SOURCE WORKFLOW: ${{ github.event.workflow_run.name }}
+            SOURCE RUN ID: ${{ github.event.workflow_run.id }}
 
-            あなたはこの PR の CI 失敗を修正する自動修正ゲートです。checkout 済みの
+            あなたはこの PR の CI 失敗またはコードレビュー指摘を修正する自動修正ゲートです。checkout 済みの
             作業ツリーは PR の head ブランチです。
 
             ## 手順
-            1. `gh run view <FAILED RUN ID> --log-failed` で失敗ログを取得し、失敗した
-               check と根本原因を特定する
+            1. SOURCE WORKFLOW が `Code review` の場合は、`gh api` で PR コメントから
+               `<!-- code-review-workflow -->` marker 付きの最新集約コメントを取得し、
+               critical / warning / info の全指摘を入力として扱う。それ以外の場合は
+               `gh run view <SOURCE RUN ID> --log-failed` で失敗ログを取得する
             2. `gh pr view` / `gh pr diff` で PR の変更内容と意図を把握する。PR タイトル
                末尾の `(#N)` から起点 issue を特定できれば `gh issue view N` で要件も読む
             3. 根本原因を修正する。症状 → 根本原因 → 同型箇所 → 修正の順で考え、
-               指摘行だけの表面的な patch にしない
+               指摘行だけの表面的な patch にしない。レビュー起点では全 severity の指摘を
+               修正し、一部だけ直した commit を push しない
             4. 修正を 1 commit にまとめて PR ブランチへ push する
 
             ## commit 規約
@@ -148,6 +183,8 @@ jobs:
             - issue の要件と CI の期待が矛盾しており、どちらが正か判断できない
             - 失敗が PR の変更と無関係(インフラ・flaky・外部サービス起因)
             - 修正に secret・環境設定・リポジトリ外の操作が必要
+            - レビュー指摘に同意できない、または修正すべきでないと判断した(判断理由と
+              対象指摘を診断コメントに明記する)
 
             ## 禁止事項
             - テストの削除・スキップ・期待値の書き換えで CI を黙らせること(テストが
@@ -159,4 +196,4 @@ jobs:
           # sonnet 既定の code-review.yml とは別判断で opus を使う
           claude_args: |
             --model opus
-            --allowedTools "Edit,Write,Bash(uv run ruff:*),Bash(uv run pytest:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh run view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*)"
+            --allowedTools "Edit,Write,Bash(uv run ruff:*),Bash(uv run pytest:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git add:*),Bash(git commit:*),Bash(git push:*),Bash(gh api:*),Bash(gh run view:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr comment:*),Bash(gh issue view:*)"

--- a/changelog.d/4550-review-autofix.changed.md
+++ b/changelog.d/4550-review-autofix.changed.md
@@ -1,0 +1,1 @@
+- CI autofix を critical / warning / info のレビュー指摘にも対応させ、PR ごとの通算 1 回上限内で自動修正する（#4550）。

--- a/docs/takt-operations.md
+++ b/docs/takt-operations.md
@@ -165,18 +165,18 @@ gh stack merge <stack番号|PR番号> --yes --squash
 draft でない PR の opened / ready_for_review / synchronize で `.github/workflows/code-review.yml` が発火し、claude-code-action が mattpocock code-review(Standards / Spec の 2 軸)+ simplify 観点(reuse / simplification / efficiency)で差分をレビューして severity 付きの集約コメントを投稿する。生成経路(takt / `/issue-direct` / 手動)によらず全 PR に同じゲートが効く。
 
 - **critical 指摘が 1 件以上あると `Code review` check が fail する**。warning / info のみなら success。`gh stack merge` の CI green 待ちにはこの check も含まれる
-- simplify 系の提案はコメントに載るだけで、CI が PR ブランチへ修正を push することはない(workflow は `contents: read`)
+- review workflow 自体は `contents: read` のまま指摘の生成だけを担う。集約コメントに critical / warning / info が 1 件以上あれば、後続の CI autofix が全指摘の修正を試みる
 - オプトアウトは PR に `skip-review` ラベルを付与する(誤検知が続く PR・機械生成の大量 PR 向け)。draft PR は最初から対象外
 - `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` がどちらも未設定の環境では fail せず skip される(evals.yml と同じ慣行)
 - 同一 PR への連続 push は進行中の run が cancel され、最新 commit のレビューだけが残る
 
 ## CI 失敗の自動修正(post-push の保険)
 
-PR をゲートする 5 workflow(CI / Dashboard / Extensions / Audio Studio / Release notes site)のいずれかが PR で失敗すると、`.github/workflows/ci-autofix.yml` が `workflow_run` で発火し、claude-code-action が失敗ログを診断して修正 commit を PR ブランチへ push する。ローカルで green にする一次経路(takt の `ci_verify` / `/issue-direct` の fix ループ)はそのままに、push 後に発生した回帰への保険として重ねる。
+PR をゲートする 5 workflow(CI / Dashboard / Extensions / Audio Studio / Release notes site)のいずれかが PR で失敗した場合、または `Code review` の集約コメントに critical / warning / info の指摘がある場合、`.github/workflows/ci-autofix.yml` が `workflow_run` で発火する。claude-code-action は失敗ログまたはレビューコメントを診断し、修正 commit を PR ブランチへ push する。レビューが指摘 0 件なら何もせず終了する。ローカルで green にする一次経路(takt の `ci_verify` / `/issue-direct` の fix ループ)はそのままに、push 後に発生した回帰への保険として重ねる。
 
 - **push は claude-code-action 既定の OIDC → Claude GitHub App トークン交換で行う**(`id-token: write`)。App トークンの push は `pull_request: synchronize` を発火させ、修正 commit の CI が自動で再検証される。code-review.yml が `contents: read` + 明示 `GITHUB_TOKEN` でレビューに閉じるのと対で、push 経路は本 workflow だけが持つ
-- **修正試行は PR あたり 1 回。** commit body の `[ci-autofix]` マーカーで判定し、2 回目以降の失敗はコメント報告のみ(コスト暴走・修正ループ防止)
-- 修正不能・修正すべきでない(仕様矛盾・flaky・インフラ起因)と判断した場合は push せず診断コメントを投稿して正常終了する
+- **修正試行は CI 起点・レビュー起点を通算して PR あたり 1 回。** commit body の `[ci-autofix]` マーカーで判定し、修正後の再レビューや CI で問題が残っても 2 回目以降はコメント報告のみ(コスト暴走・修正ループ防止)
+- 修正不能・修正すべきでない(仕様矛盾・flaky・インフラ起因・同意できないレビュー指摘)と判断した場合は push せず診断コメントを投稿して正常終了する
 - オプトアウトは PR に `skip-autofix` ラベルを付与する(`skip-review` と独立制御)。draft PR・fork からの PR は最初から対象外
 - `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` がどちらも未設定の環境では fail せず skip される(code-review.yml と同じ慣行)
 - モデルは opus(pytest 失敗の診断・修正はレビューより難易度が高く、sonnet 既定の code-review.yml とは別判断)

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import subprocess
 
 import yaml
 
@@ -12,7 +13,8 @@ WORKFLOW_PATH = REPO_ROOT / ".github/workflows/ci-autofix.yml"
 WORKFLOWS_DIR = REPO_ROOT / ".github/workflows"
 
 # PR をゲートする workflow だけが対象(evals / release-extensions は schedule / tag トリガー)
-WATCHED_WORKFLOWS = ["CI", "Dashboard", "Extensions", "Audio Studio", "Release notes site"]
+CI_WORKFLOWS = ["CI", "Dashboard", "Extensions", "Audio Studio", "Release notes site"]
+WATCHED_WORKFLOWS = [*CI_WORKFLOWS, "Code review"]
 
 _PINNED_ACTION = re.compile(r"^anthropics/claude-code-action@[0-9a-f]{40}$")
 
@@ -57,13 +59,108 @@ def test_watched_workflow_names_match_existing_workflow_files() -> None:
     assert set(WATCHED_WORKFLOWS) <= names
 
 
-def test_gate_only_processes_failed_pr_runs_from_the_same_repo() -> None:
+def test_gate_processes_ci_failures_and_every_completed_code_review() -> None:
     gate = _workflow()["jobs"]["gate"]["if"]
 
     assert "github.event.workflow_run.conclusion == 'failure'" in gate
+    assert "github.event.workflow_run.name == 'Code review'" in gate
     assert "github.event.workflow_run.event == 'pull_request'" in gate
     # fork からの PR は対象外
     assert "github.event.workflow_run.head_repository.full_name == github.repository" in gate
+
+
+def test_review_runs_skip_without_findings_and_supply_the_aggregate_comment() -> None:
+    workflow = _workflow()
+    gate = workflow["jobs"]["gate"]
+    decide = _decide_step(gate)
+
+    assert decide["env"]["SOURCE_WORKFLOW"] == "${{ github.event.workflow_run.name }}"
+    assert "<!-- code-review-workflow -->" in decide["run"]
+    assert "critical_count" in decide["run"]
+    assert "warning_count" in decide["run"]
+    assert "info_count" in decide["run"]
+    assert "${1}[[:space:][:punct:]]*[0-9]+" in decide["run"]
+    assert "][0].body" in decide["run"]
+    assert "skip-review" in decide["run"]
+    assert "awk '/^---[[:space:]]*$/{exit}" in decide["run"]
+    assert 'skip "code review reported no findings"' in decide["run"]
+
+    prompt = _autofix_step(workflow["jobs"]["autofix"])["with"]["prompt"]
+    assert "critical / warning / info" in prompt
+    assert "<!-- code-review-workflow -->" in prompt
+    assert "同意できない" in prompt
+    assert "SOURCE WORKFLOW" in prompt
+    assert "FAILED WORKFLOW" not in prompt
+
+
+def test_review_severity_parser_accepts_real_comment_formats_without_matching_prose() -> None:
+    summary = """\
+| critical | 1 |
+- **Critical**: 2
+**Critical:** 3
+- Critical: **4**
+- Critical (5 件)
+- **critical: 6件** / **warning: 7件** / **info: 8件**
+critical_path.py:42
+The critical finding is on line 99.
+"""
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "grep -ioE 'critical[[:space:][:punct:]]*[0-9]+' | grep -oE '[0-9]+'",
+        ],
+        input=summary,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.splitlines() == ["1", "2", "3", "4", "5", "6"]
+
+    for severity, expected in (("warning", "7"), ("info", "8")):
+        result = subprocess.run(
+            [
+                "bash",
+                "-c",
+                f"grep -ioE '{severity}[[:space:][:punct:]]*[0-9]+' | grep -oE '[0-9]+'",
+            ],
+            input=summary,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result.stdout.strip() == expected
+
+
+def test_review_severity_parser_ignores_finding_details_after_summary_boundary() -> None:
+    comment = """\
+<!-- code-review-workflow -->
+## Summary
+- critical: 0
+- warning: 1
+- info: 0
+---
+### critical: line 42
+The detailed finding mentions warning: 99.
+"""
+
+    result = subprocess.run(
+        [
+            "bash",
+            "-c",
+            "awk '/^---[[:space:]]*$/{exit} {print}' "
+            "| grep -ioE 'critical[[:space:][:punct:]]*[0-9]+' "
+            "| head -n 1 | grep -oE '[0-9]+' | head -n 1",
+        ],
+        input=comment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.stdout.strip() == "0"
 
 
 def test_missing_auth_explicitly_skips_the_paid_fix() -> None:
@@ -88,7 +185,7 @@ def test_draft_skip_label_and_stale_head_opt_out_of_the_fix() -> None:
     assert "skip-autofix" in decide_script
     # 失敗した commit から head が進んでいたら、新しい push の CI に判定を譲る
     assert "headRefOid" in decide_script
-    assert "FAILED_HEAD_SHA" in decide_script
+    assert "SOURCE_HEAD_SHA" in decide_script
 
     autofix = workflow["jobs"]["autofix"]
     assert autofix["needs"] == "gate"


### PR DESCRIPTION
## Summary
- Code review の completed run を severity 件数に基づいて autofix へ接続
- critical / warning / info の全指摘を修正し、修正不能時は診断コメントを投稿
- CI 起点とレビュー起点を通算した PR ごとの 1 回上限を維持

Closes #4550