### PR TITLE
fix(wf-next): 対話承認をcanonical attemptへ保持する (#4495)

### DIFF
--- a/.claude/skills/wf-new/references/wf-auto-state.py
+++ b/.claude/skills/wf-new/references/wf-auto-state.py
@@ -74,6 +74,12 @@ class Decision(TypedDict):
     reason: str
     resume_action: str | None
     allow_external_publish: bool
+    allow_duration_outside_target: bool
+
+
+class AttemptContext(TypedDict):
+    external_publish: bool
+    duration_outside_target: bool
 
 
 class TimingSegment(TypedDict):
@@ -484,6 +490,7 @@ def _decision(
         "reason": reason,
         "resume_action": resume_action,
         "allow_external_publish": config.allow_external_publish,
+        "allow_duration_outside_target": False,
     }
 
 
@@ -867,7 +874,12 @@ def acquire_lease(root: Path, *, now: float, ttl_seconds: int) -> str:
         raise ValueError("ttl_seconds は正の整数でなければなりません")
     # CLI 引数でオプションと誤認される `-` を含まない表現にする。
     token = secrets.token_hex(24)
-    payload = {"token": token, "acquired_at": now, "expires_at": now + ttl_seconds}
+    payload = {
+        "token": token,
+        "acquired_at": now,
+        "expires_at": now + ttl_seconds,
+        "context": {"external_publish": False, "duration_outside_target": False},
+    }
     with _lease_mutex(root) as state_dir:
         lock_dir = state_dir / LEASE_DIR_NAME
         lease_path = lock_dir / LEASE_FILE_NAME
@@ -958,6 +970,68 @@ def _owns_lease(root: Path, token: str) -> bool:
             and not isinstance(expires_at, bool)
             and expires_at > time.time()
         )
+
+
+def _attempt_context(lease: dict) -> AttemptContext:
+    context = lease.get("context", {})
+    if not isinstance(context, dict):
+        raise ValueError("lease context は object でなければなりません")
+    external_publish = context.get("external_publish", False)
+    duration_outside_target = context.get("duration_outside_target", False)
+    if not isinstance(external_publish, bool) or not isinstance(duration_outside_target, bool):
+        raise ValueError("lease context の approval は boolean でなければなりません")
+    return {
+        "external_publish": external_publish,
+        "duration_outside_target": duration_outside_target,
+    }
+
+
+def _owned_lease(state_dir: Path, token: str) -> tuple[Path, dict]:
+    lease_path = state_dir / LEASE_DIR_NAME / LEASE_FILE_NAME
+    try:
+        lease = _read_object(lease_path)
+    except ValueError as exc:
+        raise LeaseBusyError("attempt context を管理する lease がありません") from exc
+    expires_at = lease.get("expires_at")
+    if (
+        not secrets.compare_digest(str(lease.get("token", "")), token)
+        or not isinstance(expires_at, (int, float))
+        or isinstance(expires_at, bool)
+        or expires_at <= time.time()
+    ):
+        raise LeaseBusyError("attempt context を管理する lease token の owner ではありません")
+    return lease_path, lease
+
+
+def read_attempt_context(root: Path, token: str) -> AttemptContext:
+    with _lease_mutex(root) as state_dir:
+        _, lease = _owned_lease(state_dir, token)
+        return _attempt_context(lease)
+
+
+def approve_attempt(root: Path, token: str, approval: str) -> AttemptContext:
+    keys = {
+        "external-publish": "external_publish",
+        "duration-outside-target": "duration_outside_target",
+    }
+    try:
+        key = keys[approval]
+    except KeyError as exc:
+        raise ValueError(f"未知の approval です: {approval}") from exc
+    with _lease_mutex(root) as state_dir:
+        lease_path, lease = _owned_lease(state_dir, token)
+        context = _attempt_context(lease)
+        context[key] = True
+        lease["context"] = context
+        descriptor, temporary_name = tempfile.mkstemp(prefix=".lease-json.", dir=lease_path.parent)
+        os.close(descriptor)
+        temporary = Path(temporary_name)
+        try:
+            temporary.write_text(json.dumps(lease, ensure_ascii=False) + "\n", encoding="utf-8")
+            os.replace(temporary, lease_path)
+        finally:
+            temporary.unlink(missing_ok=True)
+        return context
 
 
 def record_attempt(
@@ -1064,9 +1138,20 @@ def resolve_action(
     *,
     config: RunnerConfig | None = None,
     executor: Literal["local", "cloud"] | None = None,
+    token: str | None = None,
 ) -> Decision:
     """Return the next delegated action without mutating workflow state."""
     resolved_config = config or _load_runner_config(root)
+    context: AttemptContext = {"external_publish": False, "duration_outside_target": False}
+    if token is not None:
+        context = read_attempt_context(root, token)
+        if context["external_publish"]:
+            resolved_config = RunnerConfig(
+                allow_external_publish=True,
+                post_publish_configured=resolved_config.post_publish_configured,
+                skip_audio_approval=resolved_config.skip_audio_approval,
+                skip_upload_approval=resolved_config.skip_upload_approval,
+            )
     try:
         collection = select_collection(root, requested)
     except NoActiveCollectionError:
@@ -1080,8 +1165,11 @@ def resolve_action(
             "reason": "no_active_collection",
             "resume_action": "wf-new",
             "allow_external_publish": resolved_config.allow_external_publish,
+            "allow_duration_outside_target": context["duration_outside_target"],
         }
-    return evaluate_collection(root, collection, resolved_config, executor=executor)
+    decision = evaluate_collection(root, collection, resolved_config, executor=executor)
+    decision["allow_duration_outside_target"] = context["duration_outside_target"]
+    return decision
 
 
 def record_bootstrap_attempt(
@@ -1128,6 +1216,11 @@ def _parser() -> argparse.ArgumentParser:
     plan.add_argument("--channel-dir", type=Path, default=Path.cwd())
     plan.add_argument("--collection")
     plan.add_argument("--executor", choices=("local", "cloud"))
+    plan.add_argument("--token")
+    approve = sub.add_parser("approve")
+    approve.add_argument("--channel-dir", type=Path, default=Path.cwd())
+    approve.add_argument("--token", required=True)
+    approve.add_argument("--approval", choices=("external-publish", "duration-outside-target"), required=True)
     record = sub.add_parser("record")
     record.add_argument("--channel-dir", type=Path, default=Path.cwd())
     record.add_argument("--token", required=True)
@@ -1166,7 +1259,9 @@ def main(argv: list[str] | None = None) -> int:
         elif args.command == "release":
             result = {"status": "released" if release_lease(root, args.token) else "not-owner"}
         elif args.command == "plan":
-            result = resolve_action(root, args.collection, executor=args.executor)
+            result = resolve_action(root, args.collection, executor=args.executor, token=args.token)
+        elif args.command == "approve":
+            result = {"status": "approved", "context": approve_attempt(root, args.token, args.approval)}
         elif args.command == "record-bootstrap":
             recorded_at = datetime.now(UTC).isoformat()
             record_bootstrap_attempt(

--- a/.claude/skills/wf-next/SKILL.md
+++ b/.claude/skills/wf-next/SKILL.md
@@ -117,12 +117,19 @@ uv run yt-workflow-state --collection "$COLLECTION_DIR" touch
 ```bash
 STATE_SCRIPT=.claude/skills/wf-new/references/wf-auto-state.py
 uv run python "$STATE_SCRIPT" acquire --channel-dir .
-uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name>
+uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name> --token <token>
 uv run python "$STATE_SCRIPT" heartbeat --channel-dir . --token <token>
 uv run python -c 'from datetime import UTC, datetime; print(datetime.now(UTC).isoformat())'
 ```
 
-`acquire` の `busy` / exit 20 では作業を開始しない。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した固定 collection と action を `<resolver-action>` としてそのまま使い、公開許可や実成果物から action を独自再判定せず、別 action へ読み替えない。別 collection ID や timing 保存処理も作らない。
+`acquire` の `busy` / exit 20 では作業を開始しない。`plan` には必ず同じ `<token>` を渡す。`plan` 後は `heartbeat` の JSON 応答が `status: refreshed` の場合だけ lease owner の確認成功として AI 開始時刻を取得し、stdout を同じ attempt 専用の `<current-attempt-ai-started-at>` として保持する。`status: not-owner` も exit 0 で返るため、exit 0 だけでは owner と判定しない。`status: not-owner` では開始時刻を取得せず停止する。resolver が返した固定 collection と action を `<resolver-action>` としてそのまま使い、公開許可や実成果物から action を独自再判定せず、別 action へ読み替えない。別 collection ID や timing 保存処理も作らない。
+
+resolver が `blocked / external_publish_disabled` を返した対話実行では、公開範囲と API write を明示してユーザー承認を取る。承認時は record / release せず、owner token で `approve --approval external-publish` を実行し、同じ token・collection で `plan` を再実行する。これにより durable な `workflow.scheduled_automation.allow_external_publish` は変更せず、同じ canonical attempt が `publish_ready` へ進む。却下時だけ blocked を記録して release する。
+
+```bash
+uv run python "$STATE_SCRIPT" approve --channel-dir . --token <token> --approval external-publish
+uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name> --token <token>
+```
 
 resolver action と直接入口の既存責務は次の対応を正とする。
 
@@ -141,7 +148,7 @@ resolver action と直接入口の既存責務は次の対応を正とする。
 uv run python "$STATE_SCRIPT" record --channel-dir . --token <token> --collection <fixed-name> --action <resolver-action> --status success|blocked|failed --reason <reason> [--resume-action <resolver-resume-action>] --ai-started-at <current-attempt-ai-started-at> [--human-interval <human-start> <human-end>]...
 ```
 
-status を記録した後は、成功時だけでなく blocked / failed の停止報告前にも同じ固定 collection を `plan --channel-dir . --collection <fixed-name>` で再評価し、次回の再開 action を推測しない。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。
+status を記録した後は、成功時だけでなく blocked / failed の停止報告前にも同じ固定 collection を `plan --channel-dir . --collection <fixed-name> --token <token>` で再評価し、次回の再開 action を推測しない。全終了経路の `finally` 相当で `release --channel-dir . --token <token>` を実行し、他 token の lease は変更しない。ただし上記の対話承認待ちはまだ終了経路ではなく、承認を attempt context に保存して再 plan するまで record / release しない。
 
 `/wf-new --auto` が token、resolver の action / collection、attempt の開始時刻を固定して本 skill へ委譲した場合は、その実行文脈を再利用する。nested `acquire` や独自 attempt の作成・記録・release は行わず、成果物と state の検証結果を呼び出し元へ返し、canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ行わせる。
 
@@ -227,6 +234,13 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
 
 以下を一気通貫実行する。実作業は subagent、成果物検証と各ステップ完了時の `workflow-state.json` 更新はメインが担当し、途中で中断しても同じ状態から再開できる。
 
+0. `01-master/<assets.master_audio>` を ffprobe し、`config.audio.target_duration_min` / `target_duration_max` と比較する。この確認は全尺動画を生成する Agent 1 の起動前に行う。目標外なら実尺と目標尺を提示して AskUserQuestion で例外承認を取り、承認時は owner token に保存して再 plan する。却下時は動画を生成せず blocked で終了する。
+
+   ```bash
+   uv run python "$STATE_SCRIPT" approve --channel-dir . --token <token> --approval duration-outside-target
+   uv run python "$STATE_SCRIPT" plan --channel-dir . --collection <fixed-name> --token <token>
+   ```
+
 1. **並列 A**（2 Agent 同時起動）:
    - Agent 1: 対象 collection、`01-master/<assets.master_audio>`、`10-assets/main.png/jpg` または `loop.mp4` を入力に Skill `/video --generate` の Subagent Contract を実行。thumbnail skill-config も渡し、`textless.enabled: false` の共有 `main.jpg` を textless 再生成へ戻さない。期待成果物は `01-master/*.mp4`。返却には同じ生成実行で解決した背景経路、effect、overlay、Full output outlookを含める
    - Agent 2 の起動前に、メインが `/video --describe` の重複トラック名を検出し、必要な表示名 mapping を確定するが、まだ `apply_track_display_names()` は呼ばない。その mapping、planning / localization、skill-config、benchmark 入力を列挙し、Agent 2 には `/video --describe` の Step 1 から品質チェック、`yt-title-duplicate-check`、検証済み `20-documentation/descriptions.json` + 同 basename HTML 保存までを実行させる。`apply_track_display_names()` と `workflow-state.json` の `assets.description` 更新は実行させない
@@ -239,7 +253,8 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
      uv run yt-workflow-state --collection "$COLLECTION_DIR" set-phase publishing
      ```
 3. **アップロード承認ゲート 3-B（`skip_upload_approval = false` のとき）**:
-   - 並列 A 完了直後、ユーザーに公開方法を提示する前に必ず `uv run yt-upload-collection --plan [-c <collection-name>]` を実行し、`config/schedule_config.json` / `config/channel/youtube.json` を反映した実際の公開タイミングを確定する
+   - 並列 A 完了直後、ユーザーに公開方法を提示する前に必ず `uv run yt-upload-collection --plan [-c <collection-name>] [--allow-duration-outside-target]` を実行し、`config/schedule_config.json` / `config/channel/youtube.json` を反映した実際の公開タイミングを確定する
+   - resolver の `allow_duration_outside_target` が true の場合は、アップロード承認ゲートの plan に `--allow-duration-outside-target` を渡す。false の場合は渡さない。会話上の承認だけからフラグを組み立てず、owner 管理の attempt context を正とする
    - plan 結果が `📅 公開設定: 非公開でアップロード（即時公開は行いません）` の場合は、予約設定または YouTube Studio での手動公開を案内する。`📅 公開設定: 限定公開 (unlisted)` / `📅 公開設定: 非公開 (private)` が出た場合は、その公開範囲でアップロードされることを AskUserQuestion の文面に含める。`📅 公開予定: <日時>` が出た場合は「今アップロード → `<日時>` に自動で一般公開」と、実際の予約時刻を AskUserQuestion の文面に含める
    - `/publish --upload` を呼ぶ前に AskUserQuestion で「YouTube にアップロード + live 移行してよいか」を確認する。このとき、plan 結果に基づく公開タイミングまたは公開範囲（非公開アップロード / 限定公開 / 非公開 / 予約公開日時）を必ず明示する
    - 承認されたら次ステップへ進む。却下されたら `phase` を `mastered` のままにして停止し、ガイダンス「準備が整ったら `/wf-next` を再実行してください」を表示
@@ -252,8 +267,9 @@ status を記録した後は、成功時だけでなく blocked / failed の停�
    - これは YouTube 上の playlist 作成と `playlist_id` 書き戻しが目的。初回動画の追加は次の `/publish --upload` 内部の自動 assign (`assign_video()`) に任せる
    - `config/channel/playlists.json` が無い、または全 playlist に `playlist_id` がある場合はスキップ
 5. **順次**: Agent ツールで subagent を起動し、対象 collection、動画、thumbnail、description を明示して Skill `/publish --upload` の Subagent Contract の `plan` / preflight だけを実行させる。state / tracking 更新と実アップロードは実行させない
+   - resolver の `allow_duration_outside_target` が true の場合は、subagent の plan / preflight とメインの実 CLI の両方へ `--allow-duration-outside-target` を渡す。false の場合は渡さない。会話上の承認だけからフラグを組み立てず、owner 管理の attempt context を正とする
    - メインが完了報告の動画・メタデータパスと plan 結果を実ファイルおよび Step 3 の承認済み公開条件と突合する。不整合なら state を更新せず停止する
-   - PASS 後、メインが `uv run yt-upload-collection [-c <collection-name>]`（release 型は `uv run yt-upload-auto`）を実行する。実 CLI が upload tracking、state 更新、collection 型の planning → live 移行を一体で行うため、メインは同じ変更を手作業で重ねない
+   - PASS 後、メインが `uv run yt-upload-collection [-c <collection-name>] [--allow-duration-outside-target]`（release 型は `uv run yt-upload-auto`）を実行する。実 CLI が upload tracking、state 更新、collection 型の planning → live 移行を一体で行うため、メインは同じ変更を手作業で重ねない
    - 実行後、メインが `20-documentation/upload_tracking.json`、対象動画、移動先 collection の state に記録された `upload.video_id` / `upload.video_url`、`stage: "live"`、`phase: "complete"` を検証する。いずれかが欠落・不整合なら完了扱いにしない
 
 #### `publishing` → リカバリ（途中エラー再実行）

--- a/changelog.d/4495-canonical-approval-attempt.fixed.md
+++ b/changelog.d/4495-canonical-approval-attempt.fixed.md
@@ -1,0 +1,1 @@
+`/wf-next` の一回限りの外部公開・目標尺外承認を lease owner の canonical attempt context に保持し、同じ resolver / upload 経路へ伝播できるようにした。

--- a/tests/repo/test_wf_auto_state.py
+++ b/tests/repo/test_wf_auto_state.py
@@ -86,6 +86,7 @@ def test_no_active_collection_starts_wf_new_without_fabricating_state(tmp_path: 
         "reason": "no_active_collection",
         "resume_action": "wf-new",
         "allow_external_publish": False,
+        "allow_duration_outside_target": False,
     }
     assert not (tmp_path / "collections").exists()
 
@@ -1124,3 +1125,44 @@ def test_cli_rejects_invalid_bootstrap_human_intervals_without_mutating_history(
     assert runner.main(argv) == 2
     assert message in json.loads(capsys.readouterr().out)["reason"]
     assert history_path.read_text(encoding="utf-8") == original
+
+
+def test_attempt_approval_replans_publish_without_changing_durable_config(tmp_path: Path, runner: ModuleType) -> None:
+    collection = _collection(
+        tmp_path,
+        "20260721-approved-publish",
+        phase="publishing",
+        assets={
+            "raw_master": "master.wav",
+            "master_audio": "master.wav",
+            "master_video": "video.mp4",
+            "description": True,
+        },
+    )
+    (collection / "01-master" / "master.wav").touch()
+    (collection / "01-master" / "video.mp4").touch()
+    write_video_description_pair(collection / "20-documentation")
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+
+    before_approval = runner.resolve_action(tmp_path, collection.name, config=_config(runner))
+    assert before_approval["reason"] == "external_publish_disabled"
+    runner.approve_attempt(tmp_path, token, "external-publish")
+    decision = runner.resolve_action(tmp_path, collection.name, config=_config(runner), token=token)
+
+    assert decision["action"] == "wf-next"
+    assert decision["reason"] == "publish_ready"
+    assert decision["allow_external_publish"] is True
+    assert decision["allow_duration_outside_target"] is False
+    assert _config(runner).allow_external_publish is False
+
+
+def test_attempt_approval_is_owner_scoped_and_duration_is_propagated(tmp_path: Path, runner: ModuleType) -> None:
+    token = runner.acquire_lease(tmp_path, now=time.time(), ttl_seconds=60)
+
+    with pytest.raises(runner.LeaseBusyError, match="owner"):
+        runner.approve_attempt(tmp_path, "not-owner", "duration-outside-target")
+
+    runner.approve_attempt(tmp_path, token, "duration-outside-target")
+    context = runner.read_attempt_context(tmp_path, token)
+
+    assert context == {"external_publish": False, "duration_outside_target": True}

--- a/tests/repo/test_wf_next_timing_skill_contract.py
+++ b/tests/repo/test_wf_next_timing_skill_contract.py
@@ -103,3 +103,14 @@ def test_delegation_reuses_one_lease_attempt_and_history_record() -> None:
     assert "canonical history の記録と lease 解放は `/wf-new --auto` に一度だけ" in direct
     assert "release --channel-dir . --token <token>" in direct
     assert "他 token" in direct
+
+
+def test_upload_plan_propagates_the_canonical_duration_approval() -> None:
+    text = WF_NEXT_SKILL.read_text(encoding="utf-8")
+    publishing = _section(text, "#### `mastered` → 公開フロー（アップロード承認ゲートあり）")
+    approval_gate = publishing[publishing.index("3. **アップロード承認ゲート") :]
+
+    plan_command = "uv run yt-upload-collection --plan [-c <collection-name>] [--allow-duration-outside-target]"
+    assert plan_command in approval_gate
+    assert "resolver の `allow_duration_outside_target` が true の場合" in approval_gate
+    assert "アップロード承認ゲートの plan に `--allow-duration-outside-target`" in approval_gate


### PR DESCRIPTION
## Summary
- lease owner に限定した一回限りの外部公開・尺例外承認 context を追加
- 同一 token で再 plan し、承認済み尺例外を upload preflight と実 CLI へ伝播
- canonical attempt に承認結果を保持する契約をテストで固定

Closes #4495