### PR TITLE
fix(wf-new): 構造化persona chainを正規判定する (#4509)

### DIFF
--- a/.claude/skills/wf-new/references/freshness-rules.md
+++ b/.claude/skills/wf-new/references/freshness-rules.md
@@ -23,7 +23,7 @@ analytics mode の前提スキルは **(analyze ∥ benchmark) → channel-strat
 - `/channel-strategy --persona` は最新ベンチマークのタグデータと `/channel-research --voice` を入力に暫定 `persona-definition.json` pair を作る
 - `/channel-strategy --persona` は暫定 persona から `/channel-strategy --scene` を実行し、その結果を反映して最終 `persona-definition.json` pair を更新する
 
-**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** persona と scene の各 JSON+HTML pair を独立に分類する（mtime 比較なし）。両 pair が fully present なら canonical validator で相互参照を確認する。各 pair の JSON/HTML 片側欠落、fully present だが schema・digest・document_type が不正、scene だけ fully present、または両 pair の参照不整合は fail-closed で停止する。両文書が未生成、または producer の暫定正規状態として persona pair だけが検証済みで scene pair が未生成なら既存の mode 別 fallback に委ねる。旧 Markdown は入力にしない。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
+**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** persona と scene の各 JSON+HTML pair を独立に分類する（mtime 比較なし）。両 pair が fully present なら canonical validator で相互参照を確認する。analytics mode では、各 pair の JSON/HTML 片側欠落、fully present だが schema・digest・document_type が不正、scene だけ fully present、または両 pair の参照不整合を成果物無変更の fail-closed で停止する。benchmark fallback / minimal mode では同じ partial / invalid 状態を警告し、`PERSONA_CHAIN_VALID=false` のまま既存の初回仮説 fallback へ委ねる。両文書が未生成、または producer の暫定正規状態として persona pair だけが検証済みで scene pair が未生成なら全 mode で既存の mode 別 fallback に委ねる。旧 Markdown は入力にしない。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
 
 検証済み analytics JSON+HTML が存在しない場合は stale ではなく、以下の入力モードに分岐する。JSON または HTML の候補が存在する場合は `.claude/skills/analytics/references/analysis-json-validator.md` の validator 成功を analytics mode の Hard Gate とする。片方不在、ファイル名日付不一致、schema/pair不一致、validator の exit 非 0 は fallback せず Phase 1 を中断し、`/analytics --analyze` の再実行を案内する:
 
@@ -196,26 +196,34 @@ if [ -e "$SCENE_JSON" ] && [ -e "$SCENE_HTML" ]; then SCENE_PAIR=full
 elif [ -e "$SCENE_JSON" ] || [ -e "$SCENE_HTML" ]; then SCENE_PAIR=partial
 fi
 
+persona_chain_invalid() {
+  if [ "$INPUT_MODE" = "analytics mode" ]; then
+    echo "persona chain 検証失敗 → $1。成果物を変更せず /channel-strategy --persona の再実行を案内"
+    exit 1
+  fi
+  echo "persona chain 警告 → $1。$INPUT_MODE の初回仮説 fallback へ委譲"
+  PERSONA_CHAIN_VALID=false
+}
+
 if [ "$PERSONA_PAIR" = "partial" ] || [ "$SCENE_PAIR" = "partial" ] || { [ "$PERSONA_PAIR" = "absent" ] && [ "$SCENE_PAIR" = "full" ]; }; then
-  echo "persona chain 検証失敗 → pair 状態が不完全なため、成果物を変更せず /channel-strategy --persona の再実行を案内"
-  exit 1
+  persona_chain_invalid "pair 状態が不完全"
 elif [ "$PERSONA_PAIR" = "full" ] && [ "$SCENE_PAIR" = "full" ]; then
   if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py \
     --persona-json "$PERSONA_JSON" \
     --scene-json "$SCENE_JSON"
   then
-    echo "persona chain 検証失敗 → 成果物を変更せず /channel-strategy --persona の再実行を案内"
-    exit 1
+    persona_chain_invalid "canonical pair が不正"
+  else
+    echo "検証済み canonical persona chain を使用"
+    PERSONA_CHAIN_VALID=true
   fi
-  echo "検証済み canonical persona chain を使用"
-  PERSONA_CHAIN_VALID=true
 elif [ "$PERSONA_PAIR" = "full" ]; then
   if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py --persona-json "$PERSONA_JSON"; then
-    echo "persona chain 検証失敗 → 暫定 persona pair が不正なため、成果物を変更せず /channel-strategy --persona の再実行を案内"
-    exit 1
+    persona_chain_invalid "暫定 persona pair が不正"
+  else
+    echo "検証済み暫定 persona pair・scene 未生成 → mode 別 fallback に委譲"
+    PERSONA_CHAIN_VALID=false
   fi
-  echo "検証済み暫定 persona pair・scene 未生成 → mode 別 fallback に委譲"
-  PERSONA_CHAIN_VALID=false
 else
   PERSONA_CHAIN_VALID=false
 fi

--- a/.claude/skills/wf-new/references/freshness-rules.md
+++ b/.claude/skills/wf-new/references/freshness-rules.md
@@ -20,10 +20,10 @@ skill 呼び出し失敗または再検証失敗時は、失敗した skill ま�
 analytics mode の前提スキルは **(analyze ∥ benchmark) → channel-strategy persona finalization** の構造:
 
 - `/analytics --analyze` と `/channel-research --benchmark` は**独立・並列**（両者とも生データの分析で上下関係なし）
-- `/channel-strategy --persona` は最新ベンチマークのタグデータと `/channel-research --voice` を入力に暫定 `persona-definition.md` を作る
-- `/channel-strategy --persona` は暫定 persona から `/channel-strategy --scene` を実行し、その結果を反映して最終 `persona-definition.md` を更新する
+- `/channel-strategy --persona` は最新ベンチマークのタグデータと `/channel-research --voice` を入力に暫定 `persona-definition.json` pair を作る
+- `/channel-strategy --persona` は暫定 persona から `/channel-strategy --scene` を実行し、その結果を反映して最終 `persona-definition.json` pair を更新する
 
-**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** `persona-definition.md` / `viewing-scene-matrix.md` は存在チェックのみ（mtime 比較なし。更新タイミングは戦略判断のため人間が決める）。analytics mode でこれらが未生成の場合、`ttp_mode: false` は Phase 1 を中断し、`true` は共通の欲求語彙選択規則による fallback で続行する。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
+**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** `persona-definition.json` / `viewing-scene-matrix.json` は `RepositorySchema.CHANNEL_STRATEGY` の JSON+HTML pair として検証し、相互参照も確認する（mtime 比較なし）。候補が片側欠落・schema 不正・HTML digest 不一致・参照不整合なら fail-closed で停止する。両文書が未生成の場合、analytics mode の `ttp_mode: false` は Phase 1 を中断し、`true` は共通の欲求語彙選択規則による fallback で続行する。旧 Markdown は入力にしない。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
 
 検証済み analytics JSON+HTML が存在しない場合は stale ではなく、以下の入力モードに分岐する。JSON または HTML の候補が存在する場合は `.claude/skills/analytics/references/analysis-json-validator.md` の validator 成功を analytics mode の Hard Gate とする。片方不在、ファイル名日付不一致、schema/pair不一致、validator の exit 非 0 は fallback せず Phase 1 を中断し、`/analytics --analyze` の再実行を案内する:
 
@@ -39,8 +39,8 @@ analytics mode の前提スキルは **(analyze ∥ benchmark) → channel-strat
 |---|---|---|---|---|
 | 1a | `/analytics --analyze` | 同じファイル名日付の `reports/analysis_*.json` + `.html` | 先に schema/pair validator が exit 0 であること。次のいずれかを満たせば stale（OR 結合）: (1) **相対比較** — 最新 `data/analytics_data_*.json` のファイル名日付 (YYYYMMDD) より古い / (2) **絶対鮮度** — 最新 `data/analytics_data_*.json` のファイル名日付が実行日 (today) から `config/skills/collection-ideate.yaml` の `freshness_days`（既定 7 日）を超えて経過 | 検証済み pair 不在は benchmark fallback mode / minimal mode へ分岐する。片方だけ存在、不正、または validator 失敗は停止。相対 stale は `/analytics --analyze`、絶対 stale は `/analytics --collect` → `/analytics --analyze` を自動実行し、再検証成功時だけ続行する |
 | 1b | `/channel-research --benchmark` | 検証済み `docs/benchmarks/benchmark-report.json` + `.html` と `data/benchmark_YYYYMMDD.json` | analytics mode では pair の古い方の mtime が `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より古ければ stale | analytics mode では `/channel-research --benchmark` を Skill ツールで実行（内部で鮮度チェック + 差分更新）。benchmark fallback mode では検証済み JSON を読む。minimal mode は `ttp_mode: false` ならスキップし、`true` なら `/channel-research --benchmark` を案内して停止する |
-| 2 | `/channel-strategy --persona` | `docs/channel/personas/persona-definition.md` | 存在すれば OK（mtime 比較なし。更新タイミングは戦略判断のため人間が決める） | analytics mode かつ `ttp_mode: false` ではユーザーに `/channel-strategy --persona` 実行を案内して中断。analytics mode かつ `true` では `.claude/skills/channel-strategy/references/desire-vocabulary.md` の fallback に従い、利用可能な競合コメント / タイトルから初回仮説の視聴者像を作ってソースと根拠を記録する。benchmark fallback mode / `ttp_mode: false` の minimal mode では config と入力データから初回仮説の視聴者像を作る。`ttp_mode: true` の minimal mode はこの判定前に停止する |
-| 3 | `/channel-strategy --persona` finalization | `docs/plans/viewing-scene-matrix.md` | 存在すれば OK（mtime 比較なし。persona 下流のため連動して判断） | analytics mode かつ `ttp_mode: false` ではユーザーに `/channel-strategy --persona` で `/channel-strategy --scene` 実行と最終 `persona-definition.md` 更新を行うよう案内して中断。analytics mode かつ `true` では同じ fallback の競合コメント / タイトルから視聴シーンを仮説化し、利用可能な根拠がなければ `判定不能` として続行する。benchmark fallback mode / `ttp_mode: false` の minimal mode では仮説ペルソナから視聴シーンを仮説化する。`ttp_mode: true` の minimal mode はこの判定前に停止する |
+| 2 | `/channel-strategy --persona` | `docs/channel/personas/persona-definition.json` + `.html` | `read_published_json_document(..., RepositorySchema.CHANNEL_STRATEGY)` 相当で検証（mtime 比較なし） | pair 未生成時の mode 別 fallback は従来どおり。候補の片側欠落・schema/pair 不正は停止 |
+| 3 | `/channel-strategy --persona` finalization | `docs/plans/viewing-scene-matrix.json` + `.html` | 同じ canonical reader で検証し、scene の `persona_id`、persona の `scene_ids` と scene ID の相互参照を確認 | pair 未生成時の mode 別 fallback は従来どおり。pair/参照不正は成果物を変更せず停止 |
 
 ## workflow-state.json との同期
 
@@ -182,8 +182,34 @@ case "$INPUT_MODE" in
     ;;
 esac
 
-# 2. persona — 存在チェックのみ
-if [ ! -f docs/channel/personas/persona-definition.md ]; then
+# 2-3. canonical persona chain — JSON+HTML pair と参照整合性を検証
+PERSONA_JSON=docs/channel/personas/persona-definition.json
+SCENE_JSON=docs/plans/viewing-scene-matrix.json
+if [ -e "$PERSONA_JSON" ] || [ -e "${PERSONA_JSON%.json}.html" ] || [ -e "$SCENE_JSON" ] || [ -e "${SCENE_JSON%.json}.html" ]; then
+  if ! "${PYTHON:-python}" - <<'PY'
+from pathlib import Path
+
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
+from youtube_automation.infrastructure.documents.publishing import read_published_json_document
+
+persona = read_published_json_document(Path("docs/channel/personas/persona-definition.json"), RepositorySchema.CHANNEL_STRATEGY)
+scene = read_published_json_document(Path("docs/plans/viewing-scene-matrix.json"), RepositorySchema.CHANNEL_STRATEGY)
+persona_id = persona["persona"]["id"]
+scene_ids = {item["id"] for item in scene["scenes"]}
+if scene["persona_id"] != persona_id or not set(persona["scene_ids"]).issubset(scene_ids):
+    raise ValueError("persona/scene の参照が一致しません")
+PY
+  then
+    echo "persona chain 検証失敗 → 成果物を変更せず /channel-strategy --persona の再実行を案内"
+    exit 1
+  fi
+  echo "検証済み canonical persona chain を使用"
+  PERSONA_CHAIN_VALID=true
+else
+  PERSONA_CHAIN_VALID=false
+fi
+
+if [ "$PERSONA_CHAIN_VALID" != "true" ]; then
   if [ "$INPUT_MODE" = "analytics mode" ] && [ "$COLLECTION_IDEATE_TTP_MODE" = "false" ]; then
     echo "persona 未定義 → /wf-new 企画工程中断、/channel-strategy --persona を案内"
     exit 1
@@ -194,10 +220,10 @@ if [ ! -f docs/channel/personas/persona-definition.md ]; then
   fi
 fi
 
-# 3. viewing-scene reflection — 存在チェックのみ
-if [ ! -f docs/plans/viewing-scene-matrix.md ]; then
+# 3. viewing-scene reflection — canonical chain 未生成時の fallback
+if [ "$PERSONA_CHAIN_VALID" != "true" ]; then
   if [ "$INPUT_MODE" = "analytics mode" ] && [ "$COLLECTION_IDEATE_TTP_MODE" = "false" ]; then
-    echo "viewing-scene 未定義 → /wf-new 企画工程中断、/channel-strategy --persona で /channel-strategy --scene 実行と最終 persona-definition.md 更新を案内"
+    echo "viewing-scene 未定義 → /wf-new 企画工程中断、/channel-strategy --persona で /channel-strategy --scene 実行と最終 persona-definition.json pair 更新を案内"
     exit 1
   elif [ "$INPUT_MODE" = "analytics mode" ]; then
     echo "viewing-scene 未定義かつ ttp_mode=true → 共通 fallback の競合コメント / タイトルから視聴シーンを仮説化して続行（根拠がなければ判定不能）"
@@ -217,10 +243,10 @@ fi
 | 検証済み `reports/analysis_*.json` が最新 `data/analytics_data_*.json` より古い日付 | `/analytics --analyze` を自動実行し、再検証成功時だけ企画フローを続行 |
 | analytics mode で最新 `data/analytics_data_*.json` のファイル名日付が実行日 (today) から `config/skills/collection-ideate.yaml` の `freshness_days`（既定 7 日）を超えて経過（絶対鮮度、#1427） | `/analytics --collect` → `/analytics --analyze` の順で自動実行し、再検証成功時だけ企画フローを続行 |
 | analytics mode で `data/benchmark_*.json` が `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より古い | `/channel-research --benchmark` を Skill ツールで自動実行 |
-| analytics mode で `persona-definition.md` が存在しない | `ttp_mode: false` は `/wf-new` を中断し、`/channel-strategy --persona` の先行実行を案内する。`true` は共通の欲求語彙選択規則に従い、利用可能な競合コメント / タイトルから初回仮説の視聴者像を作り、ソースと根拠を明記して続行する |
-| benchmark fallback mode / minimal mode で `persona-definition.md` が存在しない | benchmark fallback mode と `ttp_mode: false` の minimal mode は中断せず、config と入力データから初回仮説の視聴者像を作る。`ttp_mode: true` の minimal mode はこの判定前に停止する |
-| analytics mode で `viewing-scene-matrix.md` が存在しない | `ttp_mode: false` は `/wf-new` を中断し、`/channel-strategy --persona` で `/channel-strategy --scene` 実行と最終 `persona-definition.md` 更新を行うよう案内する。`true` は共通 fallback から視聴シーンを仮説化し、利用可能な根拠がなければ `判定不能` として続行する |
-| benchmark fallback mode / minimal mode で `viewing-scene-matrix.md` が存在しない | benchmark fallback mode と `ttp_mode: false` の minimal mode は中断せず、仮説ペルソナから視聴シーンを仮説化する。`ttp_mode: true` の minimal mode はこの判定前に停止する |
+| analytics mode で `persona-definition.json pair` が存在しない | `ttp_mode: false` は `/wf-new` を中断し、`/channel-strategy --persona` の先行実行を案内する。`true` は共通の欲求語彙選択規則に従い、利用可能な競合コメント / タイトルから初回仮説の視聴者像を作り、ソースと根拠を明記して続行する |
+| benchmark fallback mode / minimal mode で `persona-definition.json pair` が存在しない | benchmark fallback mode と `ttp_mode: false` の minimal mode は中断せず、config と入力データから初回仮説の視聴者像を作る。`ttp_mode: true` の minimal mode はこの判定前に停止する |
+| analytics mode で `viewing-scene-matrix.json pair` が存在しない | `ttp_mode: false` は `/wf-new` を中断し、`/channel-strategy --persona` で `/channel-strategy --scene` 実行と最終 `persona-definition.json pair` 更新を行うよう案内する。`true` は共通 fallback から視聴シーンを仮説化し、利用可能な根拠がなければ `判定不能` として続行する |
+| benchmark fallback mode / minimal mode で `viewing-scene-matrix.json pair` が存在しない | benchmark fallback mode と `ttp_mode: false` の minimal mode は中断せず、仮説ペルソナから視聴シーンを仮説化する。`ttp_mode: true` の minimal mode はこの判定前に停止する |
 
 ## 関連
 

--- a/.claude/skills/wf-new/references/freshness-rules.md
+++ b/.claude/skills/wf-new/references/freshness-rules.md
@@ -186,19 +186,9 @@ esac
 PERSONA_JSON=docs/channel/personas/persona-definition.json
 SCENE_JSON=docs/plans/viewing-scene-matrix.json
 if [ -e "$PERSONA_JSON" ] || [ -e "${PERSONA_JSON%.json}.html" ] || [ -e "$SCENE_JSON" ] || [ -e "${SCENE_JSON%.json}.html" ]; then
-  if ! "${PYTHON:-python}" - <<'PY'
-from pathlib import Path
-
-from youtube_automation.domains.documents.schema_registry import RepositorySchema
-from youtube_automation.infrastructure.documents.publishing import read_published_json_document
-
-persona = read_published_json_document(Path("docs/channel/personas/persona-definition.json"), RepositorySchema.CHANNEL_STRATEGY)
-scene = read_published_json_document(Path("docs/plans/viewing-scene-matrix.json"), RepositorySchema.CHANNEL_STRATEGY)
-persona_id = persona["persona"]["id"]
-scene_ids = {item["id"] for item in scene["scenes"]}
-if scene["persona_id"] != persona_id or not set(persona["scene_ids"]).issubset(scene_ids):
-    raise ValueError("persona/scene の参照が一致しません")
-PY
+  if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py \
+    --persona-json "$PERSONA_JSON" \
+    --scene-json "$SCENE_JSON"
   then
     echo "persona chain 検証失敗 → 成果物を変更せず /channel-strategy --persona の再実行を案内"
     exit 1

--- a/.claude/skills/wf-new/references/freshness-rules.md
+++ b/.claude/skills/wf-new/references/freshness-rules.md
@@ -189,6 +189,8 @@ SCENE_JSON=docs/plans/viewing-scene-matrix.json
 SCENE_HTML=${SCENE_JSON%.json}.html
 PERSONA_PAIR=absent
 SCENE_PAIR=absent
+PERSONA_PAIR_READY=false
+CHAIN_READY=false
 if [ -e "$PERSONA_JSON" ] && [ -e "$PERSONA_HTML" ]; then PERSONA_PAIR=full
 elif [ -e "$PERSONA_JSON" ] || [ -e "$PERSONA_HTML" ]; then PERSONA_PAIR=partial
 fi
@@ -202,7 +204,6 @@ persona_chain_invalid() {
     exit 1
   fi
   echo "persona chain 警告 → $1。$INPUT_MODE の初回仮説 fallback へ委譲"
-  PERSONA_CHAIN_VALID=false
 }
 
 if [ "$PERSONA_PAIR" = "partial" ] || [ "$SCENE_PAIR" = "partial" ] || { [ "$PERSONA_PAIR" = "absent" ] && [ "$SCENE_PAIR" = "full" ]; }; then
@@ -215,20 +216,19 @@ elif [ "$PERSONA_PAIR" = "full" ] && [ "$SCENE_PAIR" = "full" ]; then
     persona_chain_invalid "canonical pair が不正"
   else
     echo "検証済み canonical persona chain を使用"
-    PERSONA_CHAIN_VALID=true
+    PERSONA_PAIR_READY=true
+    CHAIN_READY=true
   fi
 elif [ "$PERSONA_PAIR" = "full" ]; then
   if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py --persona-json "$PERSONA_JSON"; then
     persona_chain_invalid "暫定 persona pair が不正"
   else
     echo "検証済み暫定 persona pair・scene 未生成 → mode 別 fallback に委譲"
-    PERSONA_CHAIN_VALID=false
+    PERSONA_PAIR_READY=true
   fi
-else
-  PERSONA_CHAIN_VALID=false
 fi
 
-if [ "$PERSONA_CHAIN_VALID" != "true" ]; then
+if [ "$PERSONA_PAIR_READY" != "true" ]; then
   if [ "$INPUT_MODE" = "analytics mode" ] && [ "$COLLECTION_IDEATE_TTP_MODE" = "false" ]; then
     echo "persona 未定義 → /wf-new 企画工程中断、/channel-strategy --persona を案内"
     exit 1
@@ -240,7 +240,7 @@ if [ "$PERSONA_CHAIN_VALID" != "true" ]; then
 fi
 
 # 3. viewing-scene reflection — canonical chain 未生成時の fallback
-if [ "$PERSONA_CHAIN_VALID" != "true" ]; then
+if [ "$CHAIN_READY" != "true" ]; then
   if [ "$INPUT_MODE" = "analytics mode" ] && [ "$COLLECTION_IDEATE_TTP_MODE" = "false" ]; then
     echo "viewing-scene 未定義 → /wf-new 企画工程中断、/channel-strategy --persona で /channel-strategy --scene 実行と最終 persona-definition.json pair 更新を案内"
     exit 1

--- a/.claude/skills/wf-new/references/freshness-rules.md
+++ b/.claude/skills/wf-new/references/freshness-rules.md
@@ -23,7 +23,7 @@ analytics mode の前提スキルは **(analyze ∥ benchmark) → channel-strat
 - `/channel-strategy --persona` は最新ベンチマークのタグデータと `/channel-research --voice` を入力に暫定 `persona-definition.json` pair を作る
 - `/channel-strategy --persona` は暫定 persona から `/channel-strategy --scene` を実行し、その結果を反映して最終 `persona-definition.json` pair を更新する
 
-**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** `persona-definition.json` / `viewing-scene-matrix.json` は `RepositorySchema.CHANNEL_STRATEGY` の JSON+HTML pair として検証し、相互参照も確認する（mtime 比較なし）。候補が片側欠落・schema 不正・HTML digest 不一致・参照不整合なら fail-closed で停止する。両文書が未生成の場合、analytics mode の `ttp_mode: false` は Phase 1 を中断し、`true` は共通の欲求語彙選択規則による fallback で続行する。旧 Markdown は入力にしない。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
+**analyze / benchmark は並列判定。その後 `/channel-strategy --persona` の最終 persona chain を判定する。** persona と scene の各 JSON+HTML pair を独立に分類する（mtime 比較なし）。両 pair が fully present なら canonical validator で相互参照を確認する。各 pair の JSON/HTML 片側欠落、fully present だが schema・digest・document_type が不正、scene だけ fully present、または両 pair の参照不整合は fail-closed で停止する。両文書が未生成、または producer の暫定正規状態として persona pair だけが検証済みで scene pair が未生成なら既存の mode 別 fallback に委ねる。旧 Markdown は入力にしない。stale report は `ttp_mode` にかかわらず、自動更新と再検証の成功時だけ続行する。
 
 検証済み analytics JSON+HTML が存在しない場合は stale ではなく、以下の入力モードに分岐する。JSON または HTML の候補が存在する場合は `.claude/skills/analytics/references/analysis-json-validator.md` の validator 成功を analytics mode の Hard Gate とする。片方不在、ファイル名日付不一致、schema/pair不一致、validator の exit 非 0 は fallback せず Phase 1 を中断し、`/analytics --analyze` の再実行を案内する:
 
@@ -40,7 +40,7 @@ analytics mode の前提スキルは **(analyze ∥ benchmark) → channel-strat
 | 1a | `/analytics --analyze` | 同じファイル名日付の `reports/analysis_*.json` + `.html` | 先に schema/pair validator が exit 0 であること。次のいずれかを満たせば stale（OR 結合）: (1) **相対比較** — 最新 `data/analytics_data_*.json` のファイル名日付 (YYYYMMDD) より古い / (2) **絶対鮮度** — 最新 `data/analytics_data_*.json` のファイル名日付が実行日 (today) から `config/skills/collection-ideate.yaml` の `freshness_days`（既定 7 日）を超えて経過 | 検証済み pair 不在は benchmark fallback mode / minimal mode へ分岐する。片方だけ存在、不正、または validator 失敗は停止。相対 stale は `/analytics --analyze`、絶対 stale は `/analytics --collect` → `/analytics --analyze` を自動実行し、再検証成功時だけ続行する |
 | 1b | `/channel-research --benchmark` | 検証済み `docs/benchmarks/benchmark-report.json` + `.html` と `data/benchmark_YYYYMMDD.json` | analytics mode では pair の古い方の mtime が `config/skills/benchmark.yaml` の `freshness_days`（既定 3 日）より古ければ stale | analytics mode では `/channel-research --benchmark` を Skill ツールで実行（内部で鮮度チェック + 差分更新）。benchmark fallback mode では検証済み JSON を読む。minimal mode は `ttp_mode: false` ならスキップし、`true` なら `/channel-research --benchmark` を案内して停止する |
 | 2 | `/channel-strategy --persona` | `docs/channel/personas/persona-definition.json` + `.html` | `read_published_json_document(..., RepositorySchema.CHANNEL_STRATEGY)` 相当で検証（mtime 比較なし） | pair 未生成時の mode 別 fallback は従来どおり。候補の片側欠落・schema/pair 不正は停止 |
-| 3 | `/channel-strategy --persona` finalization | `docs/plans/viewing-scene-matrix.json` + `.html` | 同じ canonical reader で検証し、scene の `persona_id`、persona の `scene_ids` と scene ID の相互参照を確認 | pair 未生成時の mode 別 fallback は従来どおり。pair/参照不正は成果物を変更せず停止 |
+| 3 | `/channel-strategy --persona` finalization | `docs/plans/viewing-scene-matrix.json` + `.html` | 同じ canonical reader で検証し、scene の `persona_id` と、producer と共有する参照 contract（persona の `scene_ids` は scene ID の正当な subset）を確認。完成 chain では両 ID 集合を非空とする | persona pair が正常で scene pair が未生成なら mode 別 fallback。各 pair の片側欠落、scene pair だけ存在、pair/参照不正は成果物を変更せず停止 |
 
 ## workflow-state.json との同期
 
@@ -184,8 +184,22 @@ esac
 
 # 2-3. canonical persona chain — JSON+HTML pair と参照整合性を検証
 PERSONA_JSON=docs/channel/personas/persona-definition.json
+PERSONA_HTML=${PERSONA_JSON%.json}.html
 SCENE_JSON=docs/plans/viewing-scene-matrix.json
-if [ -e "$PERSONA_JSON" ] || [ -e "${PERSONA_JSON%.json}.html" ] || [ -e "$SCENE_JSON" ] || [ -e "${SCENE_JSON%.json}.html" ]; then
+SCENE_HTML=${SCENE_JSON%.json}.html
+PERSONA_PAIR=absent
+SCENE_PAIR=absent
+if [ -e "$PERSONA_JSON" ] && [ -e "$PERSONA_HTML" ]; then PERSONA_PAIR=full
+elif [ -e "$PERSONA_JSON" ] || [ -e "$PERSONA_HTML" ]; then PERSONA_PAIR=partial
+fi
+if [ -e "$SCENE_JSON" ] && [ -e "$SCENE_HTML" ]; then SCENE_PAIR=full
+elif [ -e "$SCENE_JSON" ] || [ -e "$SCENE_HTML" ]; then SCENE_PAIR=partial
+fi
+
+if [ "$PERSONA_PAIR" = "partial" ] || [ "$SCENE_PAIR" = "partial" ] || { [ "$PERSONA_PAIR" = "absent" ] && [ "$SCENE_PAIR" = "full" ]; }; then
+  echo "persona chain 検証失敗 → pair 状態が不完全なため、成果物を変更せず /channel-strategy --persona の再実行を案内"
+  exit 1
+elif [ "$PERSONA_PAIR" = "full" ] && [ "$SCENE_PAIR" = "full" ]; then
   if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py \
     --persona-json "$PERSONA_JSON" \
     --scene-json "$SCENE_JSON"
@@ -195,6 +209,13 @@ if [ -e "$PERSONA_JSON" ] || [ -e "${PERSONA_JSON%.json}.html" ] || [ -e "$SCENE
   fi
   echo "検証済み canonical persona chain を使用"
   PERSONA_CHAIN_VALID=true
+elif [ "$PERSONA_PAIR" = "full" ]; then
+  if ! uv run python .claude/skills/wf-new/references/validate_persona_chain.py --persona-json "$PERSONA_JSON"; then
+    echo "persona chain 検証失敗 → 暫定 persona pair が不正なため、成果物を変更せず /channel-strategy --persona の再実行を案内"
+    exit 1
+  fi
+  echo "検証済み暫定 persona pair・scene 未生成 → mode 別 fallback に委譲"
+  PERSONA_CHAIN_VALID=false
 else
   PERSONA_CHAIN_VALID=false
 fi

--- a/.claude/skills/wf-new/references/ideate.md
+++ b/.claude/skills/wf-new/references/ideate.md
@@ -6,7 +6,7 @@
 
 企画候補を `collection-plan-documents.md` に従いコレクションの検証済み `20-documentation/plan_proposals.json` + `.html` draft pair に保存し、同ownerの選択確定成功後だけ `workflow-state.json` の `planning.generated = true` と `planning.final_title` を更新し、採用画像がある場合は最終 `thumbnail.jpg` の正規入力として後段へ引き渡し、無い場合は `/thumbnail <theme>` フォールバックを案内してから `/music --prompt <theme>` へ進む Next Step を示した時点で完了。open insights を企画入力にした場合は、「open insights の消費と status 反映」に従う企画確定時の status 更新（adopted / dismissed）まで完了扱いにしない。画像生成を実施した場合は、採用企画の参照画像を `20-documentation/thumbnail-prompts.md` の `Reference Assignments` へ保存できるまで完了扱いにせず、保存失敗時は停止する。
 
-**構造化文書 Hard Gate**: `references/freshness-rules.md` の鮮度判定へ進む前に、ファイル名日付が最新の `reports/analysis_*.json` と同日付 `.html` の存在を確認し、`.claude/skills/analytics/references/analysis-json-validator.md` の validator を実行する。exit 0 の場合だけ JSON を analytics mode の入力として使用する。HTML 欠損、不正 JSON、pair 不一致、validator 失敗は必須入力不足として中断し、`/analytics --analyze` 再実行を案内する。
+**構造化文書 Hard Gate**: `references/freshness-rules.md` の鮮度判定へ進む前に、ファイル名日付が最新の `reports/analysis_*.json` と同日付 `.html` の存在を確認し、`.claude/skills/analytics/references/analysis-json-validator.md` の validator を実行する。exit 0 の場合だけ JSON を analytics mode の入力として使用する。analytics report の HTML 欠損、不正 JSON、pair 不一致、validator 失敗は必須入力不足として中断し、`/analytics --analyze` 再実行を案内する。
 
 ## Untrusted Data 境界
 
@@ -86,7 +86,7 @@ Phase 1 に入る前に入力モードを 1 回だけ判定し、以降の分析
 | minimal mode | 検証済み analysis JSON と `data/benchmark_*.json` がどちらも存在しない | `ttp_mode: false` はユーザー直接入力（テーマ / ジャンル / 雰囲気）+ config。`true` は入力不足のため企画生成しない | `false` は analytics / benchmark 依存をスキップし、persona / viewing-scene を初回仮説として扱う。`true` は `/channel-research --benchmark` を案内して停止する |
 
 analytics mode では `/analytics --analyze` と `/channel-research --benchmark` を独立・並列で鮮度判定（stale 検出）し、
-`/channel-strategy --persona` の persona / scene 各 JSON+HTML pair を独立分類する。両 pair が fully present なら canonical reader と producer 共有の参照 contract で検証する。各 pair の片側欠落・schema/digest/document_type 不正・scene pair だけ存在・参照不整合は fail-closed で停止する。両 pair が未生成、または検証済み persona pair だけの暫定正規状態で scene pair が未生成なら `freshness-rules.md` の mode 別 fallback に委ね、旧 Markdown は入力にしない。
+`/channel-strategy --persona` の persona / scene 各 JSON+HTML pair を独立分類する。両 pair が fully present なら canonical reader と producer 共有の参照 contract で検証する。各 pair の片側欠落・schema/digest/document_type 不正・scene pair だけ存在・参照不整合は、analytics mode では成果物無変更の fail-closed で停止し、benchmark fallback / minimal mode では警告して初回仮説 fallback に委ねる。両 pair が未生成、または検証済み persona pair だけの暫定正規状態で scene pair が未生成なら `freshness-rules.md` の mode 別 fallback に委ね、旧 Markdown は入力にしない。
 
 - analytics report の stale / fresh 処理は `references/freshness-rules.md::stale report の自動更新` をそのまま適用し、入口側で分岐、呼出順、成功条件、停止条件を再定義しない
 - analytics mode で `/channel-research --benchmark` が stale → Skill ツールで実行（内部で差分更新）

--- a/.claude/skills/wf-new/references/ideate.md
+++ b/.claude/skills/wf-new/references/ideate.md
@@ -86,7 +86,7 @@ Phase 1 に入る前に入力モードを 1 回だけ判定し、以降の分析
 | minimal mode | 検証済み analysis JSON と `data/benchmark_*.json` がどちらも存在しない | `ttp_mode: false` はユーザー直接入力（テーマ / ジャンル / 雰囲気）+ config。`true` は入力不足のため企画生成しない | `false` は analytics / benchmark 依存をスキップし、persona / viewing-scene を初回仮説として扱う。`true` は `/channel-research --benchmark` を案内して停止する |
 
 analytics mode では `/analytics --analyze` と `/channel-research --benchmark` を独立・並列で鮮度判定（stale 検出）し、
-`/channel-strategy --persona` の最終 persona chain（`persona-definition.md` と `viewing-scene-matrix.md`）は存在チェックのみ行う（更新タイミングは戦略判断のため人間が決める）。
+`/channel-strategy --persona` の最終 persona chain（`persona-definition.json` と `viewing-scene-matrix.json` の各 JSON+HTML pair）は `read_published_json_document(..., RepositorySchema.CHANNEL_STRATEGY)` 相当で検証し、persona/scene の参照整合性も確認する。片側欠落・schema 不正・HTML digest 不一致・参照不整合は fail-closed で停止し、旧 Markdown は入力にしない。
 
 - analytics report の stale / fresh 処理は `references/freshness-rules.md::stale report の自動更新` をそのまま適用し、入口側で分岐、呼出順、成功条件、停止条件を再定義しない
 - analytics mode で `/channel-research --benchmark` が stale → Skill ツールで実行（内部で差分更新）

--- a/.claude/skills/wf-new/references/ideate.md
+++ b/.claude/skills/wf-new/references/ideate.md
@@ -86,7 +86,7 @@ Phase 1 に入る前に入力モードを 1 回だけ判定し、以降の分析
 | minimal mode | 検証済み analysis JSON と `data/benchmark_*.json` がどちらも存在しない | `ttp_mode: false` はユーザー直接入力（テーマ / ジャンル / 雰囲気）+ config。`true` は入力不足のため企画生成しない | `false` は analytics / benchmark 依存をスキップし、persona / viewing-scene を初回仮説として扱う。`true` は `/channel-research --benchmark` を案内して停止する |
 
 analytics mode では `/analytics --analyze` と `/channel-research --benchmark` を独立・並列で鮮度判定（stale 検出）し、
-`/channel-strategy --persona` の最終 persona chain（`persona-definition.json` と `viewing-scene-matrix.json` の各 JSON+HTML pair）は `read_published_json_document(..., RepositorySchema.CHANNEL_STRATEGY)` 相当で検証し、persona/scene の参照整合性も確認する。片側欠落・schema 不正・HTML digest 不一致・参照不整合は fail-closed で停止し、旧 Markdown は入力にしない。
+`/channel-strategy --persona` の persona / scene 各 JSON+HTML pair を独立分類する。両 pair が fully present なら canonical reader と producer 共有の参照 contract で検証する。各 pair の片側欠落・schema/digest/document_type 不正・scene pair だけ存在・参照不整合は fail-closed で停止する。両 pair が未生成、または検証済み persona pair だけの暫定正規状態で scene pair が未生成なら `freshness-rules.md` の mode 別 fallback に委ね、旧 Markdown は入力にしない。
 
 - analytics report の stale / fresh 処理は `references/freshness-rules.md::stale report の自動更新` をそのまま適用し、入口側で分岐、呼出順、成功条件、停止条件を再定義しない
 - analytics mode で `/channel-research --benchmark` が stale → Skill ツールで実行（内部で差分更新）

--- a/.claude/skills/wf-new/references/validate_persona_chain.py
+++ b/.claude/skills/wf-new/references/validate_persona_chain.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Validate the canonical persona and viewing-scene document chain."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from youtube_automation.core.errors import AutomationError
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
+from youtube_automation.infrastructure.documents.publishing import read_published_json_document
+
+
+def validate_persona_chain(persona_json: Path, scene_json: Path) -> None:
+    """Validate both published pairs and their bidirectional references."""
+    persona = read_published_json_document(persona_json, RepositorySchema.CHANNEL_STRATEGY)
+    scene = read_published_json_document(scene_json, RepositorySchema.CHANNEL_STRATEGY)
+    persona_id = persona["persona"]["id"]
+    scene_ids = {item["id"] for item in scene["scenes"]}
+    if scene["persona_id"] != persona_id or not set(persona["scene_ids"]).issubset(scene_ids):
+        raise ValueError("persona/scene の参照が一致しません")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--persona-json", type=Path, required=True)
+    parser.add_argument("--scene-json", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        validate_persona_chain(args.persona_json, args.scene_json)
+    except (AutomationError, KeyError, TypeError, ValueError) as exc:
+        print(f"persona chain 検証失敗: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/wf-new/references/validate_persona_chain.py
+++ b/.claude/skills/wf-new/references/validate_persona_chain.py
@@ -7,39 +7,38 @@ import argparse
 import sys
 from pathlib import Path
 
-from youtube_automation.core.errors import AutomationError, DocumentValidationError
+from youtube_automation.application.documents import (
+    validate_channel_strategy_document_type,
+    validate_persona_scene_references,
+)
+from youtube_automation.core.errors import AutomationError
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
 from youtube_automation.infrastructure.documents.publishing import read_published_json_document
+
+
+def validate_persona_document(persona_json: Path) -> dict[str, object]:
+    """Validate a published persona pair in the producer's intermediate state."""
+    persona = read_published_json_document(persona_json, RepositorySchema.CHANNEL_STRATEGY)
+    return validate_channel_strategy_document_type(persona, "persona")
 
 
 def validate_persona_chain(persona_json: Path, scene_json: Path) -> None:
     """Validate both published pairs and their bidirectional references."""
     persona = read_published_json_document(persona_json, RepositorySchema.CHANNEL_STRATEGY)
     scene = read_published_json_document(scene_json, RepositorySchema.CHANNEL_STRATEGY)
-    if not isinstance(persona, dict) or not isinstance(scene, dict):
-        raise DocumentValidationError("persona/scene は JSON object である必要があります")
-
-    persona_value = persona.get("persona")
-    scenes_value = scene.get("scenes")
-    if not isinstance(persona_value, dict) or not isinstance(scenes_value, list):
-        raise DocumentValidationError("persona/scene の参照構造が不正です")
-
-    persona_id = persona_value.get("id")
-    persona_scene_ids = persona.get("scene_ids")
-    scene_ids = {item.get("id") for item in scenes_value if isinstance(item, dict)}
-    if not isinstance(persona_scene_ids, list) or not persona_scene_ids or not scene_ids:
-        raise DocumentValidationError("persona/scene の参照は空にできません")
-    if scene.get("persona_id") != persona_id or set(persona_scene_ids) != scene_ids:
-        raise DocumentValidationError("persona/scene の参照が双方向に一致しません")
+    validate_persona_scene_references(persona, scene, require_nonempty=True)
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--persona-json", type=Path, required=True)
-    parser.add_argument("--scene-json", type=Path, required=True)
+    parser.add_argument("--scene-json", type=Path)
     args = parser.parse_args()
     try:
-        validate_persona_chain(args.persona_json, args.scene_json)
+        if args.scene_json is None:
+            validate_persona_document(args.persona_json)
+        else:
+            validate_persona_chain(args.persona_json, args.scene_json)
     except AutomationError as exc:
         print(f"persona chain 検証失敗: {exc}", file=sys.stderr)
         return 1

--- a/.claude/skills/wf-new/references/validate_persona_chain.py
+++ b/.claude/skills/wf-new/references/validate_persona_chain.py
@@ -7,7 +7,7 @@ import argparse
 import sys
 from pathlib import Path
 
-from youtube_automation.core.errors import AutomationError
+from youtube_automation.core.errors import AutomationError, DocumentValidationError
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
 from youtube_automation.infrastructure.documents.publishing import read_published_json_document
 
@@ -16,10 +16,21 @@ def validate_persona_chain(persona_json: Path, scene_json: Path) -> None:
     """Validate both published pairs and their bidirectional references."""
     persona = read_published_json_document(persona_json, RepositorySchema.CHANNEL_STRATEGY)
     scene = read_published_json_document(scene_json, RepositorySchema.CHANNEL_STRATEGY)
-    persona_id = persona["persona"]["id"]
-    scene_ids = {item["id"] for item in scene["scenes"]}
-    if scene["persona_id"] != persona_id or not set(persona["scene_ids"]).issubset(scene_ids):
-        raise ValueError("persona/scene の参照が一致しません")
+    if not isinstance(persona, dict) or not isinstance(scene, dict):
+        raise DocumentValidationError("persona/scene は JSON object である必要があります")
+
+    persona_value = persona.get("persona")
+    scenes_value = scene.get("scenes")
+    if not isinstance(persona_value, dict) or not isinstance(scenes_value, list):
+        raise DocumentValidationError("persona/scene の参照構造が不正です")
+
+    persona_id = persona_value.get("id")
+    persona_scene_ids = persona.get("scene_ids")
+    scene_ids = {item.get("id") for item in scenes_value if isinstance(item, dict)}
+    if not isinstance(persona_scene_ids, list) or not persona_scene_ids or not scene_ids:
+        raise DocumentValidationError("persona/scene の参照は空にできません")
+    if scene.get("persona_id") != persona_id or set(persona_scene_ids) != scene_ids:
+        raise DocumentValidationError("persona/scene の参照が双方向に一致しません")
 
 
 def main() -> int:
@@ -29,7 +40,7 @@ def main() -> int:
     args = parser.parse_args()
     try:
         validate_persona_chain(args.persona_json, args.scene_json)
-    except (AutomationError, KeyError, TypeError, ValueError) as exc:
+    except AutomationError as exc:
         print(f"persona chain 検証失敗: {exc}", file=sys.stderr)
         return 1
     return 0

--- a/changelog.d/4509-wf-new-structured-persona-chain.fixed.md
+++ b/changelog.d/4509-wf-new-structured-persona-chain.fixed.md
@@ -1,0 +1,1 @@
+`/wf-new` の analytics mode が検証済み JSON+HTML の persona chain を正規入力として受理し、不正な pair や参照不整合を fail-closed で拒否するよう修正した。

--- a/src/youtube_automation/application/documents/__init__.py
+++ b/src/youtube_automation/application/documents/__init__.py
@@ -1,6 +1,10 @@
 """Skill-generated operational document workflows."""
 
-from youtube_automation.application.documents.channel_strategy import write_channel_strategy_document
+from youtube_automation.application.documents.channel_strategy import (
+    validate_channel_strategy_document_type,
+    validate_persona_scene_references,
+    write_channel_strategy_document,
+)
 from youtube_automation.application.documents.collection_plan import write_collection_plan_document
 from youtube_automation.application.documents.migration import (
     DocumentWriteResult,
@@ -25,6 +29,8 @@ __all__ = [
     "music_prompt_artifact_digest",
     "read_video_description_metadata",
     "require_recorded_machine_verification",
+    "validate_channel_strategy_document_type",
+    "validate_persona_scene_references",
     "write_channel_strategy_document",
     "write_collection_plan_document",
     "write_music_prompt_document",

--- a/src/youtube_automation/application/documents/channel_strategy.py
+++ b/src/youtube_automation/application/documents/channel_strategy.py
@@ -108,23 +108,19 @@ def _validate_strategy_references(root: Path, document: dict[str, object]) -> No
         scene_path = root / _RELATIVE_TARGETS["scene"]
         if scene_ids or scene_path.exists() or scene_path.with_suffix(".html").exists():
             scene = _published(root, "scene")
-            validate_persona_scene_references(document, scene)
+            # Persona regeneration may change its ID before the scene producer
+            # catches up.  This producer boundary owns only the selected scene
+            # references, not the already-published scene's persona ownership.
+            _require_subset(scene_ids, _ids(scene.get("scenes"), "scenes"), "scene_ids")
         return
     if document_type not in {"scene", "constraints"}:
         return
     persona = _published(root, "persona")
-    if document_type == "scene":
-        # Scene is the producer of the candidate scene ID set.  At this write
-        # boundary it may remove or rename scenes that the currently published
-        # persona still references; the persona pair is updated in the next
-        # phase.  Only its ownership reference is enforceable here.
-        persona_value = persona.get("persona")
-        if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
-            raise DocumentMigrationError("persona_id が persona 正本を参照していません")
-    else:
-        persona_value = persona.get("persona")
-        if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
-            raise DocumentMigrationError("persona_id が persona 正本を参照していません")
+    # Scene and constraints both own a persona reference.  Scene may otherwise
+    # replace its ID set before the published persona catches up.
+    persona_value = persona.get("persona")
+    if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
+        raise DocumentMigrationError("persona_id が persona 正本を参照していません")
     if document_type == "constraints":
         scene = _published(root, "scene")
         _require_subset(

--- a/src/youtube_automation/application/documents/channel_strategy.py
+++ b/src/youtube_automation/application/documents/channel_strategy.py
@@ -26,7 +26,7 @@ def validate_channel_strategy_document_type(document: object, expected_type: str
     """Validate the shared strategy document type contract and return an object."""
     if not isinstance(document, dict):
         raise DocumentMigrationError("channel strategy document は JSON object で指定してください")
-    if expected_type not in _RELATIVE_TARGETS or document.get("document_type") != expected_type:
+    if document.get("document_type") != expected_type:
         raise DocumentMigrationError(f"参照先 {expected_type} の document_type が不正です")
     return document
 
@@ -114,7 +114,13 @@ def _validate_strategy_references(root: Path, document: dict[str, object]) -> No
         return
     persona = _published(root, "persona")
     if document_type == "scene":
-        validate_persona_scene_references(persona, document)
+        # Scene is the producer of the candidate scene ID set.  At this write
+        # boundary it may remove or rename scenes that the currently published
+        # persona still references; the persona pair is updated in the next
+        # phase.  Only its ownership reference is enforceable here.
+        persona_value = persona.get("persona")
+        if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
+            raise DocumentMigrationError("persona_id が persona 正本を参照していません")
     else:
         persona_value = persona.get("persona")
         if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):

--- a/src/youtube_automation/application/documents/channel_strategy.py
+++ b/src/youtube_automation/application/documents/channel_strategy.py
@@ -22,6 +22,39 @@ _RELATIVE_TARGETS = {
 }
 
 
+def validate_channel_strategy_document_type(document: object, expected_type: str) -> dict[str, object]:
+    """Validate the shared strategy document type contract and return an object."""
+    if not isinstance(document, dict):
+        raise DocumentMigrationError("channel strategy document は JSON object で指定してください")
+    if expected_type not in _RELATIVE_TARGETS or document.get("document_type") != expected_type:
+        raise DocumentMigrationError(f"参照先 {expected_type} の document_type が不正です")
+    return document
+
+
+def validate_persona_scene_references(
+    persona: object,
+    scene: object,
+    *,
+    require_nonempty: bool = False,
+) -> None:
+    """Validate producer-owned persona/scene references.
+
+    A persona may intentionally select a subset of the scenes.  The write boundary
+    also permits an empty selection while the producer is between its persona and
+    scene phases; consumers may request a completed, non-empty chain.
+    """
+    persona_document = validate_channel_strategy_document_type(persona, "persona")
+    scene_document = validate_channel_strategy_document_type(scene, "scene")
+    persona_value = persona_document.get("persona")
+    if not isinstance(persona_value, dict) or scene_document.get("persona_id") != persona_value.get("id"):
+        raise DocumentMigrationError("persona_id が persona 正本を参照していません")
+    persona_scene_ids = _string_set(persona_document.get("scene_ids"), "scene_ids")
+    scene_ids = _ids(scene_document.get("scenes"), "scenes")
+    _require_subset(persona_scene_ids, scene_ids, "scene_ids")
+    if require_nonempty and (not persona_scene_ids or not scene_ids):
+        raise DocumentMigrationError("persona/scene の参照は空にできません")
+
+
 def write_channel_strategy_document(
     json_path: Path,
     build_document: Callable[[], object],
@@ -65,9 +98,7 @@ def _published(root: Path, document_type: str) -> dict[str, object]:
         document = read_published_json_document(path, RepositorySchema.CHANNEL_STRATEGY)
     except Exception as error:
         raise DocumentMigrationError(f"参照先 {document_type} の検証済み JSON+HTML pair が必要です") from error
-    if not isinstance(document, dict) or document.get("document_type") != document_type:
-        raise DocumentMigrationError(f"参照先 {document_type} の document_type が不正です")
-    return document
+    return validate_channel_strategy_document_type(document, document_type)
 
 
 def _validate_strategy_references(root: Path, document: dict[str, object]) -> None:
@@ -77,14 +108,17 @@ def _validate_strategy_references(root: Path, document: dict[str, object]) -> No
         scene_path = root / _RELATIVE_TARGETS["scene"]
         if scene_ids or scene_path.exists() or scene_path.with_suffix(".html").exists():
             scene = _published(root, "scene")
-            _require_subset(scene_ids, _ids(scene.get("scenes"), "scenes"), "scene_ids")
+            validate_persona_scene_references(document, scene)
         return
     if document_type not in {"scene", "constraints"}:
         return
     persona = _published(root, "persona")
-    persona_value = persona.get("persona")
-    if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
-        raise DocumentMigrationError("persona_id が persona 正本を参照していません")
+    if document_type == "scene":
+        validate_persona_scene_references(persona, document)
+    else:
+        persona_value = persona.get("persona")
+        if not isinstance(persona_value, dict) or document.get("persona_id") != persona_value.get("id"):
+            raise DocumentMigrationError("persona_id が persona 正本を参照していません")
     if document_type == "constraints":
         scene = _published(root, "scene")
         _require_subset(

--- a/tests/application/documents/test_channel_strategy.py
+++ b/tests/application/documents/test_channel_strategy.py
@@ -68,6 +68,27 @@ def test_strategy_documents_publish_validated_json_html_pairs_in_dependency_orde
     assert (tmp_path / "docs/channel/creative-constraints.html").is_file()
 
 
+def test_scene_producer_can_replace_ids_before_persona_pair_is_updated(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/channel/personas/persona-definition.json", _persona())
+    initial_scene = _scene()
+    initial_scene["scenes"].append(  # type: ignore[union-attr]
+        {"id": "scene-rest", "situation": "夜の休憩", "desires": ["休息"], "evidence_ids": ["ev-1"]}
+    )
+    _write(tmp_path, "docs/plans/viewing-scene-matrix.json", initial_scene)
+    persona = _persona()
+    persona["scene_ids"] = ["scene-night"]
+    _write(tmp_path, "docs/channel/personas/persona-definition.json", persona)
+    replacement = _scene()
+    replacement["scenes"] = [
+        {"id": "scene-dawn", "situation": "朝の作業", "desires": ["集中"], "evidence_ids": ["ev-1"]}
+    ]
+
+    _write(tmp_path, "docs/plans/viewing-scene-matrix.json", replacement)
+
+    published = json.loads((tmp_path / "docs/plans/viewing-scene-matrix.json").read_text())
+    assert [scene["id"] for scene in published["scenes"]] == ["scene-dawn"]
+
+
 @pytest.mark.parametrize(
     ("relative", "document", "match"),
     [

--- a/tests/application/documents/test_channel_strategy.py
+++ b/tests/application/documents/test_channel_strategy.py
@@ -89,6 +89,30 @@ def test_scene_producer_can_replace_ids_before_persona_pair_is_updated(tmp_path:
     assert [scene["id"] for scene in published["scenes"]] == ["scene-dawn"]
 
 
+def test_persona_producer_can_clear_references_when_published_scene_has_stale_owner(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/channel/personas/persona-definition.json", _persona())
+    _write(tmp_path, "docs/plans/viewing-scene-matrix.json", _scene())
+    regenerated = _persona()
+    regenerated["persona"] = {"id": "persona-regenerated", "name": "朝の集中者", "desires": ["集中したい"]}
+
+    _write(tmp_path, "docs/channel/personas/persona-definition.json", regenerated)
+
+    published = json.loads((tmp_path / "docs/channel/personas/persona-definition.json").read_text())
+    assert published["persona"]["id"] == "persona-regenerated"
+    assert published["scene_ids"] == []
+
+
+def test_persona_producer_rejects_undefined_nonempty_scene_references(tmp_path: Path) -> None:
+    _write(tmp_path, "docs/channel/personas/persona-definition.json", _persona())
+    _write(tmp_path, "docs/plans/viewing-scene-matrix.json", _scene())
+    regenerated = _persona()
+    regenerated["persona"] = {"id": "persona-regenerated", "name": "朝の集中者", "desires": ["集中したい"]}
+    regenerated["scene_ids"] = ["scene-undefined"]
+
+    with pytest.raises(DocumentMigrationError, match="scene_ids に未定義 ID.*scene-undefined"):
+        _write(tmp_path, "docs/channel/personas/persona-definition.json", regenerated)
+
+
 @pytest.mark.parametrize(
     ("relative", "document", "match"),
     [

--- a/tests/repo/test_validate_persona_chain.py
+++ b/tests/repo/test_validate_persona_chain.py
@@ -1,21 +1,126 @@
 from __future__ import annotations
 
-import subprocess
-import sys
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.core.errors import AutomationError
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
+from youtube_automation.infrastructure.documents.publishing import publish_json_document
 
 _RUNNER = REPO_ROOT / ".claude/skills/wf-new/references/validate_persona_chain.py"
+_SPEC = importlib.util.spec_from_file_location("validate_persona_chain", _RUNNER)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
 
 
-def test_cli_requires_both_document_paths() -> None:
-    result = subprocess.run(
-        [sys.executable, str(_RUNNER)],
-        capture_output=True,
-        text=True,
-        check=False,
+def _publish(path: Path, document: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    publish_json_document(path, RepositorySchema.CHANNEL_STRATEGY)
+
+
+def _documents(tmp_path: Path, *, persona_scene_ids: list[str] | None = None) -> tuple[Path, Path]:
+    persona_path = tmp_path / "persona.json"
+    scene_path = tmp_path / "scene.json"
+    _publish(
+        persona_path,
+        {
+            "schema_version": 1,
+            "document_type": "persona",
+            "updated_at": "2026-07-02T00:00:00Z",
+            "status": "confirmed",
+            "persona": {"id": "persona-primary", "name": "primary", "desires": ["focus"]},
+            "scene_ids": ["scene-1"] if persona_scene_ids is None else persona_scene_ids,
+            "evidence": [{"id": "ev-1", "source_path": "input.json", "observation": "fact"}],
+        },
     )
+    _publish(
+        scene_path,
+        {
+            "schema_version": 1,
+            "document_type": "scene",
+            "updated_at": "2026-07-02T00:00:00Z",
+            "status": "confirmed",
+            "persona_id": "persona-primary",
+            "scenes": [
+                {"id": "scene-1", "situation": "work", "desires": ["focus"], "evidence_ids": ["ev-1"]},
+                {"id": "scene-2", "situation": "rest", "desires": ["relax"], "evidence_ids": ["ev-1"]},
+            ],
+            "evidence": [{"id": "ev-1", "source_path": "input.json", "observation": "fact"}],
+        },
+    )
+    return persona_path, scene_path
 
-    assert result.returncode == 2
-    assert "--persona-json" in result.stderr
-    assert "--scene-json" in result.stderr
+
+def _republish(path: Path, update: dict[str, object]) -> None:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    document.update(update)
+    _publish(path, document)
+
+
+def test_validate_persona_chain_accepts_producer_supported_scene_subset(tmp_path: Path) -> None:
+    persona_path, scene_path = _documents(tmp_path)
+
+    _MODULE.validate_persona_chain(persona_path, scene_path)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "value"),
+    [
+        ("empty", []),
+        ("extra", ["scene-1", "scene-missing"]),
+    ],
+)
+def test_validate_persona_chain_rejects_incomplete_or_unknown_references(
+    tmp_path: Path, mutation: str, value: list[str]
+) -> None:
+    persona_path, scene_path = _documents(tmp_path, persona_scene_ids=value)
+
+    with pytest.raises(AutomationError, match="空にできません|未定義 ID"):
+        _MODULE.validate_persona_chain(persona_path, scene_path)
+
+
+def test_validate_persona_chain_rejects_persona_id_mismatch(tmp_path: Path) -> None:
+    persona_path, scene_path = _documents(tmp_path)
+    _republish(scene_path, {"persona_id": "persona-other"})
+
+    with pytest.raises(AutomationError, match="persona_id"):
+        _MODULE.validate_persona_chain(persona_path, scene_path)
+
+
+def test_validate_persona_chain_rejects_wrong_document_type(tmp_path: Path) -> None:
+    _, scene_path = _documents(tmp_path)
+
+    with pytest.raises(AutomationError, match="document_type"):
+        _MODULE.validate_persona_chain(scene_path, scene_path)
+
+
+def test_validate_persona_chain_rejects_schema_failure(tmp_path: Path) -> None:
+    persona_path, scene_path = _documents(tmp_path)
+    persona_path.write_text("{}", encoding="utf-8")
+
+    with pytest.raises(AutomationError):
+        _MODULE.validate_persona_chain(persona_path, scene_path)
+
+
+def test_validate_persona_chain_rejects_digest_mismatch(tmp_path: Path) -> None:
+    persona_path, scene_path = _documents(tmp_path)
+    persona = json.loads(persona_path.read_text(encoding="utf-8"))
+    persona["persona"]["name"] = "tampered"
+    persona_path.write_text(json.dumps(persona), encoding="utf-8")
+
+    with pytest.raises(AutomationError):
+        _MODULE.validate_persona_chain(persona_path, scene_path)
+
+
+def test_validate_persona_chain_rejects_missing_html(tmp_path: Path) -> None:
+    persona_path, scene_path = _documents(tmp_path)
+    scene_path.with_suffix(".html").unlink()
+
+    with pytest.raises(AutomationError):
+        _MODULE.validate_persona_chain(persona_path, scene_path)

--- a/tests/repo/test_validate_persona_chain.py
+++ b/tests/repo/test_validate_persona_chain.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+
+from tests.helpers.paths import REPO_ROOT
+
+_RUNNER = REPO_ROOT / ".claude/skills/wf-new/references/validate_persona_chain.py"
+
+
+def test_cli_requires_both_document_paths() -> None:
+    result = subprocess.run(
+        [sys.executable, str(_RUNNER)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--persona-json" in result.stderr
+    assert "--scene-json" in result.stderr

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -194,7 +194,18 @@ def test_analytics_mode_accepts_verified_structured_persona_chain_without_legacy
     assert not (tmp_path / "docs/plans/viewing-scene-matrix.md").exists()
 
 
-@pytest.mark.parametrize("broken_part", ["missing-html", "invalid-schema", "digest-mismatch", "reference-mismatch"])
+@pytest.mark.parametrize(
+    "broken_part",
+    [
+        "missing-html",
+        "invalid-schema",
+        "digest-mismatch",
+        "persona-id-mismatch",
+        "empty-references",
+        "persona-missing-scene",
+        "scene-missing-persona-reference",
+    ],
+)
 def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path, broken_part: str) -> None:
     _analysis_pair(tmp_path)
     _persona_chain(tmp_path)
@@ -205,10 +216,22 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
     elif broken_part == "digest-mismatch":
         with (tmp_path / "docs/plans/viewing-scene-matrix.html").open("a", encoding="utf-8") as stream:
             stream.write("tampered")
-    else:
+    elif broken_part == "persona-id-mismatch":
         scene_path = tmp_path / "docs/plans/viewing-scene-matrix.json"
         scene = json.loads(scene_path.read_text(encoding="utf-8"))
         scene["persona_id"] = "persona-other"
+        scene_path.write_text(json.dumps(scene), encoding="utf-8")
+        publish_json_document(scene_path, RepositorySchema.CHANNEL_STRATEGY)
+    elif broken_part in {"empty-references", "persona-missing-scene"}:
+        persona_path = tmp_path / "docs/channel/personas/persona-definition.json"
+        persona = json.loads(persona_path.read_text(encoding="utf-8"))
+        persona["scene_ids"] = [] if broken_part == "empty-references" else ["scene-other"]
+        persona_path.write_text(json.dumps(persona), encoding="utf-8")
+        publish_json_document(persona_path, RepositorySchema.CHANNEL_STRATEGY)
+    else:
+        scene_path = tmp_path / "docs/plans/viewing-scene-matrix.json"
+        scene = json.loads(scene_path.read_text(encoding="utf-8"))
+        scene["scenes"].append({"id": "scene-2", "situation": "rest", "desires": ["relax"], "evidence_ids": ["ev-1"]})
         scene_path.write_text(json.dumps(scene), encoding="utf-8")
         publish_json_document(scene_path, RepositorySchema.CHANNEL_STRATEGY)
 

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -19,9 +19,7 @@ _REPO_ROOT = REPO_ROOT
 _FRESHNESS_RULES = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "freshness-rules.md"
 _WF_NEW_SKILL = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
 _WF_NEW_PHASE2 = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "phase2.md"
-_PERSONA_CHAIN_VALIDATOR = (
-    _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "validate_persona_chain.py"
-)
+_PERSONA_CHAIN_VALIDATOR = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "validate_persona_chain.py"
 
 
 def _wf_new_text() -> str:

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -238,6 +238,28 @@ def test_analytics_mode_persona_only_intermediate_state_uses_existing_fallback(
     assert expected_output in result.stdout
 
 
+@pytest.mark.parametrize("input_mode", ["benchmark-fallback", "minimal"])
+@pytest.mark.parametrize("broken_state", ["partial-pair", "invalid-pair"])
+def test_non_analytics_modes_warn_and_continue_for_unusable_persona_chain(
+    tmp_path: Path, input_mode: str, broken_state: str
+) -> None:
+    if input_mode == "benchmark-fallback":
+        _touch(tmp_path / "data/benchmark_20260701.json")
+    _persona_chain(tmp_path)
+    if broken_state == "partial-pair":
+        (tmp_path / "docs/plans/viewing-scene-matrix.html").unlink()
+    else:
+        with (tmp_path / "docs/plans/viewing-scene-matrix.html").open("a", encoding="utf-8") as stream:
+            stream.write("tampered")
+
+    result = _run_freshness_gate(tmp_path, ttp_mode=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "persona chain 警告" in result.stdout
+    assert "初回仮説 fallback へ委譲" in result.stdout
+    assert "初回仮説の視聴者像から視聴シーンを仮説化" in result.stdout
+
+
 @pytest.mark.parametrize("missing_suffix", [".json", ".html"])
 def test_analytics_mode_incomplete_scene_pair_fails_closed_without_mutation(
     tmp_path: Path, missing_suffix: str
@@ -294,6 +316,7 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
     validator = tmp_path / ".claude/skills/wf-new/references/validate_persona_chain.py"
     validator.parent.mkdir(parents=True, exist_ok=True)
     validator.write_bytes(_PERSONA_CHAIN_VALIDATOR.read_bytes())
+    before = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
     result = subprocess.run(
         ["bash", str(script)],
         cwd=tmp_path,
@@ -311,6 +334,8 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
 
     assert result.returncode != 0
     assert "persona chain 検証失敗" in result.stdout
+    for path, content in before.items():
+        assert path.read_bytes() == content
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -136,6 +136,28 @@ def _run_mode_fixture(
     )
 
 
+def _run_freshness_gate(root: Path, *, ttp_mode: bool) -> subprocess.CompletedProcess[str]:
+    validator = root / ".claude/skills/wf-new/references/validate_persona_chain.py"
+    validator.parent.mkdir(parents=True, exist_ok=True)
+    validator.write_bytes(_PERSONA_CHAIN_VALIDATOR.read_bytes())
+    script = root / "mode-check.sh"
+    script.write_text(_freshness_script(), encoding="utf-8")
+    return subprocess.run(
+        ["bash", str(script)],
+        cwd=root,
+        env={
+            **os.environ,
+            "TODAY": "20260702",
+            "COLLECTION_IDEATE_FRESHNESS_DAYS": "7",
+            "COLLECTION_IDEATE_TTP_MODE": str(ttp_mode).lower(),
+            "UV_PROJECT": str(_REPO_ROOT),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
 @pytest.mark.parametrize(
     ("files", "expected_mode"),
     [
@@ -195,6 +217,46 @@ def test_analytics_mode_accepts_verified_structured_persona_chain_without_legacy
 
 
 @pytest.mark.parametrize(
+    ("ttp_mode", "expected_returncode", "expected_output"),
+    [
+        (True, 0, "視聴シーンを仮説化して続行"),
+        (False, 1, "persona 未定義"),
+    ],
+)
+def test_analytics_mode_persona_only_intermediate_state_uses_existing_fallback(
+    tmp_path: Path, ttp_mode: bool, expected_returncode: int, expected_output: str
+) -> None:
+    _analysis_pair(tmp_path)
+    _persona_chain(tmp_path)
+    (tmp_path / "docs/plans/viewing-scene-matrix.json").unlink()
+    (tmp_path / "docs/plans/viewing-scene-matrix.html").unlink()
+
+    result = _run_freshness_gate(tmp_path, ttp_mode=ttp_mode)
+
+    assert result.returncode == expected_returncode, result.stderr
+    assert "検証済み暫定 persona pair・scene 未生成" in result.stdout
+    assert expected_output in result.stdout
+
+
+@pytest.mark.parametrize("missing_suffix", [".json", ".html"])
+def test_analytics_mode_incomplete_scene_pair_fails_closed_without_mutation(
+    tmp_path: Path, missing_suffix: str
+) -> None:
+    _analysis_pair(tmp_path)
+    _persona_chain(tmp_path)
+    missing = tmp_path / f"docs/plans/viewing-scene-matrix{missing_suffix}"
+    missing.unlink()
+    before = {path: path.read_bytes() for path in tmp_path.rglob("*") if path.is_file()}
+
+    result = _run_freshness_gate(tmp_path, ttp_mode=True)
+
+    assert result.returncode == 1
+    assert "pair 状態が不完全" in result.stdout
+    for path, content in before.items():
+        assert path.read_bytes() == content
+
+
+@pytest.mark.parametrize(
     "broken_part",
     [
         "missing-html",
@@ -203,7 +265,6 @@ def test_analytics_mode_accepts_verified_structured_persona_chain_without_legacy
         "persona-id-mismatch",
         "empty-references",
         "persona-missing-scene",
-        "scene-missing-persona-reference",
     ],
 )
 def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path, broken_part: str) -> None:
@@ -228,13 +289,6 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
         persona["scene_ids"] = [] if broken_part == "empty-references" else ["scene-other"]
         persona_path.write_text(json.dumps(persona), encoding="utf-8")
         publish_json_document(persona_path, RepositorySchema.CHANNEL_STRATEGY)
-    else:
-        scene_path = tmp_path / "docs/plans/viewing-scene-matrix.json"
-        scene = json.loads(scene_path.read_text(encoding="utf-8"))
-        scene["scenes"].append({"id": "scene-2", "situation": "rest", "desires": ["relax"], "evidence_ids": ["ev-1"]})
-        scene_path.write_text(json.dumps(scene), encoding="utf-8")
-        publish_json_document(scene_path, RepositorySchema.CHANNEL_STRATEGY)
-
     script = tmp_path / "mode-check.sh"
     script.write_text(_freshness_script(), encoding="utf-8")
     validator = tmp_path / ".claude/skills/wf-new/references/validate_persona_chain.py"

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -4,11 +4,14 @@ import json
 import os
 import re
 import subprocess
+import sys
+from contextlib import chdir
 from pathlib import Path
 
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
+from youtube_automation.application.documents import MarkdownMigrationDecision, write_channel_strategy_document
 from youtube_automation.commands.system import doctor
 from youtube_automation.domains.documents.schema_registry import RepositorySchema
 from youtube_automation.infrastructure.documents.publishing import publish_json_document
@@ -59,6 +62,41 @@ def _analysis_pair(root: Path, report_date: str = "20260702") -> None:
     publish_json_document(path, RepositorySchema.ANALYSIS_REPORT)
 
 
+def _persona_chain(root: Path) -> None:
+    persona = {
+        "schema_version": 1,
+        "document_type": "persona",
+        "updated_at": "2026-07-02T00:00:00Z",
+        "status": "confirmed",
+        "persona": {"id": "persona-primary", "name": "primary", "desires": ["focus"]},
+        "scene_ids": [],
+        "evidence": [{"id": "ev-1", "source_path": "input.json", "observation": "fact"}],
+    }
+    scene = {
+        "schema_version": 1,
+        "document_type": "scene",
+        "updated_at": "2026-07-02T00:00:00Z",
+        "status": "confirmed",
+        "persona_id": "persona-primary",
+        "scenes": [{"id": "scene-1", "situation": "work", "desires": ["focus"], "evidence_ids": ["ev-1"]}],
+        "evidence": [{"id": "ev-1", "source_path": "input.json", "observation": "fact"}],
+    }
+    with chdir(root):
+        for relative, document in (
+            ("docs/channel/personas/persona-definition.json", persona),
+            ("docs/plans/viewing-scene-matrix.json", scene),
+        ):
+            target = root / relative
+            target.parent.mkdir(parents=True, exist_ok=True)
+            write_channel_strategy_document(
+                target, lambda document=document: document, MarkdownMigrationDecision.NOT_REQUIRED
+            )
+        persona["scene_ids"] = ["scene-1"]
+        target = root / "docs/channel/personas/persona-definition.json"
+        target.write_text(json.dumps(persona), encoding="utf-8")
+        publish_json_document(target, RepositorySchema.CHANNEL_STRATEGY)
+
+
 def _run_mode_fixture(
     tmp_path: Path,
     *,
@@ -75,8 +113,7 @@ def _run_mode_fixture(
         _touch(tmp_path / "data/benchmark_20260701.json")
     if data_date is not None:
         _touch(tmp_path / f"data/analytics_data_{data_date}.json")
-    _touch(tmp_path / "docs/channel/personas/persona-definition.md", "# persona\n")
-    _touch(tmp_path / "docs/plans/viewing-scene-matrix.md", "# scene\n")
+    _persona_chain(tmp_path)
     script = tmp_path / "mode-check.sh"
     script.write_text(_freshness_script(), encoding="utf-8")
     script.chmod(0o755)
@@ -88,6 +125,8 @@ def _run_mode_fixture(
             "TODAY": today,
             "COLLECTION_IDEATE_FRESHNESS_DAYS": str(freshness_days),
             "COLLECTION_IDEATE_TTP_MODE": "false",
+            "PYTHON": sys.executable,
+            "PYTHONPATH": str(_REPO_ROOT / "src"),
         },
         capture_output=True,
         text=True,
@@ -143,6 +182,54 @@ def test_freshness_mode_script_executes_each_representative_path(tmp_path: Path,
 
     assert result.returncode == 0, result.stderr
     assert expected in result.stdout
+
+
+def test_analytics_mode_accepts_verified_structured_persona_chain_without_legacy_markdown(tmp_path: Path) -> None:
+    result = _run_mode_fixture(tmp_path, report=True)
+
+    assert result.returncode == 0, result.stderr
+    assert not (tmp_path / "docs/channel/personas/persona-definition.md").exists()
+    assert not (tmp_path / "docs/plans/viewing-scene-matrix.md").exists()
+
+
+@pytest.mark.parametrize("broken_part", ["missing-html", "invalid-schema", "digest-mismatch", "reference-mismatch"])
+def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path, broken_part: str) -> None:
+    _analysis_pair(tmp_path)
+    _persona_chain(tmp_path)
+    if broken_part == "missing-html":
+        (tmp_path / "docs/plans/viewing-scene-matrix.html").unlink()
+    elif broken_part == "invalid-schema":
+        _touch(tmp_path / "docs/channel/personas/persona-definition.json", "{}")
+    elif broken_part == "digest-mismatch":
+        with (tmp_path / "docs/plans/viewing-scene-matrix.html").open("a", encoding="utf-8") as stream:
+            stream.write("tampered")
+    else:
+        scene_path = tmp_path / "docs/plans/viewing-scene-matrix.json"
+        scene = json.loads(scene_path.read_text(encoding="utf-8"))
+        scene["persona_id"] = "persona-other"
+        scene_path.write_text(json.dumps(scene), encoding="utf-8")
+        publish_json_document(scene_path, RepositorySchema.CHANNEL_STRATEGY)
+
+    script = tmp_path / "mode-check.sh"
+    script.write_text(_freshness_script(), encoding="utf-8")
+    result = subprocess.run(
+        ["bash", str(script)],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "TODAY": "20260702",
+            "COLLECTION_IDEATE_FRESHNESS_DAYS": "7",
+            "COLLECTION_IDEATE_TTP_MODE": "false",
+            "PYTHON": sys.executable,
+            "PYTHONPATH": str(_REPO_ROOT / "src"),
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "persona chain 検証失敗" in result.stdout
 
 
 @pytest.mark.parametrize(

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -4,7 +4,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 from contextlib import chdir
 from pathlib import Path
 
@@ -20,6 +19,9 @@ _REPO_ROOT = REPO_ROOT
 _FRESHNESS_RULES = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "freshness-rules.md"
 _WF_NEW_SKILL = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "SKILL.md"
 _WF_NEW_PHASE2 = _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "phase2.md"
+_PERSONA_CHAIN_VALIDATOR = (
+    _REPO_ROOT / ".claude" / "skills" / "wf-new" / "references" / "validate_persona_chain.py"
+)
 
 
 def _wf_new_text() -> str:
@@ -114,6 +116,9 @@ def _run_mode_fixture(
     if data_date is not None:
         _touch(tmp_path / f"data/analytics_data_{data_date}.json")
     _persona_chain(tmp_path)
+    validator = tmp_path / ".claude/skills/wf-new/references/validate_persona_chain.py"
+    validator.parent.mkdir(parents=True, exist_ok=True)
+    validator.write_bytes(_PERSONA_CHAIN_VALIDATOR.read_bytes())
     script = tmp_path / "mode-check.sh"
     script.write_text(_freshness_script(), encoding="utf-8")
     script.chmod(0o755)
@@ -125,8 +130,7 @@ def _run_mode_fixture(
             "TODAY": today,
             "COLLECTION_IDEATE_FRESHNESS_DAYS": str(freshness_days),
             "COLLECTION_IDEATE_TTP_MODE": "false",
-            "PYTHON": sys.executable,
-            "PYTHONPATH": str(_REPO_ROOT / "src"),
+            "UV_PROJECT": str(_REPO_ROOT),
         },
         capture_output=True,
         text=True,
@@ -212,6 +216,9 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
 
     script = tmp_path / "mode-check.sh"
     script.write_text(_freshness_script(), encoding="utf-8")
+    validator = tmp_path / ".claude/skills/wf-new/references/validate_persona_chain.py"
+    validator.parent.mkdir(parents=True, exist_ok=True)
+    validator.write_bytes(_PERSONA_CHAIN_VALIDATOR.read_bytes())
     result = subprocess.run(
         ["bash", str(script)],
         cwd=tmp_path,
@@ -220,8 +227,7 @@ def test_analytics_mode_rejects_invalid_structured_persona_chain(tmp_path: Path,
             "TODAY": "20260702",
             "COLLECTION_IDEATE_FRESHNESS_DAYS": "7",
             "COLLECTION_IDEATE_TTP_MODE": "false",
-            "PYTHON": sys.executable,
-            "PYTHONPATH": str(_REPO_ROOT / "src"),
+            "UV_PROJECT": str(_REPO_ROOT),
         },
         capture_output=True,
         text=True,

--- a/tests/test_wf_new_analytics_fallback_skill_contract.py
+++ b/tests/test_wf_new_analytics_fallback_skill_contract.py
@@ -220,7 +220,7 @@ def test_analytics_mode_accepts_verified_structured_persona_chain_without_legacy
     ("ttp_mode", "expected_returncode", "expected_output"),
     [
         (True, 0, "視聴シーンを仮説化して続行"),
-        (False, 1, "persona 未定義"),
+        (False, 1, "viewing-scene 未定義"),
     ],
 )
 def test_analytics_mode_persona_only_intermediate_state_uses_existing_fallback(
@@ -236,6 +236,25 @@ def test_analytics_mode_persona_only_intermediate_state_uses_existing_fallback(
     assert result.returncode == expected_returncode, result.stderr
     assert "検証済み暫定 persona pair・scene 未生成" in result.stdout
     assert expected_output in result.stdout
+    assert "persona 未定義" not in result.stdout
+
+
+@pytest.mark.parametrize("input_mode", ["benchmark-fallback", "minimal"])
+def test_non_analytics_persona_only_state_keeps_persona_and_falls_back_only_for_scene(
+    tmp_path: Path, input_mode: str
+) -> None:
+    if input_mode == "benchmark-fallback":
+        _touch(tmp_path / "data/benchmark_20260701.json")
+    _persona_chain(tmp_path)
+    (tmp_path / "docs/plans/viewing-scene-matrix.json").unlink()
+    (tmp_path / "docs/plans/viewing-scene-matrix.html").unlink()
+
+    result = _run_freshness_gate(tmp_path, ttp_mode=False)
+
+    assert result.returncode == 0, result.stderr
+    assert "検証済み暫定 persona pair・scene 未生成" in result.stdout
+    assert "viewing-scene 未定義" in result.stdout
+    assert "persona 未定義" not in result.stdout
 
 
 @pytest.mark.parametrize("input_mode", ["benchmark-fallback", "minimal"])


### PR DESCRIPTION
## Summary
- persona chain gate を検証済み JSON と HTML の pair による canonical 判定へ移行
- schema 不正、digest 不一致、参照不整合を fail-closed に統一
- 構造化 persona chain を旧 Markdown 判定で拒否しない契約を固定

Closes #4509