### PR TITLE
docs: 拡張導入をextension正規入口へ統一する (#4423)

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -40,13 +40,7 @@ jobs:
             - **DistroKid Helper** — `distrokid-helper-*.zip`
             - **Community Helper** — `community-helper-*.zip`
 
-            ## 初回インストール
+            ## インストール・更新
 
-            1. 目的の拡張の zip（`*.zip`）をダウンロードして任意のフォルダに展開する。
-            2. Chrome で `chrome://extensions` を開き、右上の **デベロッパーモード** を ON にする。
-            3. **パッケージ化されていない拡張機能を読み込む**（Load unpacked）をクリックし、展開したフォルダを選択する。
-
-            ## 更新
-
-            1. 新しい zip をダウンロードして展開し、既存の展開フォルダを置き換える。
-            2. `chrome://extensions` を開き、対象拡張の **リロード**（更新アイコン）をクリックする。
+            `/extension` skill を正規入口として使うと、各拡張の状態から install / update / skip が自動判定されます。
+            Chrome で必要な操作と手動取得のフォールバックは[Chrome 拡張インストールガイド](https://youtube-automation-release-notes.pages.dev/chrome-extension-install-guide/)を参照してください。

--- a/changelog.d/4423-extension-install-guide.changed.md
+++ b/changelog.d/4423-extension-install-guide.changed.md
@@ -1,0 +1,1 @@
+Chrome 拡張の公開インストールガイドと Release 案内を `/extension` skill の自動判定を正規入口とする内容へ更新した。

--- a/docs/chrome-extension-install-guide.md
+++ b/docs/chrome-extension-install-guide.md
@@ -1,114 +1,91 @@
 # Chrome 拡張インストールガイド
 
-YouTube 自動化ツールキットの Chrome 拡張を GitHub Release からインストールする手順。
+YouTube 自動化ツールキットの Chrome 拡張を導入・更新する手順。通常は `/extension` skill を正規入口として使う。
 
 ## 対象拡張
 
 | 拡張 | 用途 |
 |---|---|
-| **suno-helper** | Suno UI 上で曲の連続生成 + playlist 追加を自動化 |
+| **suno-helper** | Suno UI 上で曲の連続生成と playlist 追加を自動化 |
 | **distrokid-helper** | DistroKid 登録フォームへの自動入力 |
+| **community-helper** | YouTube Studio のコミュニティ投稿を補助 |
 
-## 前提条件
+## 推奨: `/extension` で導入・更新する
 
-- Google Chrome（最新版推奨）
-- [GitHub CLI (`gh`)](https://cli.github.com/) がインストール済みで、`gh auth login` で認証済みであること
-- リポジトリへのアクセス権があること
+リポジトリを Codex または Claude Code で開き、フラグなしで実行する。
 
-> `gh` がない場合は、[GitHub Release ページ](https://github.com/daiki-beppu/youtube-automation/releases)から手動でダウンロードできる。`ext-v*` タグの Release を探す。
-
-## インストール手順
-
-### 1. 最新バージョンを確認する
-
-```bash
-gh release list --repo daiki-beppu/youtube-automation --limit 5 \
-  --json tagName,publishedAt \
-  --jq '[.[] | select(.tagName | startswith("ext-v"))] | .[0]'
+```text
+/extension
 ```
 
-### 2. zip をダウンロードする
+agent はローカルの `~/chrome-extensions/<name>/manifest.json` と最新の `ext-v*` Release を比較し、3 拡張をそれぞれ次のいずれかに自動判定する。
 
-必要な拡張のみダウンロードする。
+- **install**: 未導入の拡張を新規インストールする
+- **update**: Release より古い拡張を安全に更新する
+- **skip**: 最新版の拡張は変更しない
 
-```bash
-# 最新タグを変数に入れる
-TAG=$(gh release list --repo daiki-beppu/youtube-automation --limit 10 \
-  --json tagName --jq '[.[] | select(.tagName | startswith("ext-v"))][0].tagName')
+### 対象や操作を指定する
 
-# suno-helper
-gh release download --repo daiki-beppu/youtube-automation "$TAG" \
-  --pattern 'suno-helper-*.zip' --dir ~/Downloads
+対象だけを絞る modifier は複数指定できる。省略時は 3 拡張すべてが対象になる。
 
-# distrokid-helper
-gh release download --repo daiki-beppu/youtube-automation "$TAG" \
-  --pattern 'distrokid-helper-*.zip' --dir ~/Downloads
+```text
+/extension --suno
+/extension --distrokid
+/extension --community
+/extension --suno --community
 ```
 
-### 3. zip を展開する
+自動判定を使わず操作を固定する場合は、排他的な mode を 1 つ指定する。`--install` は指定対象を新規導入し、`--update` は比較結果にかかわらず指定対象を更新する。
 
-```bash
-# suno-helper
-mkdir -p ~/chrome-extensions/suno-helper
-cd ~/chrome-extensions/suno-helper
-unzip -o ~/Downloads/suno-helper-*.zip
-
-# distrokid-helper
-mkdir -p ~/chrome-extensions/distrokid-helper
-cd ~/chrome-extensions/distrokid-helper
-unzip -o ~/Downloads/distrokid-helper-*.zip
+```text
+/extension --install --suno
+/extension --update --distrokid --community
 ```
 
-### 4. Chrome に読み込む
+## agent と利用者の責務
 
-1. Chrome のアドレスバーに `chrome://extensions` と入力して開く
-2. 右上の **デベロッパーモード** を ON にする
-3. **パッケージ化されていない拡張機能を読み込む**（Load unpacked）をクリック
-4. 展開したフォルダを選択する
-   - suno-helper: `~/chrome-extensions/suno-helper/`
-   - distrokid-helper: `~/chrome-extensions/distrokid-helper/`
-5. ツールバーに拡張アイコンが表示されれば完了
+### agent が行うこと
 
-### 5. 動作確認
+- 最新 `ext-v*` Release と対象 asset の特定・download
+- 一時ディレクトリへの安全な展開と、更新時の既存ディレクトリの backup
+- `manifest.json` の name / version が対象拡張と Release に一致することの検証
+- 検証済みファイルの `~/chrome-extensions/<name>/` への配置
+- install / update / skip の結果と、Chrome で開くディレクトリの提示
 
-| 拡張 | 確認方法 |
-|---|---|
-| suno-helper | [suno.com/create](https://suno.com/create) を開き、拡張アイコンをクリック → popup が表示される |
-| distrokid-helper | DistroKid のアップロードページを開き、拡張アイコンをクリック → popup が表示される |
+### 利用者が Chrome で行うこと
 
-## 更新手順
+agent は Chrome の GUI 操作を代行しない。案内された後に、利用者が次を行う。
 
-新しいバージョンがリリースされたら、以下の手順で更新する。
+1. `chrome://extensions` を開き、**Developer mode（デベロッパーモード）**を ON にする。
+2. 初回導入では **Load unpacked（パッケージ化されていない拡張機能を読み込む）**を選び、案内された `~/chrome-extensions/<name>/` を指定する。
+3. 更新では対象拡張の **reload（リロード）**をクリックする。
+4. 対象サービスを開き、popup または overlay が表示・動作することを確認する。
 
-### 1. 新しい zip をダウンロードする
+## 手動取得（フォールバック）
+
+`/extension` skill を実行できない場合や、`gh` が未導入・未認証の場合だけ使用する。
+
+1. [GitHub Releases](https://github.com/daiki-beppu/youtube-automation/releases) を開き、最新の `ext-v*` Release を選ぶ。
+2. 必要な `<name>-*.zip` を download し、`~/chrome-extensions/<name>/` へ展開する。
+3. 展開先の `manifest.json` で name / version が選んだ拡張と Release に一致することを確認する。
+4. 前節の Chrome 操作を行う。更新時は既存フォルダを backup してから置き換え、Chrome で reload する。
+
+`gh` を利用できる場合の手動取得例:
 
 ```bash
 TAG=$(gh release list --repo daiki-beppu/youtube-automation --limit 10 \
   --json tagName --jq '[.[] | select(.tagName | startswith("ext-v"))][0].tagName')
 
-# suno-helper の場合
+# <name> は suno-helper / distrokid-helper / community-helper のいずれか
 gh release download --repo daiki-beppu/youtube-automation "$TAG" \
-  --pattern 'suno-helper-*.zip' --dir ~/Downloads
+  --pattern '<name>-*.zip' --dir ~/Downloads
 ```
-
-### 2. 既存ファイルを置き換える
-
-```bash
-cd ~/chrome-extensions/suno-helper
-rm -rf *
-unzip -o ~/Downloads/suno-helper-*.zip
-```
-
-### 3. Chrome で拡張をリロードする
-
-1. `chrome://extensions` を開く
-2. 対象拡張のリロードボタン（更新アイコン）をクリック
 
 ## トラブルシューティング
 
 | 症状 | 対処 |
 |---|---|
-| `gh release download` で 404 | `gh auth status` で認証状態を確認。リポジトリへのアクセス権があるか確認する |
-| 拡張を読み込めない | デベロッパーモードが ON になっているか確認。展開先に `manifest.json` が存在するか確認する |
-| popup が表示されない | ツールバーのパズルアイコンから拡張をピン留めする。ページをリロードしてから再度試す |
-| 古いバージョンのまま | Chrome の拡張ページでリロードボタンを押したか確認。キャッシュが残る場合は拡張を一度削除して再インストールする |
+| `gh` を利用できない | `gh auth status` を確認する。復旧できなければ手動取得（フォールバック）を使う |
+| 拡張を読み込めない | Developer mode が ON か、指定フォルダ直下に検証済みの `manifest.json` があるか確認する |
+| popup / overlay が表示されない | 拡張をピン留めし、対象ページと拡張を reload して再確認する |
+| 古いバージョンのまま | `/extension --update` を実行し、完了後に Chrome で対象拡張を reload する |

--- a/tests/repo/test_release_extensions_workflow.py
+++ b/tests/repo/test_release_extensions_workflow.py
@@ -1,7 +1,7 @@
 """`release-extensions.yml` の配布契約を静的に検証する（Issue #1022）。
 
-統一タグ `ext-v*` で3拡張の zip を単一 Release に
-添付し、Release 本文にインストール/更新手順テンプレが埋め込まれていることを担保する。
+統一タグ `ext-v*` で3拡張の zip を単一 Release に添付し、Release 本文が
+公開ガイドと `/extension` skill を正規入口として案内することを担保する。
 """
 
 from __future__ import annotations
@@ -15,6 +15,7 @@ from tests.helpers.paths import REPO_ROOT
 
 _REPO_ROOT = REPO_ROOT
 _WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "release-extensions.yml"
+_INSTALL_GUIDE_PATH = _REPO_ROOT / "docs" / "chrome-extension-install-guide.md"
 
 _RELEASE_TAG_GLOB = "ext-v*"
 _GH_RELEASE_ACTION = "softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228"
@@ -22,13 +23,8 @@ _NIX_INSTALL_ACTION = "DeterminateSystems/nix-installer-action@ef8a148080ab6020f
 _VERIFY_SCRIPT = ".claude/skills/automation-release/references/verify-extensions.sh"
 _EXTENSIONS = ("suno-helper", "distrokid-helper", "community-helper")
 _ZIP_GLOBS = tuple(f"extensions/{name}/.output/*.zip" for name in _EXTENSIONS)
-# order.md が要求する手順アンカー。初回インストール（URL + Load unpacked）と
-# 更新（リロード）の両セクションが本文に埋め込まれていることを最小限で担保する。
-_BODY_REQUIRED_PHRASES = (
-    "chrome://extensions",
-    "Load unpacked",
-    "リロード",
-)
+# Release 本文が手動手順を複製せず、正規入口を案内することを固定する。
+_BODY_REQUIRED_PHRASES = ("/extension", "chrome-extension-install-guide/")
 
 
 def _read_text(path: Path) -> str:
@@ -129,8 +125,8 @@ def test_attaches_all_zips_to_one_gh_release() -> None:
     assert zip_globs == _ZIP_GLOBS
 
 
-def test_release_body_embeds_install_and_update_template() -> None:
-    """Release 本文に初回インストール/更新手順テンプレが埋め込まれている。"""
+def test_release_body_points_to_canonical_extension_entrypoint() -> None:
+    """Release 本文は手動手順を複製せず、正規入口へ案内する。"""
     steps = _release_top_level_steps()
     release_step = next(step for step in steps if str(step.get("uses", "")).startswith(_GH_RELEASE_ACTION))
     body = str(release_step.get("with", {}).get("body", ""))
@@ -140,3 +136,34 @@ def test_release_body_embeds_install_and_update_template() -> None:
 
     for name in _EXTENSIONS:
         assert f"`{name}-*.zip`" in body
+
+    assert "gh release download" not in body
+    assert "既存の展開フォルダを置き換える" not in body
+
+
+def test_install_guide_documents_extension_skill_contract() -> None:
+    """公開ガイドが /extension の自動判定と責務境界を説明する。"""
+    guide = _read_text(_INSTALL_GUIDE_PATH)
+
+    required_phrases = (
+        "/extension",
+        "suno-helper",
+        "distrokid-helper",
+        "community-helper",
+        "install",
+        "update",
+        "skip",
+        "--suno",
+        "--distrokid",
+        "--community",
+        "--install",
+        "--update",
+        "Developer mode",
+        "Load unpacked",
+        "manifest",
+        "フォールバック",
+    )
+    for phrase in required_phrases:
+        assert phrase in guide, f"インストールガイドに必須フレーズが欠落: {phrase}"
+
+    assert guide.index("/extension") < guide.index("gh release download")


### PR DESCRIPTION
## Summary
- Chrome 拡張の公開インストールガイドを `/extension` の正規導線へ統一
- release workflow の案内も同じスキルベースの手順へ更新
- ガイドと release workflow の契約テストを追加

Closes #4423