### PR TITLE
feat: 予約投稿設定の型付きローダーを追加 (#4438)

### DIFF
--- a/changelog.d/4438-schedule-config.added.md
+++ b/changelog.d/4438-schedule-config.added.md
@@ -1,0 +1,1 @@
+`schedule_config.json` の予約投稿優先順位とアップロード既定値を型付き `ScheduleConfig` loader に集約しました。

--- a/src/youtube_automation/configuration/__init__.py
+++ b/src/youtube_automation/configuration/__init__.py
@@ -22,12 +22,14 @@ from youtube_automation.configuration.loader import (
     explicit_channel_selection,
     find_workspace_root,
     load_config,
+    load_schedule_config,
     reset,
     select_channel,
     workspace_channels,
 )
 from youtube_automation.configuration.model import ChannelConfig
 from youtube_automation.configuration.pinned_comment import PinnedComment
+from youtube_automation.configuration.schedule import ScheduleConfig
 from youtube_automation.configuration.shorts import Shorts
 
 __all__ = [
@@ -35,11 +37,13 @@ __all__ = [
     "CommunityDraft",
     "Distrokid",
     "PinnedComment",
+    "ScheduleConfig",
     "Shorts",
     "channel_dir",
     "explicit_channel_selection",
     "find_workspace_root",
     "load_config",
+    "load_schedule_config",
     "reset",
     "select_channel",
     "workspace_channels",

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -8,6 +8,7 @@ import math
 import os
 import warnings
 from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from youtube_automation.configuration.analytics import Analytics, Benchmark
 from youtube_automation.configuration.audio import Audio
@@ -39,6 +40,7 @@ from youtube_automation.configuration.meta import Branding, ChannelMeta
 from youtube_automation.configuration.model import ChannelConfig
 from youtube_automation.configuration.pinned_comment import PinnedComment
 from youtube_automation.configuration.playlists import Playlists
+from youtube_automation.configuration.schedule import ScheduleConfig
 from youtube_automation.configuration.shorts import Shorts, ShortsCollection, ShortsRelease
 from youtube_automation.configuration.workflow import (
     SCHEDULED_AUTOMATION_CADENCE_DAYS,
@@ -74,7 +76,7 @@ _instance: ChannelConfig | None = None
 _channel_dir: Path | None = None
 _explicit_channel: str | None = None
 
-__all__ = ["resolve_existing_target_dir"]
+__all__ = ["load_schedule_config", "resolve_existing_target_dir"]
 
 
 # 必須キー（ドット区切り）。分割前の channel_config.py::_REQUIRED_KEYS を新構造へ分配。
@@ -236,6 +238,81 @@ def load_config() -> ChannelConfig:
 def load_config_from_path(channel_dir_path: Path) -> ChannelConfig:
     """明示した channel root の設定を singleton state へ影響させず読み込む。"""
     return _build(channel_dir_path.resolve())
+
+
+def load_schedule_config(channel_dir_path: Path) -> ScheduleConfig:
+    """``config/schedule_config.json`` を読み、既定値と優先順位を解決する."""
+    path = channel_dir_path.resolve() / "config" / "schedule_config.json"
+    if not path.exists():
+        return _build_schedule({})
+    try:
+        with path.open(encoding="utf-8") as file:
+            raw = json.load(file)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ConfigError(f"schedule_config.json の読み込みに失敗しました: {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ConfigError(f"{path} のトップレベルは object でなければなりません")
+    return _build_schedule(raw)
+
+
+def _build_schedule(raw: dict) -> ScheduleConfig:
+    """schedule_config の各セクションを検証して flat な設定へ組み立てる."""
+    sections: dict[str, dict] = {}
+    for name in ("schedule", "upload_settings", "collections_management", "notification_settings", "api_limits"):
+        value = raw.get(name) or {}
+        if not isinstance(value, dict):
+            raise ConfigError(f"schedule_config.json の {name} は object でなければなりません")
+        sections[name] = value
+
+    schedule = sections["schedule"]
+    upload = sections["upload_settings"]
+    collections = sections["collections_management"]
+    notifications = sections["notification_settings"]
+    limits = sections["api_limits"]
+
+    timezone_name = schedule.get("timezone", "Asia/Tokyo")
+    if not isinstance(timezone_name, str) or not timezone_name:
+        raise ConfigError("schedule_config.json の schedule.timezone は空でない文字列である必要があります")
+    try:
+        timezone = ZoneInfo(timezone_name)
+    except ZoneInfoNotFoundError as exc:
+        raise ConfigError(f"schedule_config.json の schedule.timezone が不正です: {timezone_name}") from exc
+
+    if "auto_schedule_enabled" in schedule:
+        scheduling_enabled = bool(schedule["auto_schedule_enabled"])
+    else:
+        scheduling_enabled = bool(schedule.get("cadence")) or bool(schedule.get("publish_time"))
+
+    if upload.get("privacy_status") is not None:
+        logger.warning(
+            "schedule_config.json の upload_settings.privacy_status は無視されます。"
+            "実効値は config/channel/youtube.json::youtube.privacy_status です"
+        )
+
+    cadence = schedule.get("cadence") or ()
+    if not isinstance(cadence, (list, tuple)):
+        raise ConfigError("schedule_config.json の schedule.cadence は配列でなければなりません")
+
+    return ScheduleConfig(
+        timezone=timezone,
+        publish_time=str(schedule.get("publish_time") or schedule.get("day1_time") or "10:00"),
+        cadence=tuple(str(day) for day in cadence),
+        scheduling_enabled=scheduling_enabled,
+        category_id=str(upload.get("category_id", "10")),
+        auto_create_playlist=bool(upload.get("auto_create_playlist", True)),
+        max_retries=int(upload.get("max_retries", 3)),
+        retry_delay_seconds=int(upload.get("retry_delay_seconds", 300)),
+        auto_move_to_live=bool(collections.get("auto_move_to_live", True)),
+        backup_before_move=bool(collections.get("backup_before_move", False)),
+        watch_ready_directory=bool(collections.get("watch_ready_directory", True)),
+        discord_webhook_url=str(notifications.get("discord_webhook_url", "")),
+        email_notifications=bool(notifications.get("email_notifications", False)),
+        terminal_notifications=bool(notifications.get("terminal_notifications", True)),
+        upload_quota_per_day=int(limits.get("upload_quota_per_day", 6)),
+        uploads_per_batch=int(limits.get("uploads_per_batch", 5)),
+        concurrent_uploads=int(limits.get("concurrent_uploads", 1)),
+        delay_between_uploads=int(limits.get("delay_between_uploads", 5)),
+    )
 
 
 def _build(channel_dir_path: Path) -> ChannelConfig:

--- a/src/youtube_automation/configuration/schedule.py
+++ b/src/youtube_automation/configuration/schedule.py
@@ -1,0 +1,30 @@
+"""``config/schedule_config.json`` の解決済み設定."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from zoneinfo import ZoneInfo
+
+
+@dataclass(frozen=True)
+class ScheduleConfig:
+    """予約投稿とアップロード運用で利用する解決済み設定."""
+
+    timezone: ZoneInfo = field(default_factory=lambda: ZoneInfo("Asia/Tokyo"))
+    publish_time: str = "10:00"
+    cadence: tuple[str, ...] = ()
+    scheduling_enabled: bool = False
+    category_id: str = "10"
+    auto_create_playlist: bool = True
+    max_retries: int = 3
+    retry_delay_seconds: int = 300
+    auto_move_to_live: bool = True
+    backup_before_move: bool = False
+    watch_ready_directory: bool = True
+    discord_webhook_url: str = ""
+    email_notifications: bool = False
+    terminal_notifications: bool = True
+    upload_quota_per_day: int = 6
+    uploads_per_batch: int = 5
+    concurrent_uploads: int = 1
+    delay_between_uploads: int = 5

--- a/tests/configuration/test_configuration_migration_contract.py
+++ b/tests/configuration/test_configuration_migration_contract.py
@@ -2,7 +2,7 @@
 
 Coverage matrix (the implementation step must keep every row green):
 
-* B1-01: the configuration package exposes the eleven specified public names.
+* B1-01: the configuration package exposes the specified public names.
 * B1-02: wf-next skip keys default to ``True`` and preserve explicit booleans.
 * B1-03: wf-next ``approval_gates`` is rejected for every value shape.
 * B1-04: post-publish approval gates remain supported in their own namespace.
@@ -34,8 +34,10 @@ from youtube_automation.configuration import (
     CommunityDraft,
     Distrokid,
     PinnedComment,
+    ScheduleConfig,
     Shorts,
     load_config,
+    load_schedule_config,
     reset,
 )
 from youtube_automation.infrastructure.errors import ConfigError
@@ -100,11 +102,13 @@ def test_configuration_public_api_preserves_the_specified_exports():
         "CommunityDraft",
         "Distrokid",
         "PinnedComment",
+        "ScheduleConfig",
         "Shorts",
         "channel_dir",
         "explicit_channel_selection",
         "find_workspace_root",
         "load_config",
+        "load_schedule_config",
         "reset",
         "select_channel",
         "workspace_channels",
@@ -113,7 +117,9 @@ def test_configuration_public_api_preserves_the_specified_exports():
     assert configuration.CommunityDraft is CommunityDraft
     assert configuration.Distrokid is Distrokid
     assert configuration.PinnedComment is PinnedComment
+    assert configuration.ScheduleConfig is ScheduleConfig
     assert configuration.Shorts is Shorts
+    assert configuration.load_schedule_config is load_schedule_config
 
 
 def test_channel_config_is_owned_by_configuration_model():

--- a/tests/configuration/test_schedule.py
+++ b/tests/configuration/test_schedule.py
@@ -1,0 +1,79 @@
+import json
+import logging
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from youtube_automation.configuration.loader import load_schedule_config
+
+
+@pytest.mark.parametrize(
+    ("schedule", "enabled"),
+    [
+        ({"auto_schedule_enabled": True}, True),
+        ({"auto_schedule_enabled": False, "cadence": ["mon"], "publish_time": "20:00"}, False),
+        ({"cadence": ["mon"]}, True),
+        ({"cadence": []}, False),
+        ({"publish_time": "20:00"}, True),
+        ({"publish_time": ""}, False),
+        ({"day1_time": "20:00"}, False),
+        ({}, False),
+    ],
+)
+def test_scheduling_enabled_priority(tmp_path: Path, schedule: dict[str, object], enabled: bool) -> None:
+    _write_schedule(tmp_path, {"schedule": schedule})
+
+    assert load_schedule_config(tmp_path).scheduling_enabled is enabled
+
+
+def test_resolves_schedule_fields_and_defaults(tmp_path: Path) -> None:
+    _write_schedule(
+        tmp_path,
+        {
+            "schedule": {"timezone": "America/New_York", "day1_time": "21:30", "cadence": ["mon", "fri"]},
+            "upload_settings": {"category_id": "22", "auto_create_playlist": False, "max_retries": 7},
+            "collections_management": {"auto_move_to_live": False},
+            "api_limits": {"upload_quota_per_day": 3, "concurrent_uploads": 2},
+        },
+    )
+
+    config = load_schedule_config(tmp_path)
+
+    assert config.timezone == ZoneInfo("America/New_York")
+    assert config.publish_time == "21:30"
+    assert config.cadence == ("mon", "fri")
+    assert config.category_id == "22"
+    assert config.auto_create_playlist is False
+    assert config.max_retries == 7
+    assert config.retry_delay_seconds == 300
+    assert config.auto_move_to_live is False
+    assert config.upload_quota_per_day == 3
+    assert config.concurrent_uploads == 2
+
+
+def test_missing_file_uses_explicit_defaults(tmp_path: Path) -> None:
+    config = load_schedule_config(tmp_path)
+
+    assert config.timezone == ZoneInfo("Asia/Tokyo")
+    assert config.publish_time == "10:00"
+    assert config.cadence == ()
+    assert config.scheduling_enabled is False
+    assert config.auto_move_to_live is True
+    assert config.upload_quota_per_day == 6
+
+
+def test_warns_that_upload_privacy_status_is_ignored(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    _write_schedule(tmp_path, {"upload_settings": {"privacy_status": "public"}})
+
+    with caplog.at_level(logging.WARNING):
+        load_schedule_config(tmp_path)
+
+    assert "youtube.json" in caplog.text
+    assert "privacy_status" in caplog.text
+
+
+def _write_schedule(channel_dir: Path, value: dict[str, object]) -> None:
+    config_dir = channel_dir / "config"
+    config_dir.mkdir()
+    (config_dir / "schedule_config.json").write_text(json.dumps(value), encoding="utf-8")


### PR DESCRIPTION
## Summary
- `ScheduleConfig` と `load_schedule_config` を configuration owner として追加
- 予約投稿日時の4段階の優先順位、既定値、タイムゾーン、upload 関連設定を単体テストで固定
- legacy `privacy_status` の無視警告を loader に集約

Closes #4438