### PR TITLE
refactor(hybrid): pipeline stageをpolicy化する (#4434)

### DIFF
--- a/changelog.d/4434-pipeline-stage-policy.changed.md
+++ b/changelog.d/4434-pipeline-stage-policy.changed.md
@@ -1,1 +1,1 @@
-- hybrid sandwich runner の pipeline stage を `StagePolicy` adapter として分離し、media handoff と制御ファイル allowlist を単体で検証可能にした。制御面 allowlist の判定は `state_sync.relative_control_paths` を唯一の定義として adapter と既定 validator の双方から使う。
+- hybrid sandwich runner の pipeline stage を `StagePolicy` adapter として分離し、media handoff と制御ファイル allowlist を単体で検証可能にした。制御面 allowlist の判定は `state_sync.default_change_validator` を唯一の定義とし、adapter は既定 validator をそのまま再利用する。

--- a/changelog.d/4434-pipeline-stage-policy.changed.md
+++ b/changelog.d/4434-pipeline-stage-policy.changed.md
@@ -1,0 +1,1 @@
+- hybrid sandwich runner の pipeline stage を `StagePolicy` adapter として分離し、media handoff と制御ファイル allowlist を単体で検証可能にした。

--- a/changelog.d/4434-pipeline-stage-policy.changed.md
+++ b/changelog.d/4434-pipeline-stage-policy.changed.md
@@ -1,1 +1,1 @@
-- hybrid sandwich runner の pipeline stage を `StagePolicy` adapter として分離し、media handoff と制御ファイル allowlist を単体で検証可能にした。
+- hybrid sandwich runner の pipeline stage を `StagePolicy` adapter として分離し、media handoff と制御ファイル allowlist を単体で検証可能にした。制御面 allowlist の判定は `state_sync.relative_control_paths` を唯一の定義として adapter と既定 validator の双方から使う。

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -31,8 +31,8 @@ from youtube_automation.domains.post_publish import (
     verify_post_publish_completion,
 )
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
-from youtube_automation.infrastructure.vcs.state_git import build_context
-from youtube_automation.infrastructure.vcs.state_sync import EventSink, pull_update_commit_push
+from youtube_automation.infrastructure.vcs.state_git import StateGitContext, build_context
+from youtube_automation.infrastructure.vcs.state_sync import EventSink, pull_update_commit_push, relative_control_paths
 
 Agent = Literal["claude", "codex"]
 Stage = Literal["pipeline", "planning", "post-publish"]
@@ -136,23 +136,20 @@ def _verify_input_reference(request: SandwichRequest, manifest: HandoffManifest)
         raise StateSyncError("workflow-state handoff参照とpull済みmanifestが一致しません")
 
 
-def _control_paths(channel_dir: Path) -> set[str]:
-    context = build_context(channel_dir)
-    return {path.relative_to(context.repository).as_posix() for path in context.control_files}
-
-
 @dataclass(slots=True)
 class PipelineStagePolicy:
     """Media handoff and control-file policy for the default pipeline stage."""
 
     request: SandwichRequest
     store: MediaStore
-    _initial_control_paths: set[str] = field(init=False, repr=False)
+    _initial_context: StateGitContext | None = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        self._initial_control_paths = _control_paths(self.request.channel_dir)
+        self._initial_context = None
 
     def resolve(self) -> None:
+        # state_syncの既定validatorと同じfast-forward pull直後にcontrol面をsnapshotする。
+        self._initial_context = build_context(self.request.channel_dir)
         if self.request.input_handoff is None or self.request.input_destination is None:
             return
         identity = HandoffIdentity(self.request.channel, self.request.collection, self.request.input_handoff)
@@ -182,7 +179,9 @@ class PipelineStagePolicy:
         return SandwichResult("completed", self.request.collection or None)
 
     def allows(self, repository: Path, changed: set[str]) -> None:
-        allowed = self._initial_control_paths | _control_paths(self.request.channel_dir)
+        if self._initial_context is None:
+            raise StateSyncError("pipeline stage policyのresolveより先にallowsが呼ばれました")
+        allowed = relative_control_paths(self._initial_context, build_context(self.request.channel_dir))
         if changed - allowed:
             raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
 
@@ -260,6 +259,11 @@ def run_sandwich(
 
     def writer() -> None:
         nonlocal planning_collection, post_publish_collection, result
+        if policy is not None:
+            policy.resolve()
+            agent_runner(request.agent, policy.prompt_for(), request.channel_dir)
+            result = policy.verify()
+            return
         if request.stage == "planning":
             readiness = resolve_planning_readiness(request.channel_dir)
             if readiness.status == "waiting":
@@ -269,40 +273,33 @@ def run_sandwich(
             planning_collection = verify_planning_completion(request.channel_dir, readiness.collection)
             result = SandwichResult("completed", planning_collection.name)
             return
-        if request.stage == "post-publish":
-            readiness = resolve_post_publish_readiness(request.channel_dir, request.collection or None)
-            if readiness.status == "waiting":
-                result = SandwichResult("waiting", None)
-                return
-            if readiness.collection is None:
-                raise StateSyncError("cloud post-publish completion target is missing")
-            targeted_prompt = (
-                f"{request.prompt}\n"
-                f"Cloud post-publish target is collection {readiness.collection.name!r}. "
-                "Use the cloud executor and do not select or modify any other collection."
-            )
-            agent_runner(request.agent, targeted_prompt, request.channel_dir)
-            post_publish_collection = verify_post_publish_completion(request.channel_dir, readiness.collection)
-            result = SandwichResult("completed", post_publish_collection.name)
+        readiness = resolve_post_publish_readiness(request.channel_dir, request.collection or None)
+        if readiness.status == "waiting":
+            result = SandwichResult("waiting", None)
             return
-        if policy is None:
-            raise StateSyncError("pipeline stage policy is missing")
-        policy.resolve()
-        agent_runner(request.agent, policy.prompt_for(), request.channel_dir)
-        result = policy.verify()
+        if readiness.collection is None:
+            raise StateSyncError("cloud post-publish completion target is missing")
+        targeted_prompt = (
+            f"{request.prompt}\n"
+            f"Cloud post-publish target is collection {readiness.collection.name!r}. "
+            "Use the cloud executor and do not select or modify any other collection."
+        )
+        agent_runner(request.agent, targeted_prompt, request.channel_dir)
+        post_publish_collection = verify_post_publish_completion(request.channel_dir, readiness.collection)
+        result = SandwichResult("completed", post_publish_collection.name)
 
     def validate_changes(repository: Path, changed: set[str]) -> None:
         if result.status == "waiting":
             if changed:
                 raise StateSyncError("waiting cloud planning run must not change repository state")
             return
+        if policy is not None:
+            policy.allows(repository, changed)
+            return
         if request.stage == "planning":
             if planning_collection is None:
                 raise StateSyncError("cloud planning completion target is missing")
             validate_planning_changes(repository, planning_collection, changed)
-            return
-        if policy is not None:
-            policy.allows(repository, changed)
             return
         if post_publish_collection is None:
             raise StateSyncError("cloud post-publish completion target is missing")

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -31,8 +31,13 @@ from youtube_automation.domains.post_publish import (
     verify_post_publish_completion,
 )
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
-from youtube_automation.infrastructure.vcs.state_git import StateGitContext, build_context
-from youtube_automation.infrastructure.vcs.state_sync import EventSink, pull_update_commit_push, relative_control_paths
+from youtube_automation.infrastructure.vcs.state_git import build_context
+from youtube_automation.infrastructure.vcs.state_sync import (
+    ChangeValidator,
+    EventSink,
+    default_change_validator,
+    pull_update_commit_push,
+)
 
 Agent = Literal["claude", "codex"]
 Stage = Literal["pipeline", "planning", "post-publish"]
@@ -142,14 +147,11 @@ class PipelineStagePolicy:
 
     request: SandwichRequest
     store: MediaStore
-    _initial_context: StateGitContext | None = field(init=False, repr=False)
-
-    def __post_init__(self) -> None:
-        self._initial_context = None
+    _validate: ChangeValidator | None = field(init=False, default=None, repr=False)
 
     def resolve(self) -> None:
-        # state_syncの既定validatorと同じfast-forward pull直後にcontrol面をsnapshotする。
-        self._initial_context = build_context(self.request.channel_dir)
+        # allowlistは既定validatorを唯一の定義として再利用し、fast-forward pull直後にsnapshotする。
+        self._validate = default_change_validator(build_context(self.request.channel_dir))
         if self.request.input_handoff is None or self.request.input_destination is None:
             return
         identity = HandoffIdentity(self.request.channel, self.request.collection, self.request.input_handoff)
@@ -179,11 +181,9 @@ class PipelineStagePolicy:
         return SandwichResult("completed", self.request.collection or None)
 
     def allows(self, repository: Path, changed: set[str]) -> None:
-        if self._initial_context is None:
+        if self._validate is None:
             raise StateSyncError("pipeline stage policyのresolveより先にallowsが呼ばれました")
-        allowed = relative_control_paths(self._initial_context, build_context(self.request.channel_dir))
-        if changed - allowed:
-            raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
+        self._validate(repository, changed)
 
 
 def _resource_detail(report: HybridResourceReport) -> str:

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal, Protocol
 
@@ -79,8 +79,11 @@ class SandwichRequest:
             self.input_handoff is not None or self.output_handoff is not None
         ):
             raise ValidationError(f"{self.stage} stage は media handoff を受け付けません")
-        for field in filter(None, (self.collection_dir, self.input_destination, self.output_root, *self.output_files)):
-            validate_media_relative_path("runner path", field)
+        for path_value in filter(
+            None,
+            (self.collection_dir, self.input_destination, self.output_root, *self.output_files),
+        ):
+            validate_media_relative_path("runner path", path_value)
 
 
 def _inside(root: Path, relative: str) -> Path:
@@ -108,6 +111,18 @@ class SandwichResult:
     collection: str | None
 
 
+class StagePolicy(Protocol):
+    """Stage-specific execution semantics used by the sandwich pipeline."""
+
+    def resolve(self) -> None: ...
+
+    def prompt_for(self) -> str: ...
+
+    def verify(self) -> SandwichResult: ...
+
+    def allows(self, repository: Path, changed: set[str]) -> None: ...
+
+
 def _verify_input_reference(request: SandwichRequest, manifest: HandoffManifest) -> None:
     state_path = _inside(request.channel_dir, request.collection_dir) / "workflow-state.json"
     handoff = read(state_path).handoff
@@ -119,6 +134,57 @@ def _verify_input_reference(request: SandwichRequest, manifest: HandoffManifest)
         or handoff.root_sha256 != manifest.root_sha256
     ):
         raise StateSyncError("workflow-state handoff参照とpull済みmanifestが一致しません")
+
+
+def _control_paths(channel_dir: Path) -> set[str]:
+    context = build_context(channel_dir)
+    return {path.relative_to(context.repository).as_posix() for path in context.control_files}
+
+
+@dataclass(slots=True)
+class PipelineStagePolicy:
+    """Media handoff and control-file policy for the default pipeline stage."""
+
+    request: SandwichRequest
+    store: MediaStore
+    _initial_control_paths: set[str] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._initial_control_paths = _control_paths(self.request.channel_dir)
+
+    def resolve(self) -> None:
+        if self.request.input_handoff is None or self.request.input_destination is None:
+            return
+        identity = HandoffIdentity(self.request.channel, self.request.collection, self.request.input_handoff)
+        manifest = pull_handoff(
+            self.store,
+            identity,
+            _inside(self.request.channel_dir, self.request.input_destination),
+        )
+        _verify_input_reference(self.request, manifest)
+
+    def prompt_for(self) -> str:
+        return self.request.prompt
+
+    def verify(self) -> SandwichResult:
+        if self.request.output_handoff is not None and self.request.output_root is not None:
+            root = _inside(self.request.channel_dir, self.request.output_root)
+            sources = tuple(HandoffSource(_inside(root, path), path) for path in self.request.output_files)
+            push_handoff(
+                self.store,
+                HandoffIdentity(
+                    self.request.channel,
+                    self.request.collection,
+                    self.request.output_handoff,
+                ),
+                sources,
+            )
+        return SandwichResult("completed", self.request.collection or None)
+
+    def allows(self, repository: Path, changed: set[str]) -> None:
+        allowed = self._initial_control_paths | _control_paths(self.request.channel_dir)
+        if changed - allowed:
+            raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
 
 
 def _resource_detail(report: HybridResourceReport) -> str:
@@ -187,6 +253,7 @@ def run_sandwich(
     """Run the existing local-first workflow between verified MediaStore boundaries."""
     _guard_resources(request, resource_probe, on_resource_event, on_resource_diagnostics)
     context = build_context(request.channel_dir)
+    policy: StagePolicy | None = PipelineStagePolicy(request, store) if request.stage == "pipeline" else None
     result = SandwichResult("completed", request.collection or None)
     planning_collection: Path | None = None
     post_publish_collection: Path | None = None
@@ -218,17 +285,11 @@ def run_sandwich(
             post_publish_collection = verify_post_publish_completion(request.channel_dir, readiness.collection)
             result = SandwichResult("completed", post_publish_collection.name)
             return
-        if request.input_handoff is not None and request.input_destination is not None:
-            identity = HandoffIdentity(request.channel, request.collection, request.input_handoff)
-            manifest = pull_handoff(store, identity, _inside(request.channel_dir, request.input_destination))
-            _verify_input_reference(request, manifest)
-
-        agent_runner(request.agent, request.prompt, request.channel_dir)
-
-        if request.output_handoff is not None and request.output_root is not None:
-            root = _inside(request.channel_dir, request.output_root)
-            sources = tuple(HandoffSource(_inside(root, path), path) for path in request.output_files)
-            push_handoff(store, HandoffIdentity(request.channel, request.collection, request.output_handoff), sources)
+        if policy is None:
+            raise StateSyncError("pipeline stage policy is missing")
+        policy.resolve()
+        agent_runner(request.agent, policy.prompt_for(), request.channel_dir)
+        result = policy.verify()
 
     def validate_changes(repository: Path, changed: set[str]) -> None:
         if result.status == "waiting":
@@ -239,6 +300,9 @@ def run_sandwich(
             if planning_collection is None:
                 raise StateSyncError("cloud planning completion target is missing")
             validate_planning_changes(repository, planning_collection, changed)
+            return
+        if policy is not None:
+            policy.allows(repository, changed)
             return
         if post_publish_collection is None:
             raise StateSyncError("cloud post-publish completion target is missing")
@@ -251,6 +315,6 @@ def run_sandwich(
         notification_channel=request.channel,
         notification_collection=request.collection,
         on_event=on_state_sync_event,
-        change_validator=validate_changes if request.stage in {"planning", "post-publish"} else None,
+        change_validator=validate_changes,
     )
     return result

--- a/src/youtube_automation/infrastructure/vcs/state_sync.py
+++ b/src/youtube_automation/infrastructure/vcs/state_sync.py
@@ -62,9 +62,24 @@ def _changed_paths(repository: Path) -> set[str]:
     )
 
 
-def _relative_control_paths(*contexts: StateGitContext) -> set[str]:
+def relative_control_paths(*contexts: StateGitContext) -> set[str]:
+    """Return the shared allowlist of repository-relative control-plane paths."""
+
     repository = contexts[0].repository
     return {path.relative_to(repository).as_posix() for context in contexts for path in context.control_files}
+
+
+def _default_change_validator(context: StateGitContext) -> ChangeValidator:
+    """Snapshot the control plane and allow only its paths before and after a write."""
+
+    before = build_context(context.channel_dir)
+
+    def validate(repository: Path, changed: set[str]) -> None:
+        allowed = relative_control_paths(before, build_context(context.channel_dir))
+        if changed - allowed:
+            raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
+
+    return validate
 
 
 def _is_non_fast_forward(push: subprocess.CompletedProcess[str]) -> bool:
@@ -101,17 +116,10 @@ def pull_update_commit_push(
         raise StateSyncError("state同期のcommit messageは空でない1行を指定してください")
     _require_clean(context.repository)
     _pull_fast_forward(context.repository)
-    before = build_context(context.channel_dir)
+    validate = change_validator if change_validator is not None else _default_change_validator(context)
     result = writer()
-    after = build_context(context.channel_dir)
     changed = _changed_paths(context.repository)
-    if change_validator is None:
-        allowed = _relative_control_paths(before, after)
-        unexpected = changed - allowed
-        if unexpected:
-            raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
-    else:
-        change_validator(context.repository, changed)
+    validate(context.repository, changed)
     if not changed:
         return result
 

--- a/src/youtube_automation/infrastructure/vcs/state_sync.py
+++ b/src/youtube_automation/infrastructure/vcs/state_sync.py
@@ -62,20 +62,23 @@ def _changed_paths(repository: Path) -> set[str]:
     )
 
 
-def relative_control_paths(*contexts: StateGitContext) -> set[str]:
-    """Return the shared allowlist of repository-relative control-plane paths."""
-
+def _relative_control_paths(*contexts: StateGitContext) -> set[str]:
     repository = contexts[0].repository
     return {path.relative_to(repository).as_posix() for context in contexts for path in context.control_files}
 
 
-def _default_change_validator(context: StateGitContext) -> ChangeValidator:
-    """Snapshot the control plane and allow only its paths before and after a write."""
+def default_change_validator(context: StateGitContext) -> ChangeValidator:
+    """制御面をsnapshotし、書き込み前後のcontrol面pathだけを許可するvalidatorを返す。
+
+    control面allowlistの唯一の定義であり、stage別adapterもこの結果を再利用する。
+    呼び出し時点のsnapshotを ``before`` として閉じ込めるため、fast-forward pull直後に
+    生成する。
+    """
 
     before = build_context(context.channel_dir)
 
     def validate(repository: Path, changed: set[str]) -> None:
-        allowed = relative_control_paths(before, build_context(context.channel_dir))
+        allowed = _relative_control_paths(before, build_context(context.channel_dir))
         if changed - allowed:
             raise StateSyncError("writerがGit制御面state以外を変更したため停止しました")
 
@@ -116,7 +119,7 @@ def pull_update_commit_push(
         raise StateSyncError("state同期のcommit messageは空でない1行を指定してください")
     _require_clean(context.repository)
     _pull_fast_forward(context.repository)
-    validate = change_validator if change_validator is not None else _default_change_validator(context)
+    validate = change_validator if change_validator is not None else default_change_validator(context)
     result = writer()
     changed = _changed_paths(context.repository)
     validate(context.repository, changed)

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -10,7 +10,12 @@ from pathlib import Path
 import pytest
 
 from tests.helpers.paths import REPO_ROOT
-from youtube_automation.application.hybrid_runner import SandwichRequest, SandwichResult, run_sandwich
+from youtube_automation.application.hybrid_runner import (
+    PipelineStagePolicy,
+    SandwichRequest,
+    SandwichResult,
+    run_sandwich,
+)
 from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
 from youtube_automation.core.errors import ResourceLimitError, StateSyncError
 from youtube_automation.domains.hybrid_resource_guard import GIB, HybridResourceSnapshot
@@ -74,6 +79,47 @@ class PassingResourceProbe:
             monthly_run_count=0,
             estimated_run_minutes=60,
         )
+
+
+def test_pipeline_stage_policy_resolves_media_prompt_verify_and_control_allowlist(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    source = tmp_path / "song.mp3"
+    source.write_bytes(b"verified input")
+    manifest = push_handoff(
+        store,
+        HandoffIdentity("003ch", "demo", "suno-download"),
+        (HandoffSource(source, "song.mp3"),),
+    )
+    _, _, worker = _repositories(
+        tmp_path,
+        "003ch/demo/suno-download/manifest.json",
+        manifest.root_sha256,
+    )
+    request = SandwichRequest(
+        channel_dir=worker,
+        collection_dir="collections/planning/demo",
+        channel="003ch",
+        collection="demo",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+        input_handoff="suno-download",
+        input_destination="media",
+        output_handoff="master",
+        output_root="outputs",
+        output_files=("Master.mp4",),
+    )
+    policy = PipelineStagePolicy(request, store)
+
+    policy.resolve()
+    assert (worker / "media" / "song.mp3").read_bytes() == b"verified input"
+    assert policy.prompt_for() == "/wf-new --auto"
+    (worker / "outputs").mkdir()
+    (worker / "outputs" / "Master.mp4").write_bytes(b"output")
+    assert policy.verify() == SandwichResult("completed", "demo")
+    policy.allows(worker, {"collections/planning/demo/workflow-state.json"})
+    with pytest.raises(StateSyncError, match="Git制御面state以外"):
+        policy.allows(worker, {"unexpected.json"})
 
 
 def _planning_repository(tmp_path: Path, *, phase: str = "planning") -> tuple[Path, Path]:

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -117,9 +117,55 @@ def test_pipeline_stage_policy_resolves_media_prompt_verify_and_control_allowlis
     (worker / "outputs").mkdir()
     (worker / "outputs" / "Master.mp4").write_bytes(b"output")
     assert policy.verify() == SandwichResult("completed", "demo")
+    pulled = tmp_path / "pulled"
+    pull_handoff(store, HandoffIdentity("003ch", "demo", "master"), pulled)
+    assert (pulled / "Master.mp4").read_bytes() == b"output"
     policy.allows(worker, {"collections/planning/demo/workflow-state.json"})
     with pytest.raises(StateSyncError, match="Git制御面state以外"):
         policy.allows(worker, {"unexpected.json"})
+
+
+def test_pipeline_stage_policy_resolve_rejects_manifest_mismatch(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    source = tmp_path / "song.mp3"
+    source.write_bytes(b"verified input")
+    push_handoff(
+        store,
+        HandoffIdentity("003ch", "demo", "suno-download"),
+        (HandoffSource(source, "song.mp3"),),
+    )
+    _, _, worker = _repositories(tmp_path, "003ch/demo/suno-download/manifest.json", "0" * 64)
+    request = SandwichRequest(
+        channel_dir=worker,
+        collection_dir="collections/planning/demo",
+        channel="003ch",
+        collection="demo",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+        input_handoff="suno-download",
+        input_destination="media",
+    )
+
+    with pytest.raises(StateSyncError, match="workflow-state handoff参照"):
+        PipelineStagePolicy(request, store).resolve()
+
+
+def test_pipeline_stage_policy_allows_requires_resolve_snapshot(tmp_path: Path) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    _, _, worker = _repositories(tmp_path, "003ch/demo/suno-download/manifest.json", "0" * 64)
+    request = SandwichRequest(
+        channel_dir=worker,
+        collection_dir="collections/planning/demo",
+        channel="003ch",
+        collection="demo",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+    )
+
+    with pytest.raises(StateSyncError, match="resolveより先にallows"):
+        PipelineStagePolicy(request, store).allows(worker, set())
 
 
 def _planning_repository(tmp_path: Path, *, phase: str = "planning") -> tuple[Path, Path]:


### PR DESCRIPTION
## Summary
- StagePolicy interface と PipelineStagePolicy adapter を追加
- pipeline stage の media readiness、prompt、成果検証、変更 allowlist を runner から分離
- adapter の単体テストと runner の回帰テストを追加

Closes #4434