### PR TITLE
feat(documents): 運用成果物のruntime解決面を追加する (#4444)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `feat(documents)`: operational artifact inventory に正準 filename・schema pair を検証して valid / invalid / latest instance と filename 日付基準の freshness を返す runtime API を追加する（#4444）。
-
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `feat(documents)`: operational artifact inventory に正準 filename・schema pair を検証して valid / invalid / latest instance と filename 日付基準の freshness を返す runtime API を追加する（#4444）。
+
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/changelog.d/4444-operational-artifacts-runtime.added.md
+++ b/changelog.d/4444-operational-artifacts-runtime.added.md
@@ -1,0 +1,1 @@
+- operational artifact inventory に正準 filename・schema pair を検証して valid / invalid / latest instance と filename 日付基準の freshness を返す runtime API を追加する（#4444）。

--- a/src/youtube_automation/domains/documents/operational_artifacts.py
+++ b/src/youtube_automation/domains/documents/operational_artifacts.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from datetime import date, datetime
 from importlib.resources import files
 from pathlib import Path
-from typing import Final, Iterable, Mapping
+from typing import Final, Iterable, Literal, Mapping
 
 from youtube_automation.core.errors import AutomationError
 from youtube_automation.domains.documents.published import read_published_json_document
@@ -43,12 +43,15 @@ class InvalidArtifact:
     reason: str
 
 
+FreshnessReason = Literal["missing", "relative", "absolute"]
+
+
 @dataclass(frozen=True, slots=True)
 class ArtifactFreshness:
     """Result of comparing an artifact set with its upstream evidence."""
 
     is_stale: bool
-    reason: str | None
+    reason: FreshnessReason | None
     artifact_date: date | None
     against_date: date | None
 
@@ -79,8 +82,11 @@ class ArtifactSet:
         if max_age_days is not None:
             if max_age_days < 0:
                 raise ValueError("max_age_days は 0 以上で指定してください")
-            reference = against_date or artifact_date
-            if ((today or date.today()) - reference).days > max_age_days:
+            # Absolute freshness describes the age of upstream evidence.  With no
+            # upstream date there is nothing against which to declare the artifact
+            # stale; using the artifact's own date here would turn an unavailable
+            # upstream into a false stale result.
+            if against_date is not None and ((today or date.today()) - against_date).days > max_age_days:
                 return ArtifactFreshness(True, "absolute", artifact_date, against_date)
         return ArtifactFreshness(False, None, artifact_date, against_date)
 
@@ -173,7 +179,7 @@ def resolve_artifacts(
             invalid.append(InvalidArtifact(path, str(error)))
         else:
             valid.append(path)
-    latest = max(valid, key=lambda path: (_filename_date(path) or date.min, path.name), default=None)
+    latest = _latest_dated_path(valid)
     return ArtifactSet(artifact, tuple(valid), tuple(invalid), latest)
 
 
@@ -199,6 +205,10 @@ def _filename_date(path: Path) -> date | None:
         return None
 
 
+def _latest_dated_path(paths: Iterable[Path]) -> Path | None:
+    return max(paths, key=lambda path: (_filename_date(path) or date.min, path.name), default=None)
+
+
 def _latest_against_date(against: Path | ArtifactSet | Iterable[Path]) -> date | None:
     if isinstance(against, ArtifactSet):
         paths = against.valid
@@ -206,7 +216,8 @@ def _latest_against_date(against: Path | ArtifactSet | Iterable[Path]) -> date |
         paths = (against,)
     else:
         paths = tuple(against)
-    return max((_filename_date(path) for path in paths), default=None, key=lambda value: value or date.min)
+    latest = _latest_dated_path(paths)
+    return _filename_date(latest) if latest is not None else None
 
 
 def lint_operational_artifacts(

--- a/src/youtube_automation/domains/documents/operational_artifacts.py
+++ b/src/youtube_automation/domains/documents/operational_artifacts.py
@@ -6,11 +6,14 @@ import ast
 import json
 import re
 from dataclasses import dataclass
+from datetime import date, datetime
 from importlib.resources import files
 from pathlib import Path
-from typing import Final, Mapping
+from typing import Final, Iterable, Mapping
 
-from youtube_automation.domains.documents.schema_registry import repository_schema_names
+from youtube_automation.core.errors import AutomationError
+from youtube_automation.domains.documents.published import read_published_json_document
+from youtube_automation.domains.documents.schema_registry import RepositorySchema, repository_schema_names
 from youtube_automation.domains.skills.inventory import SkillInventory
 
 _TARGET_SEGMENTS: Final[tuple[str, ...]] = (
@@ -30,6 +33,56 @@ class OperationalArtifact:
     owner: str
     schema: str
     consumers: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class InvalidArtifact:
+    """A canonical artifact instance which failed its published-document contract."""
+
+    path: Path
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactFreshness:
+    """Result of comparing an artifact set with its upstream evidence."""
+
+    is_stale: bool
+    reason: str | None
+    artifact_date: date | None
+    against_date: date | None
+
+
+@dataclass(frozen=True, slots=True)
+class ArtifactSet:
+    """Resolved valid and invalid instances of one inventory artifact."""
+
+    artifact: OperationalArtifact
+    valid: tuple[Path, ...]
+    invalid: tuple[InvalidArtifact, ...]
+    latest: Path | None
+
+    def freshness(
+        self,
+        *,
+        against: Path | ArtifactSet | Iterable[Path],
+        max_age_days: int | None = None,
+        today: date | None = None,
+    ) -> ArtifactFreshness:
+        """Compare filename dates, optionally applying an absolute age limit."""
+        artifact_date = _filename_date(self.latest) if self.latest is not None else None
+        against_date = _latest_against_date(against)
+        if artifact_date is None:
+            return ArtifactFreshness(True, "missing", None, against_date)
+        if against_date is not None and artifact_date < against_date:
+            return ArtifactFreshness(True, "relative", artifact_date, against_date)
+        if max_age_days is not None:
+            if max_age_days < 0:
+                raise ValueError("max_age_days は 0 以上で指定してください")
+            reference = against_date or artifact_date
+            if ((today or date.today()) - reference).days > max_age_days:
+                return ArtifactFreshness(True, "absolute", artifact_date, against_date)
+        return ArtifactFreshness(False, None, artifact_date, against_date)
 
 
 @dataclass(frozen=True, slots=True)
@@ -89,6 +142,71 @@ def load_operational_artifact_inventory() -> OperationalArtifactInventory:
     if not isinstance(payload, Mapping):
         raise ValueError("operational-artifacts.json は object である必要があります")
     return OperationalArtifactInventory.from_mapping(payload)
+
+
+def resolve_artifacts(
+    channel_dir: Path,
+    artifact_id: str,
+    inventory: OperationalArtifactInventory | None = None,
+) -> ArtifactSet:
+    """Resolve one inventory path to validated runtime instances under a channel."""
+    contract = inventory or load_operational_artifact_inventory()
+    matches = [artifact for artifact in contract.artifacts if artifact.path == artifact_id]
+    if len(matches) != 1:
+        raise ValueError(f"未登録の operational artifact です: {artifact_id}")
+    artifact = matches[0]
+    canonical = _canonical_path_pattern(artifact.path)
+    glob_pattern = re.sub(r"<[^/]+>", "*", artifact.path)
+    candidates = sorted(path for path in channel_dir.glob(glob_pattern) if path.is_file())
+    valid: list[Path] = []
+    invalid: list[InvalidArtifact] = []
+    schema = RepositorySchema(artifact.schema)
+    for path in candidates:
+        relative = path.relative_to(channel_dir).as_posix()
+        # A broad inventory glob may also match sidecars. They are other artifact
+        # kinds, not malformed instances of this artifact.
+        if canonical.fullmatch(relative) is None:
+            continue
+        try:
+            read_published_json_document(path, schema)
+        except AutomationError as error:
+            invalid.append(InvalidArtifact(path, str(error)))
+        else:
+            valid.append(path)
+    latest = max(valid, key=lambda path: (_filename_date(path) or date.min, path.name), default=None)
+    return ArtifactSet(artifact, tuple(valid), tuple(invalid), latest)
+
+
+def _canonical_path_pattern(path: str) -> re.Pattern[str]:
+    pieces: list[str] = []
+    cursor = 0
+    token_pattern = re.compile(r"\*|<[^/]+>")
+    for match in token_pattern.finditer(path):
+        pieces.append(re.escape(path[cursor : match.start()]))
+        pieces.append(r"\d{8}" if match.group() == "*" else r"[^/]+")
+        cursor = match.end()
+    pieces.append(re.escape(path[cursor:]))
+    return re.compile("".join(pieces))
+
+
+def _filename_date(path: Path) -> date | None:
+    match = re.search(r"(?<!\d)(\d{8})(?!\d)", path.name)
+    if match is None:
+        return None
+    try:
+        return datetime.strptime(match.group(1), "%Y%m%d").date()
+    except ValueError:
+        return None
+
+
+def _latest_against_date(against: Path | ArtifactSet | Iterable[Path]) -> date | None:
+    if isinstance(against, ArtifactSet):
+        paths = against.valid
+    elif isinstance(against, Path):
+        paths = (against,)
+    else:
+        paths = tuple(against)
+    return max((_filename_date(path) for path in paths), default=None, key=lambda value: value or date.min)
 
 
 def lint_operational_artifacts(

--- a/tests/domains/documents/test_operational_artifacts.py
+++ b/tests/domains/documents/test_operational_artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
@@ -9,7 +10,10 @@ from youtube_automation.domains.documents.operational_artifacts import (
     OperationalArtifactInventory,
     lint_operational_artifacts,
     load_operational_artifact_inventory,
+    resolve_artifacts,
 )
+from youtube_automation.domains.documents.rendering import render_repository_document
+from youtube_automation.domains.documents.schema_registry import RepositorySchema
 from youtube_automation.domains.skills.inventory import SkillInventory
 
 
@@ -181,3 +185,50 @@ def test_repository_inventory_matches_all_distributed_skills_and_sources() -> No
 
     assert inventory.artifacts
     assert lint_operational_artifacts(REPO_ROOT, SkillInventory(REPO_ROOT), inventory) == []
+
+
+def _published_analysis(path: Path) -> None:
+    document = json.loads((REPO_ROOT / "tests/fixtures/documents/analysis-report.json").read_text(encoding="utf-8"))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(document), encoding="utf-8")
+    path.with_suffix(".html").write_text(
+        render_repository_document(RepositorySchema.ANALYSIS_REPORT, document), encoding="utf-8"
+    )
+
+
+def test_resolve_artifacts_excludes_analysis_sidecars_and_selects_latest(tmp_path: Path) -> None:
+    older = tmp_path / "reports" / "analysis_20260820.json"
+    latest = tmp_path / "reports" / "analysis_20260822.json"
+    _published_analysis(older)
+    _published_analysis(latest)
+    (tmp_path / "reports" / "analysis_20260822.vpd-ranking.json").write_text("{}", encoding="utf-8")
+
+    resolved = resolve_artifacts(tmp_path, "reports/analysis_*.json")
+
+    assert resolved.valid == (older, latest)
+    assert resolved.invalid == ()
+    assert resolved.latest == latest
+
+
+def test_resolve_artifacts_classifies_invalid_published_pair(tmp_path: Path) -> None:
+    invalid = tmp_path / "reports" / "analysis_20260822.json"
+    invalid.parent.mkdir(parents=True)
+    invalid.write_text("{}", encoding="utf-8")
+
+    resolved = resolve_artifacts(tmp_path, "reports/analysis_*.json")
+
+    assert resolved.valid == ()
+    assert resolved.invalid[0].path == invalid
+    assert resolved.invalid[0].reason
+    assert resolved.latest is None
+
+
+def test_artifact_freshness_compares_filename_dates(tmp_path: Path) -> None:
+    report = tmp_path / "reports" / "analysis_20260820.json"
+    _published_analysis(report)
+    data = tmp_path / "data" / "analytics_data_20260822.json"
+
+    freshness = resolve_artifacts(tmp_path, "reports/analysis_*.json").freshness(against=data)
+
+    assert freshness.is_stale is True
+    assert freshness.reason == "relative"

--- a/tests/domains/documents/test_operational_artifacts.py
+++ b/tests/domains/documents/test_operational_artifacts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from datetime import date
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
@@ -232,3 +233,50 @@ def test_artifact_freshness_compares_filename_dates(tmp_path: Path) -> None:
 
     assert freshness.is_stale is True
     assert freshness.reason == "relative"
+
+
+def test_artifact_freshness_applies_absolute_limit_to_upstream_date(tmp_path: Path) -> None:
+    report = tmp_path / "reports" / "analysis_20260822.json"
+    _published_analysis(report)
+    data = tmp_path / "data" / "analytics_data_20260822.json"
+
+    freshness = resolve_artifacts(tmp_path, "reports/analysis_*.json").freshness(
+        against=data,
+        max_age_days=1,
+        today=date(2026, 8, 24),
+    )
+
+    assert freshness.is_stale is True
+    assert freshness.reason == "absolute"
+    assert freshness.against_date == date(2026, 8, 22)
+
+
+def test_artifact_freshness_without_upstream_date_is_not_absolute_stale(tmp_path: Path) -> None:
+    report = tmp_path / "reports" / "analysis_20260820.json"
+    _published_analysis(report)
+
+    freshness = resolve_artifacts(tmp_path, "reports/analysis_*.json").freshness(
+        against=(),
+        max_age_days=1,
+        today=date(2026, 8, 24),
+    )
+
+    assert freshness.is_stale is False
+    assert freshness.reason is None
+    assert freshness.artifact_date == date(2026, 8, 20)
+    assert freshness.against_date is None
+
+
+def test_missing_artifact_takes_precedence_over_absolute_limit(tmp_path: Path) -> None:
+    data = tmp_path / "data" / "analytics_data_20260820.json"
+
+    freshness = resolve_artifacts(tmp_path, "reports/analysis_*.json").freshness(
+        against=data,
+        max_age_days=1,
+        today=date(2026, 8, 24),
+    )
+
+    assert freshness.is_stale is True
+    assert freshness.reason == "missing"
+    assert freshness.artifact_date is None
+    assert freshness.against_date == date(2026, 8, 20)


### PR DESCRIPTION
## Summary
- operational artifact の正準 filename / schema pair を検証し、valid・invalid・latest instance を一元解決する runtime API を追加
- upstream filename の日付と日数上限に基づく freshness 判定を追加
- 分析 sidecar を artifact instance から除外する回帰テストを追加

Closes #4444