### PR TITLE
refactor(hybrid): planningと公開後処理をpolicy化する (#4435)

### DIFF
--- a/changelog.d/4435-planning-post-publish-stage-policy.changed.md
+++ b/changelog.d/4435-planning-post-publish-stage-policy.changed.md
@@ -1,0 +1,1 @@
+hybrid sandwich runner の planning / post-publish を StagePolicy adapter 化し、media handoff request を分離しました。

--- a/changelog.d/4435-planning-post-publish-stage-policy.changed.md
+++ b/changelog.d/4435-planning-post-publish-stage-policy.changed.md
@@ -1,1 +1,1 @@
-hybrid sandwich runner の planning / post-publish を StagePolicy adapter 化し、media handoff request を分離しました。
+hybrid sandwich runner の planning / post-publish を共通 base を持つ StagePolicy adapter 化し、media handoff request を分離しました。

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -124,7 +124,13 @@ class StagePolicy(Protocol):
 
     def prompt_for(self) -> str: ...
 
-    def verify(self) -> str | None: ...
+    def verify(self) -> str | None:
+        """成果を検証し、確定した対象 collection 名を返す。
+
+        collection を持たない stage だけが `None` を返す。対象が確定するはずの
+        stage は検証失敗を戻り値ではなく例外で表すため、常に名前を返す。
+        """
+        ...
 
     def allows(self, repository: Path, changed: set[str]) -> None: ...
 
@@ -260,7 +266,10 @@ def _select_policy(request: SandwichRequest, store: MediaStore) -> StagePolicy:
     if request.stage == "planning":
         return PlanningStagePolicy(request.channel_dir, request.prompt, request.media_handoff)
     return PostPublishStagePolicy(
-        request.channel_dir, request.prompt, request.collection or None, request.media_handoff
+        request.channel_dir,
+        request.prompt,
+        request.media_handoff,
+        requested=request.collection or None,
     )
 
 

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -253,6 +253,17 @@ def _guard_resources(
     raise ResourceLimitError(f"hybrid resource guard rejected: {rejection_detail}")
 
 
+def _select_policy(request: SandwichRequest, store: MediaStore) -> StagePolicy:
+    """The single stage-to-policy selection boundary."""
+    if request.stage == "pipeline":
+        return PipelineStagePolicy(request, store)
+    if request.stage == "planning":
+        return PlanningStagePolicy(request.channel_dir, request.prompt, request.media_handoff)
+    return PostPublishStagePolicy(
+        request.channel_dir, request.prompt, request.collection or None, request.media_handoff
+    )
+
+
 def run_sandwich(
     request: SandwichRequest,
     store: MediaStore,
@@ -264,16 +275,10 @@ def run_sandwich(
     on_state_sync_event: EventSink | None = None,
 ) -> SandwichResult:
     """Run the existing local-first workflow between verified MediaStore boundaries."""
+    # request と stage の整合検証は policy 構築時に起きるため、resource probe より前に選択する。
+    policy = _select_policy(request, store)
     _guard_resources(request, resource_probe, on_resource_event, on_resource_diagnostics)
     context = build_context(request.channel_dir)
-    if request.stage == "pipeline":  # The single stage-to-policy selection boundary.
-        policy: StagePolicy = PipelineStagePolicy(request, store)
-    elif request.stage == "planning":
-        policy = PlanningStagePolicy(request.channel_dir, request.prompt, request.media_handoff)
-    else:
-        policy = PostPublishStagePolicy(
-            request.channel_dir, request.prompt, request.collection or None, request.media_handoff
-        )
     result = SandwichResult("completed", request.collection or None)
 
     def writer() -> None:

--- a/src/youtube_automation/application/hybrid_runner.py
+++ b/src/youtube_automation/application/hybrid_runner.py
@@ -10,11 +10,7 @@ from typing import Literal, Protocol
 
 from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
 from youtube_automation.core.errors import AutomationError, ResourceLimitError, StateSyncError, ValidationError
-from youtube_automation.domains.cloud_planning import (
-    resolve_planning_readiness,
-    validate_planning_changes,
-    verify_planning_completion,
-)
+from youtube_automation.domains.cloud_planning import PlanningStagePolicy
 from youtube_automation.domains.collections.workflow_state import read
 from youtube_automation.domains.hybrid_resource_guard import (
     HybridResourcePolicy,
@@ -25,11 +21,7 @@ from youtube_automation.domains.hybrid_resource_guard import (
 from youtube_automation.domains.media_handoff_manifest import MANIFEST_NAME, HandoffIdentity, HandoffManifest
 from youtube_automation.domains.media_store import MediaStore, validate_media_relative_path
 from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
-from youtube_automation.domains.post_publish import (
-    resolve_post_publish_readiness,
-    validate_post_publish_changes,
-    verify_post_publish_completion,
-)
+from youtube_automation.domains.post_publish import PostPublishStagePolicy
 from youtube_automation.infrastructure.auth.redaction import redact_sensitive_data
 from youtube_automation.infrastructure.vcs.state_git import build_context
 from youtube_automation.infrastructure.vcs.state_sync import (
@@ -53,15 +45,8 @@ ResourceDiagnosticsSink = Callable[[str], None]
 
 
 @dataclass(frozen=True, slots=True)
-class SandwichRequest:
-    channel_dir: Path
+class MediaHandoffRequest:
     collection_dir: str
-    channel: str
-    collection: str
-    agent: Agent
-    prompt: str
-    commit_message: str
-    stage: Stage = "pipeline"
     input_handoff: str | None = None
     input_destination: str | None = None
     output_handoff: str | None = None
@@ -69,8 +54,6 @@ class SandwichRequest:
     output_files: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
-        if not self.prompt.strip():
-            raise ValidationError("sandwich runner prompt は空にできません")
         if (self.input_handoff is None) != (self.input_destination is None):
             raise ValidationError("input handoff と destination は同時に指定してください")
         output_values = (self.output_handoff, self.output_root)
@@ -80,15 +63,27 @@ class SandwichRequest:
             raise ValidationError("output files には handoff と root が必要です")
         if self.output_handoff is not None and not self.output_files:
             raise ValidationError("output handoff には1件以上の file が必要です")
-        if self.stage in {"planning", "post-publish"} and (
-            self.input_handoff is not None or self.output_handoff is not None
-        ):
-            raise ValidationError(f"{self.stage} stage は media handoff を受け付けません")
         for path_value in filter(
             None,
             (self.collection_dir, self.input_destination, self.output_root, *self.output_files),
         ):
             validate_media_relative_path("runner path", path_value)
+
+
+@dataclass(frozen=True, slots=True)
+class SandwichRequest:
+    channel_dir: Path
+    channel: str
+    collection: str
+    agent: Agent
+    prompt: str
+    commit_message: str
+    stage: Stage = "pipeline"
+    media_handoff: MediaHandoffRequest | None = None
+
+    def __post_init__(self) -> None:
+        if not self.prompt.strip():
+            raise ValidationError("sandwich runner prompt は空にできません")
 
 
 def _inside(root: Path, relative: str) -> Path:
@@ -119,19 +114,28 @@ class SandwichResult:
 class StagePolicy(Protocol):
     """Stage-specific execution semantics used by the sandwich pipeline."""
 
+    @property
+    def waiting(self) -> bool: ...
+
+    @property
+    def collection_name(self) -> str | None: ...
+
     def resolve(self) -> None: ...
 
     def prompt_for(self) -> str: ...
 
-    def verify(self) -> SandwichResult: ...
+    def verify(self) -> str | None: ...
 
     def allows(self, repository: Path, changed: set[str]) -> None: ...
 
 
 def _verify_input_reference(request: SandwichRequest, manifest: HandoffManifest) -> None:
-    state_path = _inside(request.channel_dir, request.collection_dir) / "workflow-state.json"
+    media = request.media_handoff
+    if media is None or media.input_handoff is None:
+        raise StateSyncError("input handoff policy is missing")
+    state_path = _inside(request.channel_dir, media.collection_dir) / "workflow-state.json"
     handoff = read(state_path).handoff
-    expected_key = f"{request.channel}/{request.collection}/{request.input_handoff}/{MANIFEST_NAME}"
+    expected_key = f"{request.channel}/{request.collection}/{media.input_handoff}/{MANIFEST_NAME}"
     if (
         handoff is None
         or handoff.owner != "cloud"
@@ -149,36 +153,46 @@ class PipelineStagePolicy:
     store: MediaStore
     _validate: ChangeValidator | None = field(init=False, default=None, repr=False)
 
+    @property
+    def waiting(self) -> bool:
+        return False
+
+    @property
+    def collection_name(self) -> str | None:
+        return self.request.collection or None
+
     def resolve(self) -> None:
         # allowlistは既定validatorを唯一の定義として再利用し、fast-forward pull直後にsnapshotする。
         self._validate = default_change_validator(build_context(self.request.channel_dir))
-        if self.request.input_handoff is None or self.request.input_destination is None:
+        media = self.request.media_handoff
+        if media is None or media.input_handoff is None or media.input_destination is None:
             return
-        identity = HandoffIdentity(self.request.channel, self.request.collection, self.request.input_handoff)
+        identity = HandoffIdentity(self.request.channel, self.request.collection, media.input_handoff)
         manifest = pull_handoff(
             self.store,
             identity,
-            _inside(self.request.channel_dir, self.request.input_destination),
+            _inside(self.request.channel_dir, media.input_destination),
         )
         _verify_input_reference(self.request, manifest)
 
     def prompt_for(self) -> str:
         return self.request.prompt
 
-    def verify(self) -> SandwichResult:
-        if self.request.output_handoff is not None and self.request.output_root is not None:
-            root = _inside(self.request.channel_dir, self.request.output_root)
-            sources = tuple(HandoffSource(_inside(root, path), path) for path in self.request.output_files)
+    def verify(self) -> str | None:
+        media = self.request.media_handoff
+        if media is not None and media.output_handoff is not None and media.output_root is not None:
+            root = _inside(self.request.channel_dir, media.output_root)
+            sources = tuple(HandoffSource(_inside(root, path), path) for path in media.output_files)
             push_handoff(
                 self.store,
                 HandoffIdentity(
                     self.request.channel,
                     self.request.collection,
-                    self.request.output_handoff,
+                    media.output_handoff,
                 ),
                 sources,
             )
-        return SandwichResult("completed", self.request.collection or None)
+        return self.request.collection or None
 
     def allows(self, repository: Path, changed: set[str]) -> None:
         if self._validate is None:
@@ -252,58 +266,32 @@ def run_sandwich(
     """Run the existing local-first workflow between verified MediaStore boundaries."""
     _guard_resources(request, resource_probe, on_resource_event, on_resource_diagnostics)
     context = build_context(request.channel_dir)
-    policy: StagePolicy | None = PipelineStagePolicy(request, store) if request.stage == "pipeline" else None
+    if request.stage == "pipeline":  # The single stage-to-policy selection boundary.
+        policy: StagePolicy = PipelineStagePolicy(request, store)
+    elif request.stage == "planning":
+        policy = PlanningStagePolicy(request.channel_dir, request.prompt, request.media_handoff)
+    else:
+        policy = PostPublishStagePolicy(
+            request.channel_dir, request.prompt, request.collection or None, request.media_handoff
+        )
     result = SandwichResult("completed", request.collection or None)
-    planning_collection: Path | None = None
-    post_publish_collection: Path | None = None
 
     def writer() -> None:
-        nonlocal planning_collection, post_publish_collection, result
-        if policy is not None:
-            policy.resolve()
-            agent_runner(request.agent, policy.prompt_for(), request.channel_dir)
-            result = policy.verify()
+        nonlocal result
+        policy.resolve()
+        if policy.waiting:
+            result = SandwichResult("waiting", policy.collection_name)
             return
-        if request.stage == "planning":
-            readiness = resolve_planning_readiness(request.channel_dir)
-            if readiness.status == "waiting":
-                result = SandwichResult("waiting", readiness.collection.name if readiness.collection else None)
-                return
-            agent_runner(request.agent, request.prompt, request.channel_dir)
-            planning_collection = verify_planning_completion(request.channel_dir, readiness.collection)
-            result = SandwichResult("completed", planning_collection.name)
-            return
-        readiness = resolve_post_publish_readiness(request.channel_dir, request.collection or None)
-        if readiness.status == "waiting":
-            result = SandwichResult("waiting", None)
-            return
-        if readiness.collection is None:
-            raise StateSyncError("cloud post-publish completion target is missing")
-        targeted_prompt = (
-            f"{request.prompt}\n"
-            f"Cloud post-publish target is collection {readiness.collection.name!r}. "
-            "Use the cloud executor and do not select or modify any other collection."
-        )
-        agent_runner(request.agent, targeted_prompt, request.channel_dir)
-        post_publish_collection = verify_post_publish_completion(request.channel_dir, readiness.collection)
-        result = SandwichResult("completed", post_publish_collection.name)
+        agent_runner(request.agent, policy.prompt_for(), request.channel_dir)
+        collection = policy.verify()
+        result = SandwichResult("completed", collection)
 
     def validate_changes(repository: Path, changed: set[str]) -> None:
         if result.status == "waiting":
             if changed:
                 raise StateSyncError("waiting cloud planning run must not change repository state")
             return
-        if policy is not None:
-            policy.allows(repository, changed)
-            return
-        if request.stage == "planning":
-            if planning_collection is None:
-                raise StateSyncError("cloud planning completion target is missing")
-            validate_planning_changes(repository, planning_collection, changed)
-            return
-        if post_publish_collection is None:
-            raise StateSyncError("cloud post-publish completion target is missing")
-        validate_post_publish_changes(repository, changed)
+        policy.allows(repository, changed)
 
     pull_update_commit_push(
         context,

--- a/src/youtube_automation/commands/system/hybrid_runner.py
+++ b/src/youtube_automation/commands/system/hybrid_runner.py
@@ -7,7 +7,7 @@ import sys
 from decimal import Decimal
 from pathlib import Path
 
-from youtube_automation.application.hybrid_runner import SandwichRequest, run_sandwich
+from youtube_automation.application.hybrid_runner import MediaHandoffRequest, SandwichRequest, run_sandwich
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.hybrid_resources import SystemHybridResourceProbe
@@ -63,20 +63,34 @@ def run(args: argparse.Namespace) -> int:
         if args.local_store_root is not None:
             raise ConfigError("--local-store-root は local MediaStore 専用です")
         store = R2MediaStore(R2MediaStoreConfig.from_environment())
+    handoff_values = (
+        args.input_handoff,
+        args.input_destination,
+        args.output_handoff,
+        args.output_root,
+        *args.output_file,
+    )
+    media_handoff = (
+        MediaHandoffRequest(
+            collection_dir=args.collection_dir,
+            input_handoff=args.input_handoff,
+            input_destination=args.input_destination,
+            output_handoff=args.output_handoff,
+            output_root=args.output_root,
+            output_files=tuple(args.output_file),
+        )
+        if any(handoff_values)
+        else None
+    )
     request = SandwichRequest(
         channel_dir=args.channel_dir.resolve(),
-        collection_dir=args.collection_dir,
         channel=args.channel_slug,
         collection=args.collection,
         agent=args.agent,
         prompt=args.prompt,
         commit_message=args.commit_message,
         stage=args.stage,
-        input_handoff=args.input_handoff,
-        input_destination=args.input_destination,
-        output_handoff=args.output_handoff,
-        output_root=args.output_root,
-        output_files=tuple(args.output_file),
+        media_handoff=media_handoff,
     )
     resource_probe = SystemHybridResourceProbe(
         channel_dir=request.channel_dir,

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
-from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.core.errors import StateSyncError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 
@@ -109,3 +109,44 @@ def validate_planning_changes(repository: Path, collection: Path, changed: set[s
         allowed_postmortem = path.startswith("collections/live/") and path.endswith("/20-documentation/postmortem.md")
         if not path.startswith(collection_prefix) and not allowed_audit and not allowed_postmortem:
             raise StateSyncError(f"cloud planning changed an unowned path: {path}")
+
+
+@dataclass(slots=True)
+class PlanningStagePolicy:
+    """Adapter exposing planning semantics to the generic sandwich runner."""
+
+    root: Path
+    prompt: str
+    media_handoff: object | None = None
+    _readiness: PlanningReadiness | None = None
+    _completed: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.media_handoff is not None:
+            raise ValidationError("planning stage は media handoff を受け付けません")
+
+    @property
+    def waiting(self) -> bool:
+        return self._readiness is not None and self._readiness.status == "waiting"
+
+    @property
+    def collection_name(self) -> str | None:
+        collection = self._completed or (self._readiness.collection if self._readiness else None)
+        return collection.name if collection else None
+
+    def resolve(self) -> None:
+        self._readiness = resolve_planning_readiness(self.root)
+
+    def prompt_for(self) -> str:
+        return self.prompt
+
+    def verify(self) -> str:
+        if self._readiness is None:
+            raise StateSyncError("cloud planning readiness is missing")
+        self._completed = verify_planning_completion(self.root, self._readiness.collection)
+        return self._completed.name
+
+    def allows(self, repository: Path, changed: set[str]) -> None:
+        if self._completed is None:
+            raise StateSyncError("cloud planning completion target is missing")
+        validate_planning_changes(repository, self._completed, changed)

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Literal
 
@@ -117,9 +117,11 @@ class PlanningStagePolicy:
 
     root: Path
     prompt: str
+    # media_handoff は application.hybrid_runner.MediaHandoffRequest を指すが、
+    # domains/ は application/ に依存できないため object のまま None 判定だけを行う。
     media_handoff: object | None = None
-    _readiness: PlanningReadiness | None = None
-    _completed: Path | None = None
+    _readiness: PlanningReadiness | None = field(init=False, default=None, repr=False)
+    _completed: Path | None = field(init=False, default=None, repr=False)
 
     def __post_init__(self) -> None:
         if self.media_handoff is not None:

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
-from youtube_automation.core.errors import StateSyncError, ValidationError, WorkflowStateError
+from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.domains.cloud_stage_policy import ReadinessStagePolicy
 from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 
@@ -112,29 +113,10 @@ def validate_planning_changes(repository: Path, collection: Path, changed: set[s
 
 
 @dataclass(slots=True)
-class PlanningStagePolicy:
+class PlanningStagePolicy(ReadinessStagePolicy):
     """Adapter exposing planning semantics to the generic sandwich runner."""
 
-    root: Path
-    prompt: str
-    # media_handoff は application.hybrid_runner.MediaHandoffRequest を指すが、
-    # domains/ は application/ に依存できないため object のまま None 判定だけを行う。
-    media_handoff: object | None = None
-    _readiness: PlanningReadiness | None = field(init=False, default=None, repr=False)
-    _completed: Path | None = field(init=False, default=None, repr=False)
-
-    def __post_init__(self) -> None:
-        if self.media_handoff is not None:
-            raise ValidationError("planning stage は media handoff を受け付けません")
-
-    @property
-    def waiting(self) -> bool:
-        return self._readiness is not None and self._readiness.status == "waiting"
-
-    @property
-    def collection_name(self) -> str | None:
-        collection = self._completed or (self._readiness.collection if self._readiness else None)
-        return collection.name if collection else None
+    stage_label: ClassVar[str] = "planning"
 
     def resolve(self) -> None:
         self._readiness = resolve_planning_readiness(self.root)

--- a/src/youtube_automation/domains/cloud_stage_policy.py
+++ b/src/youtube_automation/domains/cloud_stage_policy.py
@@ -1,0 +1,57 @@
+"""Shared readiness/completion base for cloud stage policy adapters."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import ClassVar, Protocol
+
+from youtube_automation.core.errors import ValidationError
+
+
+class StageReadiness(Protocol):
+    """stage policy が readiness 値に求める最小契約。"""
+
+    @property
+    def status(self) -> str: ...
+
+    @property
+    def collection(self) -> Path | None: ...
+
+
+class OpaqueMediaHandoff(Protocol):
+    """media handoff 設定を「None 判定だけする不透明値」として表す marker。
+
+    実体は `application.hybrid_runner.MediaHandoffRequest` だが、`domains/` は
+    `application/` に依存できないため、中身を参照しない marker 型として受け取る。
+    """
+
+
+@dataclass(slots=True)
+class ReadinessStagePolicy:
+    """readiness → verify → allowlist を辿る cloud stage adapter の共通土台。
+
+    media handoff は pipeline stage 専用のため、この土台を使う stage は構築時点
+    （= runner が resource probe などの副作用へ進む前）で必ず拒否する。
+    """
+
+    stage_label: ClassVar[str]
+
+    root: Path
+    prompt: str
+    media_handoff: OpaqueMediaHandoff | None = None
+    _readiness: StageReadiness | None = field(init=False, default=None, repr=False)
+    _completed: Path | None = field(init=False, default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.media_handoff is not None:
+            raise ValidationError(f"{self.stage_label} stage は media handoff を受け付けません")
+
+    @property
+    def waiting(self) -> bool:
+        return self._readiness is not None and self._readiness.status == "waiting"
+
+    @property
+    def collection_name(self) -> str | None:
+        collection = self._completed or (self._readiness.collection if self._readiness else None)
+        return collection.name if collection else None

--- a/src/youtube_automation/domains/post_publish.py
+++ b/src/youtube_automation/domains/post_publish.py
@@ -6,12 +6,13 @@ import json
 import os
 import tempfile
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Literal
+from typing import ClassVar, Literal
 
-from youtube_automation.core.errors import StateSyncError, ValidationError, WorkflowStateError
+from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.domains.cloud_stage_policy import ReadinessStagePolicy
 from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 from youtube_automation.infrastructure.filesystem import file_lock
@@ -251,30 +252,12 @@ def validate_post_publish_changes(repository: Path, changed: set[str]) -> None:
 
 
 @dataclass(slots=True)
-class PostPublishStagePolicy:
+class PostPublishStagePolicy(ReadinessStagePolicy):
     """Adapter exposing post-publish semantics to the generic sandwich runner."""
 
-    root: Path
-    prompt: str
+    stage_label: ClassVar[str] = "post-publish"
+
     requested: str | None = None
-    # media_handoff は application.hybrid_runner.MediaHandoffRequest を指すが、
-    # domains/ は application/ に依存できないため object のまま None 判定だけを行う。
-    media_handoff: object | None = None
-    _readiness: PostPublishReadiness | None = field(init=False, default=None, repr=False)
-    _completed: Path | None = field(init=False, default=None, repr=False)
-
-    def __post_init__(self) -> None:
-        if self.media_handoff is not None:
-            raise ValidationError("post-publish stage は media handoff を受け付けません")
-
-    @property
-    def waiting(self) -> bool:
-        return self._readiness is not None and self._readiness.status == "waiting"
-
-    @property
-    def collection_name(self) -> str | None:
-        collection = self._completed or (self._readiness.collection if self._readiness else None)
-        return collection.name if collection else None
 
     def resolve(self) -> None:
         self._readiness = resolve_post_publish_readiness(self.root, self.requested)

--- a/src/youtube_automation/domains/post_publish.py
+++ b/src/youtube_automation/domains/post_publish.py
@@ -11,7 +11,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
 
-from youtube_automation.core.errors import StateSyncError, WorkflowStateError
+from youtube_automation.core.errors import StateSyncError, ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.inventory import CollectionRecord, UnreadableWorkflowState, iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState, read
 from youtube_automation.infrastructure.filesystem import file_lock
@@ -248,3 +248,51 @@ def validate_post_publish_changes(repository: Path, changed: set[str]) -> None:
     unexpected = changed - allowed
     if unexpected:
         raise StateSyncError(f"cloud post-publish changed an unowned path: {sorted(unexpected)[0]}")
+
+
+@dataclass(slots=True)
+class PostPublishStagePolicy:
+    """Adapter exposing post-publish semantics to the generic sandwich runner."""
+
+    root: Path
+    prompt: str
+    requested: str | None = None
+    media_handoff: object | None = None
+    _readiness: PostPublishReadiness | None = None
+    _completed: Path | None = None
+
+    def __post_init__(self) -> None:
+        if self.media_handoff is not None:
+            raise ValidationError("post-publish stage は media handoff を受け付けません")
+
+    @property
+    def waiting(self) -> bool:
+        return self._readiness is not None and self._readiness.status == "waiting"
+
+    @property
+    def collection_name(self) -> str | None:
+        collection = self._completed or (self._readiness.collection if self._readiness else None)
+        return collection.name if collection else None
+
+    def resolve(self) -> None:
+        self._readiness = resolve_post_publish_readiness(self.root, self.requested)
+
+    def prompt_for(self) -> str:
+        if self._readiness is None or self._readiness.collection is None:
+            raise StateSyncError("cloud post-publish completion target is missing")
+        return (
+            f"{self.prompt}\n"
+            f"Cloud post-publish target is collection {self._readiness.collection.name!r}. "
+            "Use the cloud executor and do not select or modify any other collection."
+        )
+
+    def verify(self) -> str:
+        if self._readiness is None or self._readiness.collection is None:
+            raise StateSyncError("cloud post-publish completion target is missing")
+        self._completed = verify_post_publish_completion(self.root, self._readiness.collection)
+        return self._completed.name
+
+    def allows(self, repository: Path, changed: set[str]) -> None:
+        if self._completed is None:
+            raise StateSyncError("cloud post-publish completion target is missing")
+        validate_post_publish_changes(repository, changed)

--- a/src/youtube_automation/domains/post_publish.py
+++ b/src/youtube_automation/domains/post_publish.py
@@ -6,7 +6,7 @@ import json
 import os
 import tempfile
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Literal
@@ -257,9 +257,11 @@ class PostPublishStagePolicy:
     root: Path
     prompt: str
     requested: str | None = None
+    # media_handoff は application.hybrid_runner.MediaHandoffRequest を指すが、
+    # domains/ は application/ に依存できないため object のまま None 判定だけを行う。
     media_handoff: object | None = None
-    _readiness: PostPublishReadiness | None = None
-    _completed: Path | None = None
+    _readiness: PostPublishReadiness | None = field(init=False, default=None, repr=False)
+    _completed: Path | None = field(init=False, default=None, repr=False)
 
     def __post_init__(self) -> None:
         if self.media_handoff is not None:

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -15,10 +15,11 @@ from youtube_automation.application.hybrid_runner import (
     PipelineStagePolicy,
     SandwichRequest,
     SandwichResult,
+    Stage,
     run_sandwich,
 )
 from youtube_automation.application.media_handoff import HandoffSource, pull_handoff, push_handoff
-from youtube_automation.core.errors import ResourceLimitError, StateSyncError
+from youtube_automation.core.errors import ResourceLimitError, StateSyncError, ValidationError
 from youtube_automation.domains.hybrid_resource_guard import GIB, HybridResourceSnapshot
 from youtube_automation.domains.media_handoff_manifest import HandoffIdentity
 from youtube_automation.domains.post_publish import mark_complete
@@ -571,6 +572,37 @@ def test_runner_emits_rejection_and_stops_when_resource_inspection_fails(tmp_pat
 
     assert len(events) == 1
     assert "probe" in events[0].detail
+
+
+@pytest.mark.parametrize("stage", ["planning", "post-publish"])
+def test_runner_rejects_stage_with_media_handoff_before_probing_resources(tmp_path: Path, stage: Stage) -> None:
+    store = LocalMediaStore(tmp_path / "store")
+    _, _, worker = _repositories(tmp_path, "unused/manifest.json", "0" * 64)
+    events = []
+
+    class UnusableResourceProbe:
+        def inspect(self) -> HybridResourceSnapshot:
+            raise AssertionError("resource probe must not run for an invalid stage request")
+
+    request = SandwichRequest(
+        channel_dir=worker,
+        channel="003ch",
+        collection="",
+        agent="claude",
+        prompt="/wf-new --auto",
+        commit_message="chore: runner state",
+        stage=stage,
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+        ),
+    )
+
+    with pytest.raises(ValidationError, match="media handoff を受け付けません"):
+        run_sandwich(request, store, resource_probe=UnusableResourceProbe(), on_resource_event=events.append)
+
+    assert events == []
 
 
 def test_posix_script_completes_local_pull_run_push(tmp_path: Path) -> None:

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -11,6 +11,7 @@ import pytest
 
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.application.hybrid_runner import (
+    MediaHandoffRequest,
     PipelineStagePolicy,
     SandwichRequest,
     SandwichResult,
@@ -97,17 +98,19 @@ def test_pipeline_stage_policy_resolves_media_prompt_verify_and_control_allowlis
     )
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
-        input_handoff="suno-download",
-        input_destination="media",
-        output_handoff="master",
-        output_root="outputs",
-        output_files=("Master.mp4",),
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+            output_handoff="master",
+            output_root="outputs",
+            output_files=("Master.mp4",),
+        ),
     )
     policy = PipelineStagePolicy(request, store)
 
@@ -116,7 +119,7 @@ def test_pipeline_stage_policy_resolves_media_prompt_verify_and_control_allowlis
     assert policy.prompt_for() == "/wf-new --auto"
     (worker / "outputs").mkdir()
     (worker / "outputs" / "Master.mp4").write_bytes(b"output")
-    assert policy.verify() == SandwichResult("completed", "demo")
+    assert policy.verify() == "demo"
     pulled = tmp_path / "pulled"
     pull_handoff(store, HandoffIdentity("003ch", "demo", "master"), pulled)
     assert (pulled / "Master.mp4").read_bytes() == b"output"
@@ -137,14 +140,16 @@ def test_pipeline_stage_policy_resolve_rejects_manifest_mismatch(tmp_path: Path)
     _, _, worker = _repositories(tmp_path, "003ch/demo/suno-download/manifest.json", "0" * 64)
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
-        input_handoff="suno-download",
-        input_destination="media",
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+        ),
     )
 
     with pytest.raises(StateSyncError, match="workflow-state handoff参照"):
@@ -156,7 +161,6 @@ def test_pipeline_stage_policy_allows_requires_resolve_snapshot(tmp_path: Path) 
     _, _, worker = _repositories(tmp_path, "003ch/demo/suno-download/manifest.json", "0" * 64)
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
@@ -266,7 +270,6 @@ def test_cloud_planning_commits_prompt_artifacts_and_prepared_state_as_single_wr
     result = run_sandwich(
         SandwichRequest(
             channel_dir=worker,
-            collection_dir="",
             channel="003ch",
             collection="",
             agent="claude",
@@ -298,7 +301,6 @@ def test_cloud_planning_waits_without_agent_or_commit_after_planning_phase(tmp_p
     result = run_sandwich(
         SandwichRequest(
             channel_dir=worker,
-            collection_dir="",
             channel="003ch",
             collection="",
             agent="claude",
@@ -335,7 +337,6 @@ def test_cloud_post_publish_commits_only_verified_tracking(tmp_path: Path) -> No
     result = run_sandwich(
         SandwichRequest(
             channel_dir=worker,
-            collection_dir="",
             channel="003ch",
             collection="",
             agent="claude",
@@ -371,7 +372,6 @@ def test_cloud_post_publish_rejects_tracking_without_pinned_actual_artifact(tmp_
         run_sandwich(
             SandwichRequest(
                 channel_dir=worker,
-                collection_dir="",
                 channel="003ch",
                 collection="",
                 agent="claude",
@@ -408,17 +408,19 @@ def test_runner_completes_manifest_pull_agent_push_and_state_commit(tmp_path: Pa
 
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
-        input_handoff="suno-download",
-        input_destination="media",
-        output_handoff="master",
-        output_root="outputs",
-        output_files=("Master.mp4",),
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+            output_handoff="master",
+            output_root="outputs",
+            output_files=("Master.mp4",),
+        ),
     )
 
     run_sandwich(request, store, resource_probe=PassingResourceProbe(), agent_runner=agent)
@@ -470,14 +472,16 @@ def test_runner_rejects_manifest_that_does_not_match_git_state_before_agent(tmp_
 
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
-        input_handoff="suno-download",
-        input_destination="media",
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+        ),
     )
 
     with pytest.raises(StateSyncError, match="manifestが一致しません"):
@@ -510,14 +514,16 @@ def test_runner_emits_rejection_and_has_no_git_media_or_agent_side_effect_when_r
 
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
-        input_handoff="suno-download",
-        input_destination="media",
+        media_handoff=MediaHandoffRequest(
+            collection_dir="collections/planning/demo",
+            input_handoff="suno-download",
+            input_destination="media",
+        ),
     )
 
     with pytest.raises(ResourceLimitError, match="resource guard rejected"):
@@ -552,12 +558,12 @@ def test_runner_emits_rejection_and_stops_when_resource_inspection_fails(tmp_pat
 
     request = SandwichRequest(
         channel_dir=worker,
-        collection_dir="collections/planning/demo",
         channel="003ch",
         collection="demo",
         agent="claude",
         prompt="/wf-new --auto",
         commit_message="chore: runner state",
+        media_handoff=MediaHandoffRequest(collection_dir="collections/planning/demo"),
     )
 
     with pytest.raises(ResourceLimitError, match="probe unavailable"):

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -122,3 +122,8 @@ def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_pat
     policy.allows(tmp_path, {"collections/planning/demo/workflow-state.json"})
     with pytest.raises(StateSyncError, match="unowned path"):
         policy.allows(tmp_path, {"README.md"})
+
+
+def test_planning_stage_policy_hides_private_state_from_constructor(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="_readiness"):
+        PlanningStagePolicy(tmp_path, "/wf-new --auto", _readiness=None)  # type: ignore[call-arg]

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -8,6 +8,7 @@ import pytest
 from youtube_automation.core.errors import StateSyncError
 from youtube_automation.domains.cloud_planning import (
     PlanningReadiness,
+    PlanningStagePolicy,
     _planning_states,
     resolve_planning_readiness,
     verify_planning_completion,
@@ -96,3 +97,28 @@ def test_completion_resolves_exactly_one_new_collection(tmp_path: Path) -> None:
 
     with pytest.raises(StateSyncError, match="exactly one"):
         verify_planning_completion(tmp_path, None)
+
+
+def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_path: Path) -> None:
+    collection = _state(tmp_path, "demo", phase="planning", created_at="2026-01-01T00:00:00Z")
+    policy = PlanningStagePolicy(tmp_path, "/wf-new --auto")
+
+    policy.resolve()
+    assert policy.waiting is False
+    assert policy.prompt_for() == "/wf-new --auto"
+
+    state_path = collection / "workflow-state.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    state.update(phase="prepared")
+    state["planning"]["generated"] = True
+    state["assets"]["music_prompts"] = True
+    state_path.write_text(json.dumps(state) + "\n", encoding="utf-8")
+    docs = collection / "20-documentation"
+    docs.mkdir()
+    for name in ("plan_proposals.json", "plan_proposals.html", "suno-prompts.json", "suno-prompts.html"):
+        (docs / name).write_text("{}\n", encoding="utf-8")
+
+    assert policy.verify() == "demo"
+    policy.allows(tmp_path, {"collections/planning/demo/workflow-state.json"})
+    with pytest.raises(StateSyncError, match="unowned path"):
+        policy.allows(tmp_path, {"README.md"})

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from youtube_automation.core.errors import StateSyncError
+from youtube_automation.core.errors import StateSyncError, ValidationError
 from youtube_automation.domains.cloud_planning import (
     PlanningReadiness,
     PlanningStagePolicy,
@@ -124,6 +124,6 @@ def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_pat
         policy.allows(tmp_path, {"README.md"})
 
 
-def test_planning_stage_policy_hides_private_state_from_constructor(tmp_path: Path) -> None:
-    with pytest.raises(TypeError, match="_readiness"):
-        PlanningStagePolicy(tmp_path, "/wf-new --auto", _readiness=None)  # type: ignore[call-arg]
+def test_planning_stage_policy_rejects_media_handoff_before_any_side_effect(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="media handoff を受け付けません"):
+        PlanningStagePolicy(tmp_path, "/wf-new --auto", object())

--- a/tests/domains/test_cloud_stage_policy.py
+++ b/tests/domains/test_cloud_stage_policy.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import ClassVar
+
+import pytest
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.cloud_planning import PlanningStagePolicy
+from youtube_automation.domains.cloud_stage_policy import ReadinessStagePolicy
+from youtube_automation.domains.post_publish import PostPublishStagePolicy
+
+
+@dataclass(frozen=True, slots=True)
+class _Readiness:
+    status: str
+    collection: Path | None
+
+
+@dataclass(slots=True)
+class _StubStagePolicy(ReadinessStagePolicy):
+    stage_label: ClassVar[str] = "stub"
+
+
+def test_readiness_driven_stage_policies_share_one_base() -> None:
+    assert issubclass(PlanningStagePolicy, ReadinessStagePolicy)
+    assert issubclass(PostPublishStagePolicy, ReadinessStagePolicy)
+
+
+def test_waiting_and_collection_name_follow_readiness_then_completion(tmp_path: Path) -> None:
+    policy = _StubStagePolicy(tmp_path, "/prompt")
+
+    assert policy.waiting is False
+    assert policy.collection_name is None
+
+    policy._readiness = _Readiness("waiting", tmp_path / "demo")
+    assert policy.waiting is True
+    assert policy.collection_name == "demo"
+
+    policy._readiness = _Readiness("ready", None)
+    assert policy.waiting is False
+    assert policy.collection_name is None
+
+    policy._completed = tmp_path / "confirmed"
+    assert policy.collection_name == "confirmed"
+
+
+def test_base_rejects_media_handoff_with_the_stage_label(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="stub stage は media handoff を受け付けません"):
+        _StubStagePolicy(tmp_path, "/prompt", object())

--- a/tests/domains/test_post_publish.py
+++ b/tests/domains/test_post_publish.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from youtube_automation.core.errors import StateSyncError
+from youtube_automation.core.errors import StateSyncError, ValidationError
 from youtube_automation.domains.collections.inventory import CollectionRecord
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.post_publish import (
@@ -161,6 +161,6 @@ def test_post_publish_stage_policy_adapts_target_prompt_completion_and_allowlist
         policy.allows(tmp_path, {"README.md"})
 
 
-def test_post_publish_stage_policy_hides_private_state_from_constructor(tmp_path: Path) -> None:
-    with pytest.raises(TypeError, match="_completed"):
-        PostPublishStagePolicy(tmp_path, "/publish", _completed=None)  # type: ignore[call-arg]
+def test_post_publish_stage_policy_rejects_media_handoff_before_any_side_effect(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="media handoff を受け付けません"):
+        PostPublishStagePolicy(tmp_path, "/publish", None, object())

--- a/tests/domains/test_post_publish.py
+++ b/tests/domains/test_post_publish.py
@@ -144,7 +144,7 @@ def test_readiness_waits_when_no_live_collection_needs_followup(tmp_path: Path) 
 
 def test_post_publish_stage_policy_adapts_target_prompt_completion_and_allowlist(tmp_path: Path) -> None:
     collection = _collection(tmp_path)
-    policy = PostPublishStagePolicy(tmp_path, "/publish", None)
+    policy = PostPublishStagePolicy(tmp_path, "/publish", requested=None)
 
     policy.resolve()
     assert policy.waiting is False
@@ -163,4 +163,4 @@ def test_post_publish_stage_policy_adapts_target_prompt_completion_and_allowlist
 
 def test_post_publish_stage_policy_rejects_media_handoff_before_any_side_effect(tmp_path: Path) -> None:
     with pytest.raises(ValidationError, match="media handoff を受け付けません"):
-        PostPublishStagePolicy(tmp_path, "/publish", None, object())
+        PostPublishStagePolicy(tmp_path, "/publish", object(), requested=None)

--- a/tests/domains/test_post_publish.py
+++ b/tests/domains/test_post_publish.py
@@ -11,6 +11,7 @@ from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.post_publish import (
     PostPublishDecision,
     PostPublishReadiness,
+    PostPublishStagePolicy,
     _post_publish_readiness,
     evaluate,
     mark_complete,
@@ -139,3 +140,22 @@ def test_readiness_waits_when_no_live_collection_needs_followup(tmp_path: Path) 
 
     assert readiness.status == "waiting"
     assert readiness.collection is None
+
+
+def test_post_publish_stage_policy_adapts_target_prompt_completion_and_allowlist(tmp_path: Path) -> None:
+    collection = _collection(tmp_path)
+    policy = PostPublishStagePolicy(tmp_path, "/publish", None)
+
+    policy.resolve()
+    assert policy.waiting is False
+    assert "collection 'demo'" in policy.prompt_for()
+    for step in ("playlist-assignment", "pinned-comment", "metadata-audit"):
+        mark_complete(tmp_path, collection, step)
+    (tmp_path / "pinned_comment_history.json").write_text(
+        json.dumps({"schema_version": 1, "posted": {"video-1": {}}}) + "\n", encoding="utf-8"
+    )
+
+    assert policy.verify() == "demo"
+    policy.allows(tmp_path, {"post_publish_history.json", "pinned_comment_history.json"})
+    with pytest.raises(StateSyncError, match="unowned path"):
+        policy.allows(tmp_path, {"README.md"})

--- a/tests/domains/test_post_publish.py
+++ b/tests/domains/test_post_publish.py
@@ -159,3 +159,8 @@ def test_post_publish_stage_policy_adapts_target_prompt_completion_and_allowlist
     policy.allows(tmp_path, {"post_publish_history.json", "pinned_comment_history.json"})
     with pytest.raises(StateSyncError, match="unowned path"):
         policy.allows(tmp_path, {"README.md"})
+
+
+def test_post_publish_stage_policy_hides_private_state_from_constructor(tmp_path: Path) -> None:
+    with pytest.raises(TypeError, match="_completed"):
+        PostPublishStagePolicy(tmp_path, "/publish", _completed=None)  # type: ignore[call-arg]


### PR DESCRIPTION
## Summary
- planning / post-publish の readiness、prompt、成果検証、変更 allowlist を StagePolicy adapter に集約
- runner の stage 分岐と collection の nonlocal 持ち回りを除去
- media handoff 設定を MediaHandoffRequest に分離

Closes #4435