### PR TITLE
fix(documents): 分析成果物の解決をregistryへ統一する (#4445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `fix(documents)`: doctor と progress hook の analysis report 解決を operational artifact registry に統一し、分析 sidecar を進捗完了判定からも除外する（#4445）。
+
+- `feat(documents)`: operational artifact inventory に正準 filename・schema pair を検証して valid / invalid / latest instance と filename 日付基準の freshness を返す runtime API を追加する（#4444）。
+
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- `fix(documents)`: doctor と progress hook の analysis report 解決を operational artifact registry に統一し、分析 sidecar を進捗完了判定からも除外する（#4445）。
-
-- `feat(documents)`: operational artifact inventory に正準 filename・schema pair を検証して valid / invalid / latest instance と filename 日付基準の freshness を返す runtime API を追加する（#4444）。
-
 - `feat(wf-status)`: 制作状況 snapshot を要対応件数から各 collection の next action・成果物根拠へ走査できる technical / austere な運用キューへ再設計し、CSS filter の選択・focus と mobile containment を明確化する（#4405）。
 
 - `feat(documents)`: 候補 review View を番号・preview・固定 QA・確定操作が一続きに読める technical / austere な比較台帳へ再設計し、mobile containment と keyboard focus を明確化する（#4404）。

--- a/changelog.d/4445-consumers-use-registry.fixed.md
+++ b/changelog.d/4445-consumers-use-registry.fixed.md
@@ -1,0 +1,1 @@
+- doctor と progress hook の analysis report 解決を operational artifact registry に統一し、分析 sidecar を進捗完了判定からも除外する（#4445）。

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -1544,8 +1544,10 @@ def _resolve_wf_new_input_mode(channel_dir: Path) -> _WfNewInputMode:
         stale_reason = freshness.reason if freshness.is_stale else None
         if stale_reason == "missing":
             stale_reason = None
-        elif stale_reason is None and latest_data is not None and _analytics_data_exceeds_freshness_days(
-            latest_data[0], channel_dir
+        elif (
+            stale_reason is None
+            and latest_data is not None
+            and _analytics_data_exceeds_freshness_days(latest_data[0], channel_dir)
         ):
             stale_reason = "absolute"
         return _WfNewInputMode(

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -47,7 +47,7 @@ from youtube_automation.domains.channel_readiness import (
     evaluate_initial_setup_readiness,
     evaluate_ttp_wf_new_readiness,
 )
-from youtube_automation.domains.documents.schema_registry import RepositorySchema
+from youtube_automation.domains.documents.operational_artifacts import resolve_artifacts
 from youtube_automation.infrastructure.auth import (
     UPLOAD_REQUIRED_SCOPES,
     OAuthCredentialState,
@@ -65,7 +65,6 @@ from youtube_automation.infrastructure.collections.numbered_duplicates import (
     format_scan_error_reason,
     scan_numbered_duplicates,
 )
-from youtube_automation.infrastructure.documents.publishing import read_published_json_document
 from youtube_automation.infrastructure.retry import QUOTA_REASONS
 from youtube_automation.infrastructure.youtube.reporting_api import ReportingAPIClient
 from youtube_automation.infrastructure.youtube.streaming.state_reconciliation import reconcile_streaming_vps
@@ -78,7 +77,6 @@ AUTOMATION_PACKAGE_NAME = "youtube-channels-automation"
 SKILLS_SYNC_ARGV = ("uv", "run", "yt-skills", "sync", "--asset", "skills", "--force")
 SKILLS_SYNC_PRUNE_ARGV = (*SKILLS_SYNC_ARGV, "--prune", "--yes")
 SKILLS_SYNC_CMD = shlex.join(SKILLS_SYNC_ARGV)
-ANALYSIS_REPORT_FILENAME_RE = re.compile(r"analysis_\d{8}\.json")
 LEGACY_BUNDLED_SKILLS = (
     "onboard",
     "distrokid-prep",
@@ -1535,45 +1533,31 @@ def check_analytics_report(channel_dir: Path) -> CheckResult:
 
 
 def _resolve_wf_new_input_mode(channel_dir: Path) -> _WfNewInputMode:
-    reports_dir = channel_dir / "reports"
     data_dir = channel_dir / "data"
-    report_candidates = [
-        path
-        for path in _matching_files(reports_dir, "analysis_*.json")
-        if ANALYSIS_REPORT_FILENAME_RE.fullmatch(path.name)
-    ]
-    reports: list[Path] = []
-    invalid_report = False
-    for report in report_candidates:
-        try:
-            read_published_json_document(report, RepositorySchema.ANALYSIS_REPORT)
-        except AutomationError:
-            invalid_report = True
-        else:
-            reports.append(report)
+    reports = resolve_artifacts(channel_dir, "reports/analysis_*.json")
     benchmarks = _matching_files(data_dir, "benchmark_*.json")
     data_files = _matching_files(data_dir, "analytics_data_*.json")
 
-    if reports:
-        latest_report = _latest_filename_date(reports)
+    if reports.valid:
         latest_data = _latest_filename_date(data_files)
-        stale_reason: str | None = None
-        if latest_data is not None and (latest_report is None or latest_report[0] < latest_data[0]):
-            stale_reason = "relative"
+        freshness = reports.freshness(against=data_files)
+        stale_reason = freshness.reason if freshness.is_stale else None
+        if stale_reason == "missing":
+            stale_reason = None
         elif latest_data is not None and _analytics_data_exceeds_freshness_days(latest_data[0], channel_dir):
             stale_reason = "absolute"
         return _WfNewInputMode(
             mode="analytics mode",
-            report_count=len(reports),
+            report_count=len(reports.valid),
             benchmark_count=len(benchmarks),
             stale_report=stale_reason is not None,
             stale_reason=stale_reason,
-            invalid_report=invalid_report,
+            invalid_report=bool(reports.invalid),
         )
-    if invalid_report:
+    if reports.invalid:
         return _WfNewInputMode(
             mode="invalid analytics report",
-            report_count=len(report_candidates),
+            report_count=len(reports.invalid),
             benchmark_count=len(benchmarks),
             stale_report=False,
             invalid_report=True,

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -1544,7 +1544,9 @@ def _resolve_wf_new_input_mode(channel_dir: Path) -> _WfNewInputMode:
         stale_reason = freshness.reason if freshness.is_stale else None
         if stale_reason == "missing":
             stale_reason = None
-        elif latest_data is not None and _analytics_data_exceeds_freshness_days(latest_data[0], channel_dir):
+        elif stale_reason is None and latest_data is not None and _analytics_data_exceeds_freshness_days(
+            latest_data[0], channel_dir
+        ):
             stale_reason = "absolute"
         return _WfNewInputMode(
             mode="analytics mode",

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date, datetime
@@ -13,15 +12,13 @@ from youtube_automation.core.errors import AutomationError
 from youtube_automation.domains.collections.inventory import iter_collections
 from youtube_automation.domains.collections.workflow_state import WorkflowState
 from youtube_automation.domains.collections.workflow_state import read as read_workflow_state
-from youtube_automation.domains.documents.schema_registry import RepositorySchema
+from youtube_automation.domains.documents.operational_artifacts import resolve_artifacts
 from youtube_automation.domains.post_publish import verify_post_publish_completion
-from youtube_automation.infrastructure.documents.publishing import read_published_json_document
 
 STAGES = ("企画", "音源生成", "マスター化", "動画化", "サムネイル", "アップロード", "公開後処理", "分析")
 
 # /wf-status が定義する v2 phase 語彙を正規の段判定にも使う。
 WF_STATUS_PHASES = frozenset({"planning", "prepared", "cloud_owned", "mastered", "publishing", "complete"})
-_ANALYSIS_REPORT = re.compile(r"analysis_(\d{8})\.json\Z")
 
 
 @dataclass(frozen=True)
@@ -110,20 +107,9 @@ def _publish_date(state: WorkflowState) -> date | None:
 def _analysis_complete(root: Path, published_on: date | None) -> bool:
     if published_on is None:
         return False
-    reports = root / "reports"
-    if not reports.is_dir():
-        return False
-    for path in reports.glob("analysis_*.json"):
-        match = _ANALYSIS_REPORT.fullmatch(path.name)
-        if path.is_file() and match is not None:
-            try:
-                report_date = datetime.strptime(match.group(1), "%Y%m%d").date()
-            except ValueError:
-                continue
-            if report_date >= published_on:
-                read_published_json_document(path, RepositorySchema.ANALYSIS_REPORT)
-                return True
-    return False
+    reports = resolve_artifacts(root, "reports/analysis_*.json")
+    published_marker = Path(f"published_{published_on:%Y%m%d}.json")
+    return bool(reports.valid) and not reports.freshness(against=published_marker).is_stale
 
 
 def _completed_stages(root: Path, collection: Path, state: WorkflowState) -> frozenset[str]:

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -2698,6 +2698,23 @@ class TestCheckAnalyticsReport:
         assert "/analytics --collect" in r.next_action["instructions"]
         assert "/analytics --analyze" in r.next_action["instructions"]
 
+    def test_relative_stale_takes_priority_when_data_is_also_absolute_stale(self, tmp_path, monkeypatch):
+        """report が data より古い場合は data 自体も古くても相対鮮度を先に案内する。"""
+        monkeypatch.setattr(doctor, "_today_yyyymmdd", lambda: "20260702")
+        _write_analysis_pair(tmp_path, "20260621")
+
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        (data_dir / "analytics_data_20260622_120000.json").write_text("{}", encoding="utf-8")
+
+        result = doctor.check_analytics_report(tmp_path)
+
+        assert result.status == "fail"
+        assert "最新 data/analytics_data_*.json より古い" in result.message
+        assert "freshness_days" not in result.message
+        assert result.next_action is not None
+        assert result.next_action["instructions"].startswith("/analytics --analyze")
+
     def test_analysis_file_absolute_stale_respects_collection_ideate_override(self, tmp_path, monkeypatch):
         """collection-ideate freshness_days override は doctor の絶対鮮度判定にも効く."""
         monkeypatch.setattr(doctor, "_today_yyyymmdd", lambda: "20260702")

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -424,6 +424,7 @@ def test_should_not_complete_post_publish_for_other_video_or_analysis_before_pub
     reports = tmp_path / "reports"
     reports.mkdir()
     (reports / "analysis_20261340.json").write_text("{}", encoding="utf-8")
+    (reports / "analysis_20260721.vpd-ranking.json").write_text("{}", encoding="utf-8")
     _analysis_pair(reports, "20260719")
 
     message = _progress_message(tmp_path, capsys, command="gh pr checks 42")


### PR DESCRIPTION
## Summary
- doctor と progress_hook の analysis report 解決・検証・freshness 判定を operational artifact registry 経由へ統一
- progress_hook の完了判定でも分析 sidecar を除外する回帰テストを追加

Closes #4445