### PR TITLE
refactor(uploads): スケジュール設定を型付き設定へ移行 (#4439)

### DIFF
--- a/changelog.d/4439-schedule-consumers.changed.md
+++ b/changelog.d/4439-schedule-consumers.changed.md
@@ -1,0 +1,1 @@
+- uploads のスケジュール設定 consumer を解決済み `ScheduleConfig` に統一し、重複していた JSON loader を削除しました。

--- a/src/youtube_automation/commands/uploads/collection_uploader.py
+++ b/src/youtube_automation/commands/uploads/collection_uploader.py
@@ -23,7 +23,10 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--plan", action="store_true")
     parser.add_argument("--daemon", "-d", action="store_true")
     parser.add_argument("--collection", "-c")
-    parser.add_argument("--config")
+    parser.add_argument(
+        "--config",
+        help="schedule_config.json のファイルパス（既定: <channel_dir>/config/schedule_config.json）",
+    )
     parser.add_argument(
         "--allow-duration-outside-target",
         action="store_true",

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -241,8 +241,16 @@ def load_config_from_path(channel_dir_path: Path) -> ChannelConfig:
 
 
 def load_schedule_config(channel_dir_path: Path) -> ScheduleConfig:
-    """``config/schedule_config.json`` を読み、既定値と優先順位を解決する."""
-    path = channel_dir_path.resolve() / "config" / "schedule_config.json"
+    """channel root 配下の ``config/schedule_config.json`` を読み、既定値と優先順位を解決する."""
+    return load_schedule_config_from_file(channel_dir_path.resolve() / "config" / "schedule_config.json")
+
+
+def load_schedule_config_from_file(path: Path) -> ScheduleConfig:
+    """schedule_config JSON をファイルパス直指定で読み、既定値と優先順位を解決する.
+
+    `--config <path>` のように任意のパスを渡す CLI 経路のための入口。
+    channel root からの解決は `load_schedule_config` を使う。
+    """
     if not path.exists():
         return _build_schedule({})
     try:

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -298,6 +298,7 @@ def _build_schedule(raw: dict) -> ScheduleConfig:
         publish_time=str(schedule.get("publish_time") or schedule.get("day1_time") or "10:00"),
         cadence=tuple(str(day) for day in cadence),
         scheduling_enabled=scheduling_enabled,
+        scheduling_explicitly_disabled=schedule.get("auto_schedule_enabled") is False,
         category_id=str(upload.get("category_id", "10")),
         auto_create_playlist=bool(upload.get("auto_create_playlist", True)),
         max_retries=int(upload.get("max_retries", 3)),

--- a/src/youtube_automation/configuration/schedule.py
+++ b/src/youtube_automation/configuration/schedule.py
@@ -14,6 +14,7 @@ class ScheduleConfig:
     publish_time: str = "10:00"
     cadence: tuple[str, ...] = ()
     scheduling_enabled: bool = False
+    scheduling_explicitly_disabled: bool = False
     category_id: str = "10"
     auto_create_playlist: bool = True
     max_retries: int = 3

--- a/src/youtube_automation/domains/uploads/_complete_collection_executor.py
+++ b/src/youtube_automation/domains/uploads/_complete_collection_executor.py
@@ -6,6 +6,7 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
+from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.core.adapters import cost_tracker
 from youtube_automation.core.adapters.security import redact_sensitive_data
 from youtube_automation.core.adapters.youtube import complete_collection_quota_plan, quota_shortages
@@ -31,7 +32,7 @@ class CompleteCollectionExecutor:
         self,
         uploader,
         tracking_store,
-        config: dict,
+        config: ScheduleConfig,
         playlist_assignment,
         move_collection_to_live,
         upload_journal_factory: Callable[[Path], UploadJournal] = UploadJournal,
@@ -71,7 +72,7 @@ class CompleteCollectionExecutor:
         self.tracking_store.save(collection_path, tracking)
 
         post_processing_errors: list[str] = []
-        if self.config["collections_management"].get("auto_move_to_live", True):
+        if self.config.auto_move_to_live:
             try:
                 collection_path = self.move_collection_to_live(collection_path)
             except AutomationError as error:

--- a/src/youtube_automation/domains/uploads/_published_dates.py
+++ b/src/youtube_automation/domains/uploads/_published_dates.py
@@ -8,7 +8,7 @@ from datetime import datetime, timedelta, tzinfo
 from pathlib import Path
 from typing import ClassVar
 
-from youtube_automation.configuration import load_config
+from youtube_automation.configuration import ScheduleConfig, load_config
 from youtube_automation.core.adapters.runtime import get_schedule_timezone, resolve_default_publish_at
 from youtube_automation.core.errors import ValidationError, YouTubeAPIError
 from youtube_automation.infrastructure.google.youtube import execute_youtube_request, validate_youtube_response_items
@@ -54,28 +54,6 @@ def _published_datetime(video: object) -> datetime:
         raise ValidationError(f"published dates response has invalid publishedAt: {publish_at}") from exc
 
 
-def _scheduling_enabled(schedule_cfg: dict) -> bool:
-    """``schedule_config.json`` の ``schedule`` セクションからスケジュール公開有効性を判定する。
-
-    優先順位（#647 ユーザーが「予約投稿の設定をしたつもりが即時公開された」FB 対応）:
-
-    1. ``auto_schedule_enabled`` が明示的に ``true`` → 有効。
-    2. ``auto_schedule_enabled`` が明示的に ``false`` → 無効（予約日時を設定しない）。
-    3. キー未設定で ``cadence`` (非空) または ``publish_time`` が明示設定 → 暗黙オプトイン: 有効。
-    4. 上記いずれにも該当しなければ無効（即時公開）。
-
-    ``day1_time`` は旧テンプレ互換のため ``publish_time`` が無いときのフォールバックとして使うが、
-    「明示的なスケジュール設定」のシグナルとしては扱わない（過去テンプレで既定値が
-    入っていることがあるため）。
-    """
-    if "auto_schedule_enabled" in schedule_cfg:
-        return bool(schedule_cfg["auto_schedule_enabled"])
-
-    has_cadence = bool(schedule_cfg.get("cadence"))
-    has_publish_time = "publish_time" in schedule_cfg and bool(schedule_cfg.get("publish_time"))
-    return has_cadence or has_publish_time
-
-
 class PublishedDatesScheduler:
     """設定と YouTube service provider から公開日時を計算する。"""
 
@@ -92,7 +70,7 @@ class PublishedDatesScheduler:
 
     def __init__(
         self,
-        config: dict,
+        config: ScheduleConfig,
         youtube_service_provider: Callable[[], object],
         now_provider: Callable[[tzinfo | None], datetime] | None = None,
     ) -> None:
@@ -175,9 +153,8 @@ class PublishedDatesScheduler:
         Returns:
             ISO 8601 形式の公開日時文字列。予約日時を設定しない場合は None。
         """
-        schedule_cfg = self.config.get("schedule", {})
-        if not _scheduling_enabled(schedule_cfg):
-            if schedule_cfg.get("auto_schedule_enabled") is False:
+        if not self.config.scheduling_enabled:
+            if self.config.scheduling_explicitly_disabled:
                 logger.info("📅 公開設定: 即時公開（schedule.auto_schedule_enabled=false）")
                 return None
             default_publish_at = resolve_default_publish_at(load_config())
@@ -187,12 +164,12 @@ class PublishedDatesScheduler:
             logger.info("📅 公開設定: 即時公開（schedule_config.json で auto_schedule_enabled 未設定）")
             return None
 
-        publish_time = schedule_cfg.get("publish_time", schedule_cfg.get("day1_time", "17:00"))
+        publish_time = self.config.publish_time
         tz = get_schedule_timezone(self.config)
         hour, minute = map(int, publish_time.split(":"))
 
         # cadence 曜日を isoweekday に変換（未設定なら全曜日許可）
-        cadence = schedule_cfg.get("cadence", [])
+        cadence = self.config.cadence
         allowed_weekdays = {self._WEEKDAY_MAP[d.lower()] for d in cadence} if cadence else set(range(1, 8))
 
         now = self.now_provider(tz)

--- a/src/youtube_automation/domains/uploads/_tracking_io.py
+++ b/src/youtube_automation/domains/uploads/_tracking_io.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import now_in_schedule_tz
 from youtube_automation.core.errors import ValidationError, WorkflowStateError, WorkflowStateSectionTypeError
@@ -31,7 +32,7 @@ logger = logging.getLogger(__name__)
 class TrackingStore:
     """collection tracking と upload workflow state を永続化する。"""
 
-    def __init__(self, collections_root: Path, config: dict) -> None:
+    def __init__(self, collections_root: Path, config: ScheduleConfig) -> None:
         self.collections_root = collections_root
         self.config = config
 

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -1,6 +1,5 @@
 """Complete Collection upload orchestration owned by the uploads domain."""
 
-import json
 import logging
 from collections.abc import Callable
 from datetime import datetime
@@ -8,7 +7,7 @@ from pathlib import Path
 
 import schedule
 
-from youtube_automation.configuration import channel_dir, load_config
+from youtube_automation.configuration import channel_dir, load_config, load_schedule_config
 from youtube_automation.core.adapters.youtube import (
     DAILY_BUCKET_LIMITS,
     UNIT_COSTS,
@@ -34,7 +33,6 @@ from youtube_automation.infrastructure.filesystem import (
     make_directory,
     path_exists,
     path_is_directory,
-    read_file_text,
     rename_path,
 )
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
@@ -93,7 +91,10 @@ class CollectionUploader:
                 allow_duration_outside_target=allow_duration_outside_target,
             ),
         )
-        self.config = self._load_config()
+        config_root = (
+            self.config_path.parent.parent if self.config_path.parent.name == "config" else self.config_path.parent
+        )
+        self.config = load_schedule_config(config_root)
         self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
         self.upload_journal_factory = upload_journal_factory
         self.youtube_service = None
@@ -116,36 +117,6 @@ class CollectionUploader:
         )
 
     # ─── 設定・初期化 ───────────────────────────────
-
-    def _load_config(self) -> dict:
-        """スケジュール設定読み込み"""
-        default_config = {
-            "schedule": {"day1_time": "10:00", "timezone": "Asia/Tokyo"},
-            "upload_settings": {"category_id": "10"},
-            "collections_management": {"auto_move_to_live": True},
-            "api_limits": {"upload_quota_per_day": 6, "concurrent_uploads": 1, "delay_between_uploads": 5},
-        }
-
-        if path_exists(self.config_path):
-            try:
-                loaded_config = json.loads(read_file_text(self.config_path))
-                upload_settings = loaded_config.get("upload_settings")
-                if isinstance(upload_settings, dict) and upload_settings.get("privacy_status") is not None:
-                    logger.warning(
-                        "⚠️  schedule_config.json の upload_settings.privacy_status は参照されません。"
-                        "実効値は config/channel/youtube.json::privacy_status です (#1472)"
-                    )
-                for key, val in loaded_config.items():
-                    if isinstance(val, dict) and key in default_config:
-                        default_config[key].update(val)
-                    else:
-                        default_config[key] = val
-                return default_config
-            except (OSError, json.JSONDecodeError) as e:
-                logger.warning(f"⚠️  設定ファイル読み込みエラー: {e}")
-                logger.warning("デフォルト設定を使用します")
-
-        return default_config
 
     def initialize_youtube_service(self):
         """YouTube API サービス初期化"""
@@ -305,7 +276,6 @@ class CollectionUploader:
     def show_plan(self, collection_path: Path):
         """ドライラン — スケジュール計算のみ表示"""
         publish_at = self.published_dates.calculate_publish_at()
-        schedule_cfg = self.config.get("schedule", {})
 
         print(f"📋 アップロード計画: {collection_path.name}")
         print()
@@ -323,8 +293,7 @@ class CollectionUploader:
                 privacy_label = {"unlisted": "限定公開", "private": "非公開"}.get(privacy_status, privacy_status)
                 print(f"  📅 公開設定: {privacy_label} ({privacy_status})")
                 print("     └ config/channel/youtube.json::privacy_status を反映")
-            looks_like_schedule_intent = any(schedule_cfg.get(k) for k in ("cadence", "publish_time", "day1_time"))
-            if looks_like_schedule_intent and schedule_cfg.get("auto_schedule_enabled") is False:
+            if not self.config.scheduling_enabled and self.config.cadence:
                 print(
                     "  ⚠️  schedule.auto_schedule_enabled が false に設定されています。"
                     "予約投稿したい場合は true に変更してください"
@@ -362,9 +331,9 @@ class CollectionUploader:
         """自動スケジュール実行（常駐プロセス）"""
         config = load_config()
         logger.info(f"🤖 {config.meta.channel_name} - Collection Uploader 開始")
-        logger.info(f"⏰ 投稿時間: {self.config['schedule']['day1_time']}")
+        logger.info(f"⏰ 投稿時間: {self.config.publish_time}")
 
-        schedule.every().day.at(self.config["schedule"]["day1_time"]).do(self._daily_check_and_upload)
+        schedule.every().day.at(self.config.publish_time).do(self._daily_check_and_upload)
 
         logger.info("🔄 スケジューラー開始（Ctrl+C で終了）")
 

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -7,7 +7,8 @@ from pathlib import Path
 
 import schedule
 
-from youtube_automation.configuration import channel_dir, load_config, load_schedule_config
+from youtube_automation.configuration import ScheduleConfig, channel_dir, load_config
+from youtube_automation.configuration.loader import load_schedule_config_from_file
 from youtube_automation.core.adapters.youtube import (
     DAILY_BUCKET_LIMITS,
     UNIT_COSTS,
@@ -91,10 +92,7 @@ class CollectionUploader:
                 allow_duration_outside_target=allow_duration_outside_target,
             ),
         )
-        config_root = (
-            self.config_path.parent.parent if self.config_path.parent.name == "config" else self.config_path.parent
-        )
-        self.config = load_schedule_config(config_root)
+        self.config = load_schedule_config_from_file(self.config_path)
         self.tracking_store = tracking_store or TrackingStore(self.collections_root, self.config)
         self.upload_journal_factory = upload_journal_factory
         self.youtube_service = None
@@ -117,6 +115,18 @@ class CollectionUploader:
         )
 
     # ─── 設定・初期化 ───────────────────────────────
+
+    def _apply_config(self, config: ScheduleConfig) -> None:
+        """解決済み設定を差し替え、同じ設定を参照する collaborator へ一括反映する。
+
+        ``ScheduleConfig`` は frozen なため差し替えは新インスタンスになる。
+        collaborator は構築時に受け取った参照を保持するので、ここで同期しないと
+        古い設定を読み続ける。
+        """
+        self.config = config
+        self.tracking_store.config = config
+        self.published_dates.config = config
+        self.complete_collection_executor.config = config
 
     def initialize_youtube_service(self):
         """YouTube API サービス初期化"""
@@ -293,7 +303,7 @@ class CollectionUploader:
                 privacy_label = {"unlisted": "限定公開", "private": "非公開"}.get(privacy_status, privacy_status)
                 print(f"  📅 公開設定: {privacy_label} ({privacy_status})")
                 print("     └ config/channel/youtube.json::privacy_status を反映")
-            if not self.config.scheduling_enabled and self.config.cadence:
+            if self.config.scheduling_explicitly_disabled:
                 print(
                     "  ⚠️  schedule.auto_schedule_enabled が false に設定されています。"
                     "予約投稿したい場合は true に変更してください"

--- a/src/youtube_automation/domains/uploads/shorts.py
+++ b/src/youtube_automation/domains/uploads/shorts.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from youtube_automation.configuration import channel_dir, load_config
+from youtube_automation.configuration import channel_dir, load_config, load_schedule_config
 from youtube_automation.core.adapters.media import CollectionPaths
 from youtube_automation.core.adapters.runtime import get_schedule_timezone
 from youtube_automation.core.errors import (
@@ -28,7 +28,7 @@ from youtube_automation.domains.uploads._published_dates import PublishedDatesSc
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
 from youtube_automation.domains.uploads.upload_journal import UploadJournal
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
-from youtube_automation.infrastructure.filesystem import list_directory, path_exists, read_json
+from youtube_automation.infrastructure.filesystem import list_directory, path_exists
 from youtube_automation.infrastructure.google.youtube import YouTubeClients
 
 logger = logging.getLogger(__name__)
@@ -88,7 +88,7 @@ class ShortUploader:
         self.collections_root = Path(collections_root)
         self.uploader = YouTubeAutoUploader(collections_root, youtube_clients)
         self.channel_dir = channel_dir()
-        self.schedule_config = self._load_schedule_config()
+        self.schedule_config = load_schedule_config(self.channel_dir)
         self.tracking_store = (
             tracking_store if tracking_store is not None else TrackingStore(self.collections_root, self.schedule_config)
         )
@@ -98,24 +98,6 @@ class ShortUploader:
             if published_dates is not None
             else PublishedDatesScheduler(self.schedule_config, lambda: self.uploader.youtube)
         )
-
-    # ─── 設定読み込み ────────────────────────────────
-
-    def _load_schedule_config(self) -> dict:
-        """`config/schedule_config.json` を読み込む（存在しなければ空 dict）.
-
-        schedule_config は新 ChannelConfig には含めず、JSON を都度読みする
-        旧 `CollectionUploader` のパターンを踏襲（タイムゾーンや投稿間隔は
-        運用ごとに上書きされやすいため、シングルトンに乗せない）。
-        """
-        path = self.channel_dir / "config" / "schedule_config.json"
-        if not path_exists(path):
-            return {}
-        try:
-            return read_json(path)
-        except (OSError, json.JSONDecodeError) as e:
-            logger.warning(f"schedule_config.json 読み込み失敗: {e}")
-            return {}
 
     # ─── 投稿間隔チェック (plan 要件 6.1) ─────────────
 

--- a/src/youtube_automation/infrastructure/runtime/schedule.py
+++ b/src/youtube_automation/infrastructure/runtime/schedule.py
@@ -2,29 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 from datetime import datetime
-from typing import Any
 from zoneinfo import ZoneInfo
 
-from youtube_automation.core.errors import ConfigError, ValidationError
-
-SCHEDULE_SECTION = "schedule"
-TIMEZONE_KEY = "timezone"
-DEFAULT_SCHEDULE_TIMEZONE = "Asia/Tokyo"
+from youtube_automation.configuration import ScheduleConfig
+from youtube_automation.core.errors import ValidationError
 
 
-def get_schedule_timezone(schedule_config: Mapping[str, Any]) -> ZoneInfo:
+def get_schedule_timezone(schedule_config: ScheduleConfig) -> ZoneInfo:
     """Resolve the configured schedule timezone."""
-    schedule = schedule_config.get(SCHEDULE_SECTION, {})
-    if not isinstance(schedule, Mapping):
-        raise ConfigError("schedule_config.json の schedule は object である必要があります")
-
-    timezone_name = schedule.get(TIMEZONE_KEY, DEFAULT_SCHEDULE_TIMEZONE)
-    if not isinstance(timezone_name, str) or not timezone_name:
-        raise ConfigError("schedule_config.json の schedule.timezone は空でない文字列である必要があります")
-
-    return ZoneInfo(timezone_name)
+    return schedule_config.timezone
 
 
 def ensure_tz_aware(dt: datetime, *, context: str) -> datetime:
@@ -53,7 +40,7 @@ def ensure_tz_aware(dt: datetime, *, context: str) -> datetime:
     return dt
 
 
-def now_in_schedule_tz(schedule_config: Mapping[str, Any]) -> datetime:
+def now_in_schedule_tz(schedule_config: ScheduleConfig) -> datetime:
     """schedule.timezone の現在時刻を TZ-aware datetime として返す.
 
     永続化用 timestamp の生成を一点に集約し、`datetime.now()`（TZ-naive）の混入を防ぐ。

--- a/tests/configuration/test_schedule.py
+++ b/tests/configuration/test_schedule.py
@@ -5,7 +5,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from youtube_automation.configuration.loader import load_schedule_config
+from youtube_automation.configuration.loader import load_schedule_config, load_schedule_config_from_file
 
 
 @pytest.mark.parametrize(
@@ -61,6 +61,32 @@ def test_missing_file_uses_explicit_defaults(tmp_path: Path) -> None:
     assert config.scheduling_enabled is False
     assert config.auto_move_to_live is True
     assert config.upload_quota_per_day == 6
+
+
+def test_from_file_reads_a_path_outside_a_config_directory(tmp_path: Path) -> None:
+    path = tmp_path / "backup" / "my_schedule.json"
+    path.parent.mkdir()
+    payload = {"schedule": {"auto_schedule_enabled": True, "publish_time": "21:00"}}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    config = load_schedule_config_from_file(path)
+
+    assert config.scheduling_enabled is True
+    assert config.publish_time == "21:00"
+
+
+def test_from_file_uses_defaults_when_the_file_is_missing(tmp_path: Path) -> None:
+    config = load_schedule_config_from_file(tmp_path / "absent.json")
+
+    assert config.publish_time == "10:00"
+    assert config.scheduling_enabled is False
+
+
+def test_scheduling_explicitly_disabled_tracks_the_auto_schedule_flag(tmp_path: Path) -> None:
+    _write_schedule(tmp_path, {"schedule": {"auto_schedule_enabled": False}})
+
+    assert load_schedule_config(tmp_path).scheduling_explicitly_disabled is True
+    assert load_schedule_config_from_file(tmp_path / "absent.json").scheduling_explicitly_disabled is False
 
 
 def test_warns_that_upload_privacy_status_is_ignored(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -377,8 +377,7 @@ def _make_uploader_with_collection_mock(tmp_path: Path):
         mock_cls.return_value = mock_inner
         uploader = CollectionUploader(collections_root=str(tmp_path / "collections"))
         # auto_move_to_live を無効化してパス変動を防ぐ
-        uploader.config = replace(uploader.config, auto_move_to_live=False)
-        uploader.complete_collection_executor.config = uploader.config
+        uploader._apply_config(replace(uploader.config, auto_move_to_live=False))
         return uploader, mock_inner
 
 
@@ -554,8 +553,7 @@ def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
             collections_root=str(tmp_path / "collections"),
             config_path=str(config_path),
         )
-        uploader.config = replace(uploader.config, auto_move_to_live=False)
-        uploader.complete_collection_executor.config = uploader.config
+        uploader._apply_config(replace(uploader.config, auto_move_to_live=False))
         return uploader, mock_inner
 
 
@@ -771,6 +769,67 @@ class TestDefaultPublishTimeFallback:
 
         assert result is None
         assert not mock_resolve.called
+
+
+class TestScheduleConfigPathResolution:
+    """#4439: `--config` に渡した任意パスの schedule_config を直接読むこと。"""
+
+    def test_reads_config_path_outside_a_config_directory(self, tmp_path):
+        from youtube_automation.domains.uploads.collection import CollectionUploader
+
+        # Given: config/ 配下ではない運用者指定のパスに設定を置く
+        config_path = tmp_path / "backup" / "my_schedule.json"
+        config_path.parent.mkdir(parents=True)
+        config_path.write_text(
+            json.dumps({"schedule": {"auto_schedule_enabled": True, "cadence": ["mon"], "publish_time": "21:00"}}),
+            encoding="utf-8",
+        )
+
+        with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader"):
+            uploader = CollectionUploader(
+                collections_root=str(tmp_path / "collections"),
+                config_path=str(config_path),
+            )
+
+        # Then: デフォルトへ黙って落ちず、指定ファイルの内容が反映される
+        assert uploader.config.scheduling_enabled is True
+        assert uploader.config.cadence == ("mon",)
+        assert uploader.config.publish_time == "21:00"
+
+    def test_apply_config_propagates_to_collaborators(self, tmp_path):
+        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+
+        uploader._apply_config(replace(uploader.config, publish_time="23:45"))
+
+        assert uploader.config.publish_time == "23:45"
+        assert uploader.tracking_store.config is uploader.config
+        assert uploader.published_dates.config is uploader.config
+        assert uploader.complete_collection_executor.config is uploader.config
+
+
+class TestShowPlanScheduleWarning:
+    """#4439: auto_schedule_enabled=false の取りこぼしを cadence 未設定でも警告すること。"""
+
+    _WARNING = "schedule.auto_schedule_enabled が false に設定されています"
+
+    def test_warns_when_scheduling_is_explicitly_disabled_without_cadence(self, tmp_path, capsys):
+        uploader, _ = _make_uploader_with_schedule_config(
+            tmp_path,
+            {"schedule": {"auto_schedule_enabled": False, "publish_time": "21:00", "timezone": "Asia/Tokyo"}},
+        )
+
+        with patch.object(uploader.published_dates, "calculate_publish_at", return_value=None):
+            uploader.show_plan(tmp_path / "collection")
+
+        assert self._WARNING in capsys.readouterr().out
+
+    def test_does_not_warn_when_scheduling_is_merely_unset(self, tmp_path, capsys):
+        uploader, _ = _make_uploader_with_schedule_config(tmp_path, {"schedule": {"timezone": "Asia/Tokyo"}})
+
+        with patch.object(uploader.published_dates, "calculate_publish_at", return_value=None):
+            uploader.show_plan(tmp_path / "collection")
+
+        assert self._WARNING not in capsys.readouterr().out
 
 
 class TestPublishedDatesQuotaRecording:
@@ -1064,8 +1123,7 @@ class TestExecuteCompleteCollectionResume:
 
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config = replace(uploader.config, auto_move_to_live=True)
-        uploader.complete_collection_executor.config = uploader.config
+        uploader._apply_config(replace(uploader.config, auto_move_to_live=True))
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_PLAYLIST_FAILED",
@@ -1094,8 +1152,7 @@ class TestExecuteCompleteCollectionResume:
         """dedup skip 時も live 移動後の tracking/workflow-state に既存 video_id を記録する."""
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config = replace(uploader.config, auto_move_to_live=True)
-        uploader.complete_collection_executor.config = uploader.config
+        uploader._apply_config(replace(uploader.config, auto_move_to_live=True))
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_EXISTING",
@@ -1130,8 +1187,7 @@ class TestExecuteCompleteCollectionResume:
         """rename 完了後の Windows access denied でも live 側の後処理を完了する."""
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config = replace(uploader.config, auto_move_to_live=True)
-        uploader.complete_collection_executor.config = uploader.config
+        uploader._apply_config(replace(uploader.config, auto_move_to_live=True))
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_MOVED",

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -11,10 +11,12 @@ import json
 import logging
 import shutil
 import sys
+from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
 
 import pytest
 from googleapiclient.errors import HttpError
@@ -22,6 +24,7 @@ from httplib2 import Response
 
 from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
 from tests.helpers.video_description import write_video_description_pair
+from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.domains.uploads.collection import PlaylistAssignment, PublishedDatesScheduler, TrackingStore
 
 sys.path.insert(0, str(REPO_ROOT))
@@ -374,7 +377,8 @@ def _make_uploader_with_collection_mock(tmp_path: Path):
         mock_cls.return_value = mock_inner
         uploader = CollectionUploader(collections_root=str(tmp_path / "collections"))
         # auto_move_to_live を無効化してパス変動を防ぐ
-        uploader.config["collections_management"]["auto_move_to_live"] = False
+        uploader.config = replace(uploader.config, auto_move_to_live=False)
+        uploader.complete_collection_executor.config = uploader.config
         return uploader, mock_inner
 
 
@@ -539,7 +543,8 @@ def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
     """schedule_config.json を指定して CollectionUploader を構築する."""
     from youtube_automation.domains.uploads.collection import CollectionUploader
 
-    config_path = tmp_path / "schedule_config.json"
+    config_path = tmp_path / "config" / "schedule_config.json"
+    config_path.parent.mkdir(exist_ok=True)
     config_path.write_text(json.dumps(schedule_config), encoding="utf-8")
 
     with patch("youtube_automation.domains.uploads.collection.YouTubeAutoUploader") as mock_cls:
@@ -549,7 +554,8 @@ def _make_uploader_with_schedule_config(tmp_path: Path, schedule_config: dict):
             collections_root=str(tmp_path / "collections"),
             config_path=str(config_path),
         )
-        uploader.config["collections_management"]["auto_move_to_live"] = False
+        uploader.config = replace(uploader.config, auto_move_to_live=False)
+        uploader.complete_collection_executor.config = uploader.config
         return uploader, mock_inner
 
 
@@ -773,7 +779,7 @@ class TestPublishedDatesQuotaRecording:
     def _make_scheduler_with_mock_service(self):
         mock_service = MagicMock()
         scheduler = PublishedDatesScheduler(
-            {"schedule": {"timezone": "Asia/Tokyo"}},
+            ScheduleConfig(),
             lambda: mock_service,
         )
         return scheduler, mock_service
@@ -1058,7 +1064,8 @@ class TestExecuteCompleteCollectionResume:
 
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config["collections_management"]["auto_move_to_live"] = True
+        uploader.config = replace(uploader.config, auto_move_to_live=True)
+        uploader.complete_collection_executor.config = uploader.config
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_PLAYLIST_FAILED",
@@ -1087,7 +1094,8 @@ class TestExecuteCompleteCollectionResume:
         """dedup skip 時も live 移動後の tracking/workflow-state に既存 video_id を記録する."""
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config["collections_management"]["auto_move_to_live"] = True
+        uploader.config = replace(uploader.config, auto_move_to_live=True)
+        uploader.complete_collection_executor.config = uploader.config
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_EXISTING",
@@ -1122,7 +1130,8 @@ class TestExecuteCompleteCollectionResume:
         """rename 完了後の Windows access denied でも live 側の後処理を完了する."""
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
         uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
-        uploader.config["collections_management"]["auto_move_to_live"] = True
+        uploader.config = replace(uploader.config, auto_move_to_live=True)
+        uploader.complete_collection_executor.config = uploader.config
         mock_inner.upload_collection.return_value = {
             "complete_video": {
                 "video_id": "V_MOVED",
@@ -1476,7 +1485,7 @@ def test_execute_collection_suppresses_lower_default_publish_fallback_when_sched
 class TestScheduleConfigPrivacyStatusDeprecation:
     """#1472: schedule_config.json::upload_settings.privacy_status は未参照。
 
-    実効値は config/channel/youtube.json::privacy_status に一本化し、
+    実効値は config/channel/youtube.json::youtube.privacy_status に一本化し、
     残存設定には警告で案内する。
     """
 
@@ -1488,15 +1497,15 @@ class TestScheduleConfigPrivacyStatusDeprecation:
                 tmp_path,
                 {"upload_settings": {"privacy_status": "unlisted"}},
             )
-        assert "upload_settings.privacy_status は参照されません" in caplog.text
-        assert "youtube.json::privacy_status" in caplog.text
+        assert "upload_settings.privacy_status は無視されます" in caplog.text
+        assert "youtube.json::youtube.privacy_status" in caplog.text
 
     def test_default_config_has_no_privacy_status_and_no_warning(self, tmp_path, caplog):
         import logging
 
         with caplog.at_level(logging.WARNING, logger="youtube_automation.commands.uploads.collection_uploader"):
             uploader, _ = _make_uploader_with_collection_mock(tmp_path)
-        assert "privacy_status" not in uploader.config["upload_settings"]
+        assert not hasattr(uploader.config, "privacy_status")
         assert "upload_settings.privacy_status" not in caplog.text
 
 
@@ -1505,7 +1514,7 @@ class TestTrackingStoreAtomicity:
 
     def test_save_leaves_no_tmp_file_and_roundtrips(self, tmp_path):
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
-        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
+        store = TrackingStore(tmp_path / "collections", ScheduleConfig(timezone=ZoneInfo("UTC")))
 
         tracking = store.load(col)
         tracking["status"] = "updated"
@@ -1519,7 +1528,7 @@ class TestTrackingStoreAtomicity:
     def test_load_returns_none_and_quarantines_corrupt_file(self, tmp_path):
         col, tracking_path = _make_tracking_collection(tmp_path, resume_uri=None)
         tracking_path.write_text("{truncated", encoding="utf-8")
-        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
+        store = TrackingStore(tmp_path / "collections", ScheduleConfig(timezone=ZoneInfo("UTC")))
 
         result = store.load(col)
 
@@ -1535,7 +1544,7 @@ class TestTrackingStoreAtomicity:
 
         col, _ = _make_tracking_collection(tmp_path, resume_uri=None)
         state_path = col / "workflow-state.json"
-        store = TrackingStore(tmp_path / "collections", {"schedule": {"timezone": "UTC"}})
+        store = TrackingStore(tmp_path / "collections", ScheduleConfig(timezone=ZoneInfo("UTC")))
 
         def update_after_concurrent_writer(path, updater):
             owner_update(path, lambda state: state.__setitem__("concurrent_marker", "preserved"))

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -5,6 +5,7 @@ from typing import ClassVar
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
+from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.domains.uploads.collection import PublishedDatesScheduler
 
 TZ = ZoneInfo("Asia/Tokyo")
@@ -20,14 +21,12 @@ def calculate_publish_at(
     """本番 collaborator を固定時刻・既存公開日で実行するテストadapter。"""
 
     scheduler = PublishedDatesScheduler(
-        {
-            "schedule": {
-                "auto_schedule_enabled": auto_schedule_enabled,
-                "cadence": cadence or [],
-                "publish_time": publish_time,
-                "timezone": "Asia/Tokyo",
-            }
-        },
+        ScheduleConfig(
+            timezone=TZ,
+            scheduling_enabled=auto_schedule_enabled,
+            cadence=tuple(cadence or ()),
+            publish_time=publish_time,
+        ),
         MagicMock(),
     )
     scheduler.get_published_dates = MagicMock(return_value=existing_dates)
@@ -127,37 +126,39 @@ class TestCadenceScheduling:
 
 
 class TestSchedulingEnabledHeuristic:
-    """schedule_config.json から予約公開有効性を判定する観測契約。"""
+    """解決済み ScheduleConfig から予約公開有効性を判定する観測契約。"""
 
     @staticmethod
-    def _calculate(schedule: dict) -> str | None:
-        scheduler = PublishedDatesScheduler({"schedule": schedule}, MagicMock())
+    def _calculate(*, enabled: bool, cadence: tuple[str, ...] = (), publish_time: str = "10:00") -> str | None:
+        scheduler = PublishedDatesScheduler(
+            ScheduleConfig(scheduling_enabled=enabled, cadence=cadence, publish_time=publish_time), MagicMock()
+        )
         scheduler.get_published_dates = MagicMock(return_value=set())
         return scheduler.calculate_publish_at()
 
     def test_explicit_true_enables(self):
-        assert self._calculate({"auto_schedule_enabled": True}) is not None
+        assert self._calculate(enabled=True) is not None
 
     def test_explicit_false_disables_even_when_cadence_present(self):
         """auto_schedule_enabled=false が明示されていればスケジュール無効（後方互換）."""
-        assert self._calculate({"auto_schedule_enabled": False, "cadence": ["tue", "thu", "sat"]}) is None
+        assert self._calculate(enabled=False, cadence=("tue", "thu", "sat")) is None
 
     def test_cadence_alone_implies_enabled(self):
         """cadence が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
-        assert self._calculate({"cadence": ["tue", "thu", "sat"]}) is not None
+        assert self._calculate(enabled=True, cadence=("tue", "thu", "sat")) is not None
 
     def test_publish_time_alone_implies_enabled(self):
         """publish_time が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
-        assert self._calculate({"publish_time": "20:00"}) is not None
+        assert self._calculate(enabled=True, publish_time="20:00") is not None
 
     def test_empty_cadence_does_not_imply_enabled(self):
         """空 cadence はオプトインシグナルにならない."""
-        assert self._calculate({"cadence": []}) is None
+        assert self._calculate(enabled=False) is None
 
     def test_day1_time_alone_does_not_imply_enabled(self):
         """day1_time のみは過去テンプレで既定値が入っていることがあるためシグナルにしない."""
         # 旧テンプレ互換（auto_schedule_enabled なしで day1_time のみ）はスケジュール無効
-        assert self._calculate({"day1_time": "20:00", "timezone": "Asia/Tokyo"}) is None
+        assert self._calculate(enabled=False, publish_time="20:00") is None
 
     def test_empty_dict_disables(self):
-        assert self._calculate({}) is None
+        assert self._calculate(enabled=False) is None

--- a/tests/domains/uploads/test_short_uploader.py
+++ b/tests/domains/uploads/test_short_uploader.py
@@ -112,11 +112,15 @@ def _make_short_uploader(
             mock_inner.upload_video.return_value = "V"
             ...
     """
+    from youtube_automation.configuration import ScheduleConfig
     from youtube_automation.domains.uploads import shorts as su_mod
+
+    raw_schedule = (schedule_config or {}).get("schedule", {})
+    resolved_schedule = ScheduleConfig(timezone=ZoneInfo(raw_schedule.get("timezone", "Asia/Tokyo")))
 
     with (
         patch.object(su_mod, "YouTubeAutoUploader") as mock_cls,
-        patch.object(su_mod.ShortUploader, "_load_schedule_config", return_value=schedule_config or {}),
+        patch.object(su_mod, "load_schedule_config", return_value=resolved_schedule),
     ):
         mock_uploader = MagicMock()
         mock_cls.return_value = mock_uploader
@@ -174,6 +178,13 @@ class TestInit:
         with _make_short_uploader() as (uploader, mock_inner):
             # Then: `uploader.uploader` 属性が YouTubeAutoUploader モックを指す
             assert uploader.uploader is mock_inner
+
+    def test_missing_schedule_config_uses_resolved_defaults(self):
+        """schedule_config.json 欠落時も typed loader の既定値を保持する。"""
+        from youtube_automation.configuration import ScheduleConfig
+
+        with _make_short_uploader(schedule_config={}) as (uploader, _):
+            assert uploader.schedule_config == ScheduleConfig()
 
     def test_short_uploader_accepts_shared_tracking_and_published_date_collaborators(self):
         """Collection uploader と同じ collaborator を明示注入できる。"""

--- a/tests/infrastructure/runtime/test_schedule.py
+++ b/tests/infrastructure/runtime/test_schedule.py
@@ -5,7 +5,8 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from youtube_automation.core.errors import ConfigError, ValidationError
+from youtube_automation.configuration import ScheduleConfig
+from youtube_automation.core.errors import ValidationError
 from youtube_automation.infrastructure.runtime.schedule import (
     ensure_tz_aware,
     get_schedule_timezone,
@@ -14,26 +15,16 @@ from youtube_automation.infrastructure.runtime.schedule import (
 
 
 def test_get_schedule_timezone_uses_configured_timezone():
-    tz = get_schedule_timezone({"schedule": {"timezone": "America/New_York"}})
+    tz = get_schedule_timezone(ScheduleConfig(timezone=ZoneInfo("America/New_York")))
 
     assert tz.key == "America/New_York"
     assert datetime(2026, 1, 1, tzinfo=tz).utcoffset() == timedelta(hours=-5)
 
 
 def test_get_schedule_timezone_defaults_to_tokyo_when_schedule_is_missing():
-    tz = get_schedule_timezone({})
+    tz = get_schedule_timezone(ScheduleConfig())
 
     assert datetime(2026, 1, 1, tzinfo=tz).utcoffset() == timedelta(hours=9)
-
-
-def test_get_schedule_timezone_rejects_non_mapping_schedule():
-    with pytest.raises(ConfigError, match="schedule"):
-        get_schedule_timezone({"schedule": "Asia/Tokyo"})
-
-
-def test_get_schedule_timezone_rejects_empty_timezone():
-    with pytest.raises(ConfigError, match="schedule.timezone"):
-        get_schedule_timezone({"schedule": {"timezone": ""}})
 
 
 # ─── ensure_tz_aware（書き込み側 TZ-naive 検出の防御コード, #533） ───
@@ -69,19 +60,14 @@ def test_ensure_tz_aware_includes_context_in_message():
 
 
 def test_now_in_schedule_tz_returns_tz_aware_datetime():
-    now = now_in_schedule_tz({"schedule": {"timezone": "Asia/Tokyo"}})
+    now = now_in_schedule_tz(ScheduleConfig())
 
     assert now.tzinfo is not None
     assert now.utcoffset() == timedelta(hours=9)
 
 
 def test_now_in_schedule_tz_defaults_to_tokyo():
-    now = now_in_schedule_tz({})
+    now = now_in_schedule_tz(ScheduleConfig())
 
     assert now.tzinfo is not None
     assert now.utcoffset() == timedelta(hours=9)
-
-
-def test_now_in_schedule_tz_rejects_invalid_schedule_config():
-    with pytest.raises(ConfigError, match="schedule"):
-        now_in_schedule_tz({"schedule": "Asia/Tokyo"})


### PR DESCRIPTION
## Summary
- uploads consumer を型付き `ScheduleConfig` に移行
- `CollectionUploader` / `ShortUploader` の重複 loader を削除
- runtime helper と collaborator の属性アクセスを統一し、明示無効化と設定欠落の経路をテストで固定

Closes #4439