### PR TITLE
test(uploads): now_provider で cadence 時刻を固定する (#4457)

### DIFF
--- a/changelog.d/4457-published-dates-now-provider.changed.md
+++ b/changelog.d/4457-published-dates-now-provider.changed.md
@@ -1,1 +1,1 @@
-`PublishedDatesScheduler` の cadence テストを datetime の module global patch から `now_provider` 注入へ移し、時刻 seam を実際のテスト経路で検証するようにした。
+- `PublishedDatesScheduler` の cadence テストを datetime の module global patch から `now_provider` 注入へ移し、時刻 seam を実際のテスト経路で検証するようにした（#4457）。

--- a/changelog.d/4457-published-dates-now-provider.changed.md
+++ b/changelog.d/4457-published-dates-now-provider.changed.md
@@ -1,0 +1,1 @@
+`PublishedDatesScheduler` の cadence テストを datetime の module global patch から `now_provider` 注入へ移し、時刻 seam を実際のテスト経路で検証するようにした。

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -2,7 +2,7 @@
 
 from datetime import date, datetime
 from typing import ClassVar
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 from zoneinfo import ZoneInfo
 
 from youtube_automation.configuration import ScheduleConfig
@@ -28,16 +28,10 @@ def calculate_publish_at(
             publish_time=publish_time,
         ),
         MagicMock(),
+        now_provider=lambda timezone: now,
     )
     scheduler.get_published_dates = MagicMock(return_value=existing_dates)
-
-    class FixedDateTime(datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return now
-
-    with patch("youtube_automation.domains.uploads._published_dates.datetime", FixedDateTime):
-        return scheduler.calculate_publish_at()
+    return scheduler.calculate_publish_at()
 
 
 class TestCadenceScheduling:

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -28,7 +28,8 @@ def calculate_publish_at(
             publish_time=publish_time,
         ),
         MagicMock(),
-        now_provider=lambda timezone: now,
+        # now は Asia/Tokyo 付きの固定値なので、渡される tz は使わない
+        now_provider=lambda _tz: now,
     )
     scheduler.get_published_dates = MagicMock(return_value=existing_dates)
     return scheduler.calculate_publish_at()


### PR DESCRIPTION
## Summary
- cadence テストの固定時刻を PublishedDatesScheduler.now_provider から注入
- datetime global patch とテスト専用 FixedDateTime を削除

Closes #4457