### PR TITLE
fix(uploads): preflight責務をupload境界へ統一する (#4458)

### DIFF
--- a/changelog.d/4458-unify-upload-preflight.fixed.md
+++ b/changelog.d/4458-unify-upload-preflight.fixed.md
@@ -1,0 +1,1 @@
+`YouTubeAutoUploader` を upload preflight の単一責務境界とし、collection 骨格・認証チャンネル・メタデータ品質の検査がどの CLI 経路でも一度だけ実行されるよう統一した。

--- a/changelog.d/4458-unify-upload-preflight.fixed.md
+++ b/changelog.d/4458-unify-upload-preflight.fixed.md
@@ -1,1 +1,1 @@
-`YouTubeAutoUploader` を upload preflight の単一責務境界とし、collection 骨格・認証チャンネル・メタデータ品質の検査がどの CLI 経路でも一度だけ実行されるよう統一した。
+`YouTubeAutoUploader` を upload preflight の単一責務境界とし、collection 骨格・認証チャンネル・メタデータ品質の検査がどの CLI 経路でも一度だけ実行されるよう統一した。`yt-upload-collection --plan` のドライランも同じ検査集合を通し、fail-closed 通知の stage は preflight と実行系を区別して送るようにした。

--- a/src/youtube_automation/commands/uploads/collection_uploader.py
+++ b/src/youtube_automation/commands/uploads/collection_uploader.py
@@ -51,18 +51,32 @@ def run(args: argparse.Namespace) -> None:
             return
         notifications = PipelineNotificationBridge(create_discord_notification_sink())
         channel = load_config().meta.channel_short
+
+        def notify_abort(stage: str) -> None:
+            notifications.emit(
+                NotificationEventKind.FAIL_CLOSED_ABORTED,
+                channel=channel,
+                collection=target.name,
+                stage=stage,
+            )
+
         if args.plan:
+            # show_plan は表示専用なので、ドライランでも実行時と同じ検査集合を
+            # 通すために upload 境界の preflight を明示的に依頼する。
+            try:
+                uploader.preflight_check(target)
+            except (AutomationError, OSError, ValueError):
+                notify_abort("upload-preflight")
+                raise
             uploader.show_plan(target)
         else:
+            # この try は preflight だけでなく execute_next_step 全体（実アップロード /
+            # tracking I/O / quota 判定 / プレイリスト割当）を囲むため、stage は
+            # preflight 固定ではなく実行系を表す名前にする。
             try:
                 result = uploader.execute_next_step(target)
             except (AutomationError, OSError, ValueError):
-                notifications.emit(
-                    NotificationEventKind.FAIL_CLOSED_ABORTED,
-                    channel=channel,
-                    collection=target.name,
-                    stage="upload-preflight",
-                )
+                notify_abort("upload-execution")
                 raise
             action = result.get("action")
             if action == ACTION_COMPLETE_COLLECTION_UPLOADED:

--- a/src/youtube_automation/commands/uploads/collection_uploader.py
+++ b/src/youtube_automation/commands/uploads/collection_uploader.py
@@ -51,20 +51,19 @@ def run(args: argparse.Namespace) -> None:
             return
         notifications = PipelineNotificationBridge(create_discord_notification_sink())
         channel = load_config().meta.channel_short
-        try:
-            uploader.ensure_upload_preflight(target)
-        except (AutomationError, OSError, ValueError):
-            notifications.emit(
-                NotificationEventKind.FAIL_CLOSED_ABORTED,
-                channel=channel,
-                collection=target.name,
-                stage="upload-preflight",
-            )
-            raise
         if args.plan:
             uploader.show_plan(target)
         else:
-            result = uploader.execute_next_step(target)
+            try:
+                result = uploader.execute_next_step(target)
+            except (AutomationError, OSError, ValueError):
+                notifications.emit(
+                    NotificationEventKind.FAIL_CLOSED_ABORTED,
+                    channel=channel,
+                    collection=target.name,
+                    stage="upload-preflight",
+                )
+                raise
             action = result.get("action")
             if action == ACTION_COMPLETE_COLLECTION_UPLOADED:
                 notifications.emit(

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -237,6 +237,15 @@ class CollectionUploader:
     ) -> dict:
         return self.complete_collection_executor.run(collection_path, tracking, publish_at)
 
+    def preflight_check(self, collection_path: Path) -> None:
+        """アップロードを伴わない経路（``--plan``）から upload 境界の preflight を依頼する。
+
+        検査の実体は `YouTubeAutoUploader.preflight_check` が単独で持ち、
+        `execute_next_step` 経路では `upload_collection` の内部で同じ検査集合が
+        1 回だけ走る。ここで検査を再実装しないことが二重実行を防ぐ条件。
+        """
+        self.uploader.preflight_check(collection_path)
+
     # ─── ステータス表示 ──────────────────────────────
 
     def show_status(self, collection_path: Path):

--- a/src/youtube_automation/domains/uploads/collection.py
+++ b/src/youtube_automation/domains/uploads/collection.py
@@ -27,7 +27,6 @@ from youtube_automation.domains.uploads._playlist_assignment import PlaylistAssi
 from youtube_automation.domains.uploads._preflight import PreflightChecker
 from youtube_automation.domains.uploads._published_dates import PublishedDatesScheduler
 from youtube_automation.domains.uploads._tracking_io import TrackingStore
-from youtube_automation.domains.uploads.preflight import ensure_collection_preflight
 from youtube_automation.domains.uploads.upload_journal import UploadJournal, UploadJournalOutcome
 from youtube_automation.domains.uploads.youtube import YouTubeAutoUploader
 from youtube_automation.infrastructure.filesystem import (
@@ -237,11 +236,6 @@ class CollectionUploader:
         publish_at: str | None = None,
     ) -> dict:
         return self.complete_collection_executor.run(collection_path, tracking, publish_at)
-
-    def ensure_upload_preflight(self, collection_path: Path) -> None:
-        """CLI の各入口で共通の骨格・タイトル preflight を実行する。"""
-        ensure_collection_preflight(collection_path)
-        self.uploader.preflight_check(collection_path)
 
     # ─── ステータス表示 ──────────────────────────────
 

--- a/src/youtube_automation/domains/uploads/youtube.py
+++ b/src/youtube_automation/domains/uploads/youtube.py
@@ -26,7 +26,7 @@ from youtube_automation.domains.uploads._uploader_constants import (
     YOUTUBE_VIDEO_URL_PREFIX,
 )
 from youtube_automation.domains.uploads.policy import SESSION_EXPIRED_HTTP_STATUSES, RetryDecision, ThumbnailCompression
-from youtube_automation.domains.uploads.preflight import check_title_codepoint_limit
+from youtube_automation.domains.uploads.preflight import check_title_codepoint_limit, ensure_collection_preflight
 from youtube_automation.domains.youtube.channel_settings import build_upload_status_flags
 from youtube_automation.infrastructure.filesystem import file_size, path_exists, remove_file
 from youtube_automation.infrastructure.google.upload import HttpError, create_media_upload
@@ -290,7 +290,8 @@ class YouTubeAutoUploader(ResumableUploader):
         self._verified_authenticated_channel_id = authenticated_channel_id
 
     def preflight_check(self, collection_dir: Path) -> None:
-        """チャンネル本人性を確認してからメタデータ品質を検証する。"""
+        """collection 骨格・チャンネル本人性・メタデータ品質を検証する。"""
+        ensure_collection_preflight(collection_dir)
         self._verify_authenticated_upload_channel()
         self.preflight_checker.check(collection_dir)
 

--- a/tests/commands/test_pipeline_notification_wiring.py
+++ b/tests/commands/test_pipeline_notification_wiring.py
@@ -110,7 +110,8 @@ def test_upload_command_notifies_terminal_pipeline_result(
     assert sink.events == [NotificationEvent(expected_kind, "ambient-lab", "night-rain", expected_stage)]
 
 
-def test_upload_preflight_failure_notifies_before_error_propagates(monkeypatch, tmp_path: Path) -> None:
+def test_upload_execution_failure_notifies_with_execution_stage(monkeypatch, tmp_path: Path) -> None:
+    """execute_next_step 全体を囲む try は preflight ではなく実行系 stage を通知する。"""
     target = tmp_path / "collections" / "planning" / "night-rain"
     uploader = MagicMock()
     uploader.find_collection.return_value = target
@@ -133,7 +134,39 @@ def test_upload_preflight_failure_notifies_before_error_propagates(monkeypatch, 
             NotificationEventKind.FAIL_CLOSED_ABORTED,
             "ambient-lab",
             "night-rain",
-            "upload-preflight",
+            "upload-execution",
         )
     ]
     uploader.execute_next_step.assert_called_once_with(target)
+
+
+def test_plan_preflight_failure_notifies_with_preflight_stage(monkeypatch, tmp_path: Path) -> None:
+    """--plan の fail-closed は preflight 由来なので stage も preflight を示す。"""
+    target = tmp_path / "collections" / "planning" / "night-rain"
+    uploader = MagicMock()
+    uploader.find_collection.return_value = target
+    uploader.preflight_check.side_effect = ConfigError("channel mismatch")
+    sink = RecordingSink()
+    monkeypatch.setattr(collection_uploader, "CollectionUploader", lambda **_kwargs: uploader)
+    monkeypatch.setattr(collection_uploader, "create_authenticated_youtube_clients", lambda: object())
+    monkeypatch.setattr(collection_uploader, "create_discord_notification_sink", lambda: sink)
+    monkeypatch.setattr(
+        collection_uploader,
+        "load_config",
+        lambda: SimpleNamespace(meta=SimpleNamespace(channel_short="ambient-lab")),
+    )
+
+    with pytest.raises(ConfigError, match="channel mismatch"):
+        collection_uploader.run(Namespace(config=None, daemon=False, collection="night-rain", status=False, plan=True))
+
+    assert sink.events == [
+        NotificationEvent(
+            NotificationEventKind.FAIL_CLOSED_ABORTED,
+            "ambient-lab",
+            "night-rain",
+            "upload-preflight",
+        )
+    ]
+    uploader.preflight_check.assert_called_once_with(target)
+    uploader.show_plan.assert_not_called()
+    uploader.execute_next_step.assert_not_called()

--- a/tests/commands/test_pipeline_notification_wiring.py
+++ b/tests/commands/test_pipeline_notification_wiring.py
@@ -114,7 +114,7 @@ def test_upload_preflight_failure_notifies_before_error_propagates(monkeypatch, 
     target = tmp_path / "collections" / "planning" / "night-rain"
     uploader = MagicMock()
     uploader.find_collection.return_value = target
-    uploader.ensure_upload_preflight.side_effect = ConfigError("channel mismatch")
+    uploader.execute_next_step.side_effect = ConfigError("channel mismatch")
     sink = RecordingSink()
     monkeypatch.setattr(collection_uploader, "CollectionUploader", lambda **_kwargs: uploader)
     monkeypatch.setattr(collection_uploader, "create_authenticated_youtube_clients", lambda: object())
@@ -136,4 +136,4 @@ def test_upload_preflight_failure_notifies_before_error_propagates(monkeypatch, 
             "upload-preflight",
         )
     ]
-    uploader.execute_next_step.assert_not_called()
+    uploader.execute_next_step.assert_called_once_with(target)

--- a/tests/commands/uploads/test_upload_cli_error_boundary.py
+++ b/tests/commands/uploads/test_upload_cli_error_boundary.py
@@ -127,19 +127,22 @@ def test_shorts_cli_normalizes_collection_to_absolute_path_for_upload(monkeypatc
 
 
 @pytest.mark.parametrize(
-    ("option", "expected_action"),
+    ("option", "expected_action", "preflight"),
     [
-        ("--status", "show_status"),
-        ("--plan", "show_plan"),
-        (None, "execute_next_step"),
+        ("--status", "show_status", False),
+        # show_plan は表示専用なので CLI が preflight を明示的に依頼する。
+        ("--plan", "show_plan", True),
+        # execute 経路は upload_collection 内部で 1 回だけ preflight が走る。
+        (None, "execute_next_step", False),
     ],
 )
-def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expected_action):
+def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expected_action, preflight):
     from youtube_automation.commands.uploads import collection_uploader
 
     target = Path("/collection")
     uploader = SimpleNamespace(
         find_collection=MagicMock(return_value=target),
+        preflight_check=MagicMock(),
         show_status=MagicMock(),
         show_plan=MagicMock(),
         execute_next_step=MagicMock(),
@@ -164,6 +167,7 @@ def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expecte
         allow_duration_outside_target=False,
     )
     uploader.find_collection.assert_called_once_with("slug")
+    assert uploader.preflight_check.called is preflight
     getattr(uploader, expected_action).assert_called_once_with(target)
 
 

--- a/tests/commands/uploads/test_upload_cli_error_boundary.py
+++ b/tests/commands/uploads/test_upload_cli_error_boundary.py
@@ -127,20 +127,19 @@ def test_shorts_cli_normalizes_collection_to_absolute_path_for_upload(monkeypatc
 
 
 @pytest.mark.parametrize(
-    ("option", "expected_action", "preflight"),
+    ("option", "expected_action"),
     [
-        ("--status", "show_status", False),
-        ("--plan", "show_plan", True),
-        (None, "execute_next_step", True),
+        ("--status", "show_status"),
+        ("--plan", "show_plan"),
+        (None, "execute_next_step"),
     ],
 )
-def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expected_action, preflight):
+def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expected_action):
     from youtube_automation.commands.uploads import collection_uploader
 
     target = Path("/collection")
     uploader = SimpleNamespace(
         find_collection=MagicMock(return_value=target),
-        ensure_upload_preflight=MagicMock(),
         show_status=MagicMock(),
         show_plan=MagicMock(),
         execute_next_step=MagicMock(),
@@ -165,7 +164,6 @@ def test_collection_cli_dispatches_normal_operation(monkeypatch, option, expecte
         allow_duration_outside_target=False,
     )
     uploader.find_collection.assert_called_once_with("slug")
-    assert uploader.ensure_upload_preflight.called is preflight
     getattr(uploader, expected_action).assert_called_once_with(target)
 
 

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -9,10 +9,12 @@ CollectionUploader のユニットテスト
 
 import json
 import logging
+import shutil
 import sys
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -20,7 +22,8 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from tests.helpers.paths import REPO_ROOT
+from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
+from tests.helpers.video_description import write_video_description_pair
 from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.domains.uploads.collection import PlaylistAssignment, PublishedDatesScheduler, TrackingStore
 
@@ -56,9 +59,17 @@ def test_collection_uploader_imports_playlist_manager():
     assert PlaylistManager.__module__ == "youtube_automation.domains.uploads.playlists"
 
 
-@pytest.mark.parametrize(("argv", "method_name"), [(["--plan"], "show_plan"), ([], "execute_next_step")])
-def test_main_delegates_preflight_to_upload_boundary(monkeypatch, tmp_path, argv, method_name):
-    """CLI は preflight を重複実行せず domain operation へ委譲する。"""
+@pytest.mark.parametrize(
+    ("argv", "method_name", "preflight_calls"),
+    [
+        # show_plan は表示専用なので CLI が upload 境界の preflight を明示的に依頼する。
+        (["--plan"], "show_plan", 1),
+        # execute 経路は upload_collection 内部で preflight が走るため CLI からは呼ばない。
+        ([], "execute_next_step", 0),
+    ],
+)
+def test_main_delegates_preflight_to_upload_boundary(monkeypatch, tmp_path, argv, method_name, preflight_calls):
+    """CLI は preflight を重複実行せず upload 境界へ委譲する。"""
     from youtube_automation.commands.uploads import collection_uploader
 
     target = tmp_path / "collections" / "planning" / "20990101-test-collection"
@@ -74,7 +85,7 @@ def test_main_delegates_preflight_to_upload_boundary(monkeypatch, tmp_path, argv
     ):
         collection_uploader.main()
 
-    mock_uploader.ensure_upload_preflight.assert_not_called()
+    assert mock_uploader.preflight_check.call_count == preflight_calls
     getattr(mock_uploader, method_name).assert_called_once_with(target)
 
 
@@ -114,6 +125,98 @@ def test_collection_cli_returns_nonzero_when_playlist_assignment_fails(monkeypat
     monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "-c", target.name])
     with patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=uploader):
         assert collection_uploader.main() == 1
+
+
+def test_collection_preflight_uses_public_inner_uploader_operation(tmp_path):
+    """Collection domain は検査を再実装せず upload 境界の preflight へ委譲する。"""
+    from youtube_automation.domains.uploads import collection as collection_domain
+
+    uploader = object.__new__(collection_domain.CollectionUploader)
+    uploader.uploader = MagicMock()
+    target = tmp_path / "collection"
+
+    uploader.preflight_check(target)
+
+    uploader.uploader.preflight_check.assert_called_once_with(target)
+
+
+def _write_cli_title_collection(channel_dir: Path, *, title_template_check: dict[str, object] | None) -> Path:
+    """CLI が実際に解決する planning コレクションを作る。"""
+    collection = channel_dir / "collections" / "planning" / "20990101-volume-collection"
+    for subdir in ("01-master", "02-Individual-music", "03-Individual-movie", "10-assets", "20-documentation"):
+        (collection / subdir).mkdir(parents=True, exist_ok=True)
+    (collection / "01-master" / "master.mp4").write_bytes(b"probe is mocked")
+    write_video_description_pair(
+        collection / "20-documentation",
+        title="Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves",
+        description="00:00 Opening Groove\n10:00 Midnight Funk\n20:00 Last Call Soul",
+        tags=["soul funk", "retro groove", "study music"],
+    )
+    state: dict[str, object] = {"scene_phrases": {lang: {"title": f"title-{lang}"} for lang in ("ja", "en", "de")}}
+    if title_template_check is not None:
+        state["title_template_check"] = title_template_check
+    (collection / "workflow-state.json").write_text(json.dumps(state), encoding="utf-8")
+    return collection
+
+
+def _title_preflight_config() -> SimpleNamespace:
+    return SimpleNamespace(
+        audio=SimpleNamespace(chapter_max=100),
+        content=SimpleNamespace(
+            tags=SimpleNamespace(min_count=None, for_collection=lambda _name: ["fallback"]),
+            title=SimpleNamespace(
+                template="{adjective} Soul/Funk {noun} | {hours} Hours of {mood}",
+                template_check={"core_vocabulary": ["Soul", "Funk"]},
+            ),
+        ),
+        localizations=SimpleNamespace(supported_languages=["ja", "en", "de"]),
+        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4346)
+        playlists=SimpleNamespace(items={}),
+    )
+
+
+@pytest.mark.parametrize(
+    ("title_template_check", "expected_outcome"),
+    [({"allow_volume_patterns": True}, "pass"), (None, "fail")],
+)
+def test_plan_title_preflight_honors_collection_opt_in(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    title_template_check: dict[str, object] | None,
+    expected_outcome: str,
+) -> None:
+    """`--plan` も state の title opt-in を実際に評価する（素通ししない）。
+
+    execute 経路の同一検査は `upload_collection` 内部で担保されている
+    （`test_youtube_auto_uploader.py::...forwards_resume_kwargs...`）。
+    """
+    from youtube_automation.commands.uploads import collection_uploader
+    from youtube_automation.configuration import reset as reset_config
+    from youtube_automation.domains.uploads.collection import CollectionUploader
+
+    fixture_channel = FIXTURES_DIR / "sample_channel"
+    test_channel = tmp_path / "channel"
+    shutil.copytree(fixture_channel, test_channel)
+    collection = _write_cli_title_collection(test_channel, title_template_check=title_template_check)
+
+    monkeypatch.setenv("CHANNEL_DIR", str(test_channel))
+    monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "--plan", "-c", collection.name])
+    reset_config()
+
+    with (
+        patch("youtube_automation.domains.uploads._preflight.load_config", return_value=_title_preflight_config()),
+        patch("youtube_automation.domains.uploads._preflight.probe_duration", return_value=3600),
+        patch("youtube_automation.domains.uploads.youtube.YouTubeAutoUploader._verify_authenticated_upload_channel"),
+        patch.object(CollectionUploader, "show_plan") as mock_show_plan,
+    ):
+        if expected_outcome == "pass":
+            assert collection_uploader.main() == 0
+            mock_show_plan.assert_called_once_with(collection)
+        else:
+            assert collection_uploader.main() == 1
+            assert "巻数表記を検出" in capsys.readouterr().err
+            mock_show_plan.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -547,13 +650,19 @@ class TestAutoDetectCollection:
         assert uploader.find_collection("published") == live
 
     @pytest.mark.parametrize(
-        ("argv", "method_name"),
-        [(["--status"], "show_status"), (["--plan"], "show_plan"), ([], "execute_next_step")],
+        ("argv", "method_name", "preflight_calls"),
+        [
+            (["--status"], "show_status", 0),
+            (["--plan"], "show_plan", 1),
+            ([], "execute_next_step", 0),
+        ],
     )
-    def test_main_uses_safe_auto_detect_for_status_plan_and_upload(self, monkeypatch, tmp_path, argv, method_name):
+    def test_main_uses_safe_auto_detect_for_status_plan_and_upload(
+        self, monkeypatch, tmp_path, argv, method_name, preflight_calls
+    ):
         from youtube_automation.commands.uploads import collection_uploader
 
-        uploader, _ = _make_uploader_with_collection_mock(tmp_path)
+        uploader, mock_inner = _make_uploader_with_collection_mock(tmp_path)
         live = tmp_path / "collections" / "live" / "20260101-published-collection"
         target = tmp_path / "collections" / "planning" / "20260201-mastered-collection"
         _write_workflow_state(live, phase="complete", video_id="published-video")
@@ -568,6 +677,7 @@ class TestAutoDetectCollection:
             collection_uploader.main()
 
         method.assert_called_once_with(target)
+        assert mock_inner.preflight_check.call_count == preflight_calls
 
     @pytest.mark.parametrize("argv", [["--status"], ["--plan"], []])
     def test_main_fails_loudly_when_auto_detect_has_no_candidate(self, monkeypatch, tmp_path, capsys, argv):

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -9,12 +9,10 @@ CollectionUploader のユニットテスト
 
 import json
 import logging
-import shutil
 import sys
 from dataclasses import replace
 from datetime import datetime, timedelta
 from pathlib import Path
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 from zoneinfo import ZoneInfo
 
@@ -22,8 +20,7 @@ import pytest
 from googleapiclient.errors import HttpError
 from httplib2 import Response
 
-from tests.helpers.paths import FIXTURES_DIR, REPO_ROOT
-from tests.helpers.video_description import write_video_description_pair
+from tests.helpers.paths import REPO_ROOT
 from youtube_automation.configuration import ScheduleConfig
 from youtube_automation.domains.uploads.collection import PlaylistAssignment, PublishedDatesScheduler, TrackingStore
 
@@ -59,12 +56,9 @@ def test_collection_uploader_imports_playlist_manager():
     assert PlaylistManager.__module__ == "youtube_automation.domains.uploads.playlists"
 
 
-@pytest.mark.parametrize(
-    ("argv", "method_name"),
-    [(["--plan"], "show_plan"), ([], "execute_next_step")],
-)
-def test_main_runs_shared_preflight_before_plan_or_execute(monkeypatch, tmp_path, argv, method_name):
-    """実行可能な CLI 入口は upload preflight を通してから処理する。"""
+@pytest.mark.parametrize(("argv", "method_name"), [(["--plan"], "show_plan"), ([], "execute_next_step")])
+def test_main_delegates_preflight_to_upload_boundary(monkeypatch, tmp_path, argv, method_name):
+    """CLI は preflight を重複実行せず domain operation へ委譲する。"""
     from youtube_automation.commands.uploads import collection_uploader
 
     target = tmp_path / "collections" / "planning" / "20990101-test-collection"
@@ -80,7 +74,7 @@ def test_main_runs_shared_preflight_before_plan_or_execute(monkeypatch, tmp_path
     ):
         collection_uploader.main()
 
-    mock_uploader.ensure_upload_preflight.assert_called_once_with(target)
+    mock_uploader.ensure_upload_preflight.assert_not_called()
     getattr(mock_uploader, method_name).assert_called_once_with(target)
 
 
@@ -93,7 +87,7 @@ def test_main_exits_before_state_changes_when_channel_identity_preflight_fails(m
     target.mkdir(parents=True)
     mock_uploader = MagicMock()
     mock_uploader.find_collection.return_value = target
-    mock_uploader.ensure_upload_preflight.side_effect = ConfigError("channel_id mismatch")
+    mock_uploader.execute_next_step.side_effect = ConfigError("channel_id mismatch")
 
     monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "-c", target.name])
     with patch(
@@ -101,7 +95,7 @@ def test_main_exits_before_state_changes_when_channel_identity_preflight_fails(m
     ):
         assert collection_uploader.main() == 1
 
-    mock_uploader.execute_next_step.assert_not_called()
+    mock_uploader.execute_next_step.assert_called_once_with(target)
     mock_uploader.show_plan.assert_not_called()
     mock_uploader.show_status.assert_not_called()
 
@@ -120,104 +114,6 @@ def test_collection_cli_returns_nonzero_when_playlist_assignment_fails(monkeypat
     monkeypatch.setattr(sys, "argv", ["yt-upload-collection", "-c", target.name])
     with patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=uploader):
         assert collection_uploader.main() == 1
-
-
-def test_collection_preflight_uses_public_inner_uploader_operation(monkeypatch, tmp_path):
-    """Collection domain は内部 uploader の private preflight を直接呼ばない。"""
-    from youtube_automation.domains.uploads import collection as collection_domain
-
-    uploader = object.__new__(collection_domain.CollectionUploader)
-    uploader.uploader = MagicMock()
-    target = tmp_path / "collection"
-
-    with patch.object(collection_domain, "ensure_collection_preflight") as outer_preflight:
-        uploader.ensure_upload_preflight(target)
-
-    outer_preflight.assert_called_once_with(target)
-    uploader.uploader.preflight_check.assert_called_once_with(target)
-
-
-def _write_cli_title_collection(channel_dir: Path, *, title_template_check: dict[str, object] | None) -> Path:
-    """CLI が実際に解決する planning コレクションを作る。"""
-    collection = channel_dir / "collections" / "planning" / "20990101-volume-collection"
-    for subdir in ("01-master", "02-Individual-music", "03-Individual-movie", "10-assets", "20-documentation"):
-        (collection / subdir).mkdir(parents=True, exist_ok=True)
-    (collection / "01-master" / "master.mp4").write_bytes(b"probe is mocked")
-    write_video_description_pair(
-        collection / "20-documentation",
-        title="Funky Soul Spirit Vol.2 | 3 Hours of Feel-Good Retro Grooves",
-        description="00:00 Opening Groove\n10:00 Midnight Funk\n20:00 Last Call Soul",
-        tags=["soul funk", "retro groove", "study music"],
-    )
-    state: dict[str, object] = {"scene_phrases": {lang: {"title": f"title-{lang}"} for lang in ("ja", "en", "de")}}
-    if title_template_check is not None:
-        state["title_template_check"] = title_template_check
-    (collection / "workflow-state.json").write_text(json.dumps(state), encoding="utf-8")
-    return collection
-
-
-def _title_preflight_config() -> SimpleNamespace:
-    return SimpleNamespace(
-        audio=SimpleNamespace(chapter_max=100),
-        content=SimpleNamespace(
-            tags=SimpleNamespace(min_count=None, for_collection=lambda _name: ["fallback"]),
-            title=SimpleNamespace(
-                template="{adjective} Soul/Funk {noun} | {hours} Hours of {mood}",
-                template_check={"core_vocabulary": ["Soul", "Funk"]},
-            ),
-        ),
-        localizations=SimpleNamespace(supported_languages=["ja", "en", "de"]),
-        # 分類プレイリスト（auto_add 以外）を持たないチャンネル → 未割り当て検出は対象外 (#4346)
-        playlists=SimpleNamespace(items={}),
-    )
-
-
-@pytest.mark.parametrize(
-    ("argv", "method_name"),
-    [(["--plan"], "show_plan"), ([], "execute_next_step")],
-)
-@pytest.mark.parametrize(
-    ("title_template_check", "expected_outcome"),
-    [({"allow_volume_patterns": True}, "pass"), (None, "fail")],
-)
-def test_main_title_preflight_honors_collection_opt_in_for_each_cli_entry(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-    capsys: pytest.CaptureFixture[str],
-    argv: list[str],
-    method_name: str,
-    title_template_check: dict[str, object] | None,
-    expected_outcome: str,
-) -> None:
-    """実行可能な CLI 入口が state の title opt-in を実際に評価する。"""
-    from youtube_automation.commands.uploads import collection_uploader
-    from youtube_automation.configuration import reset as reset_config
-    from youtube_automation.domains.uploads.collection import CollectionUploader
-
-    fixture_channel = FIXTURES_DIR / "sample_channel"
-    test_channel = tmp_path / "channel"
-    shutil.copytree(fixture_channel, test_channel)
-    collection = _write_cli_title_collection(test_channel, title_template_check=title_template_check)
-    mock_config = MagicMock()
-    mock_config.meta.channel_short = "test"
-
-    monkeypatch.setenv("CHANNEL_DIR", str(test_channel))
-    monkeypatch.setattr(sys, "argv", ["yt-upload-collection", *argv, "-c", collection.name])
-    reset_config()
-
-    with (
-        patch("youtube_automation.domains.uploads._preflight.load_config", return_value=_title_preflight_config()),
-        patch("youtube_automation.domains.uploads._preflight.probe_duration", return_value=3600),
-        patch("youtube_automation.domains.uploads.youtube.YouTubeAutoUploader._verify_authenticated_upload_channel"),
-        patch.object(CollectionUploader, method_name) as mock_action,
-    ):
-        if expected_outcome == "pass":
-            assert collection_uploader.main() == 0
-            mock_action.assert_called_once_with(collection)
-        else:
-            assert collection_uploader.main() == 1
-            assert "巻数表記を検出" in capsys.readouterr().err
-            mock_action.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -668,17 +564,10 @@ class TestAutoDetectCollection:
         mock_config.meta.channel_short = "test"
 
         monkeypatch.setattr(sys, "argv", ["yt-upload-collection", *argv])
-        with (
-            patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=uploader),
-            patch("youtube_automation.domains.uploads.collection.ensure_collection_preflight") as mock_preflight,
-        ):
+        with patch("youtube_automation.commands.uploads.collection_uploader.CollectionUploader", return_value=uploader):
             collection_uploader.main()
 
         method.assert_called_once_with(target)
-        if argv == ["--status"]:
-            mock_preflight.assert_not_called()
-        else:
-            mock_preflight.assert_called_once_with(target)
 
     @pytest.mark.parametrize("argv", [["--status"], ["--plan"], []])
     def test_main_fails_loudly_when_auto_detect_has_no_candidate(self, monkeypatch, tmp_path, capsys, argv):

--- a/tests/domains/uploads/test_preflight.py
+++ b/tests/domains/uploads/test_preflight.py
@@ -93,6 +93,8 @@ def _write_collection(
     master_dir = collection_dir / "01-master"
     master_dir.mkdir(parents=True)
     (master_dir / "master.mp4").write_bytes(b"probe is mocked")
+    (collection_dir / "02-Individual-music").mkdir()
+    (collection_dir / "10-assets").mkdir()
     return collection_dir
 
 

--- a/tests/domains/uploads/test_youtube_auto_uploader.py
+++ b/tests/domains/uploads/test_youtube_auto_uploader.py
@@ -133,6 +133,7 @@ class TestUploadChannelIdentityPreflight:
         )
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch(
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
@@ -159,6 +160,7 @@ class TestUploadChannelIdentityPreflight:
         collection = tmp_path / "collection"
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch(
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
@@ -182,6 +184,7 @@ class TestUploadChannelIdentityPreflight:
         )
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch(
                 "youtube_automation.domains.uploads.youtube.load_config",
                 return_value=SimpleNamespace(meta=SimpleNamespace(channel_id="UC_CONFIGURED")),
@@ -235,6 +238,8 @@ def _write_preflight_collection(tmp_path: Path, scene_languages: list[str]) -> P
     master_dir = col_dir / "01-master"
     master_dir.mkdir()
     (master_dir / "master.mp4").write_bytes(b"probe is mocked")
+    (col_dir / "02-Individual-music").mkdir()
+    (col_dir / "10-assets").mkdir()
     return col_dir
 
 
@@ -317,6 +322,8 @@ def _write_title_collection(
     master_dir = col_dir / "01-master"
     master_dir.mkdir()
     (master_dir / "master.mp4").write_bytes(b"probe is mocked")
+    (col_dir / "02-Individual-music").mkdir()
+    (col_dir / "10-assets").mkdir()
     return col_dir
 
 
@@ -611,8 +618,9 @@ class TestUploadCollectionForwarding:
         on_complete = MagicMock()
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight") as skeleton_preflight,
             patch.object(uploader, "_verify_authenticated_upload_channel"),
-            patch.object(uploader.preflight_checker, "check"),
+            patch.object(uploader.preflight_checker, "check") as metadata_preflight,
             patch.object(
                 uploader,
                 "_upload_complete_collection",
@@ -636,6 +644,8 @@ class TestUploadCollectionForwarding:
         assert call_kwargs.get("resume_session_uri") == _SESS_PREV
         assert call_kwargs.get("on_session_uri_changed") is on_session
         assert call_kwargs.get("on_upload_complete") is on_complete
+        skeleton_preflight.assert_called_once_with(col_dir)
+        metadata_preflight.assert_called_once_with(col_dir)
 
 
 def test_uploader_delegates_complete_collection_to_injected_strategy(tmp_path):
@@ -1599,6 +1609,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader.preflight_checker, "check"),
             patch.object(
@@ -1630,6 +1641,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader.preflight_checker, "check"),
             patch.object(
@@ -1654,6 +1666,7 @@ class TestDefaultPublishAt:
         uploader = YouTubeAutoUploader(collections_root=str(tmp_path))
 
         with (
+            patch("youtube_automation.domains.uploads.youtube.ensure_collection_preflight"),
             patch.object(uploader, "_verify_authenticated_upload_channel"),
             patch.object(uploader.preflight_checker, "check"),
             patch.object(


### PR DESCRIPTION
## Summary
- upload preflight を YouTubeAutoUploader 内部へ集約
- 両 CLI 経路で同一検査集合を一度だけ実行
- 重複入口を削除し回帰テストを更新

Closes #4458