### PR TITLE
fix(ci): autofix の checkout に persist-credentials: false を追加 (#4591)

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -145,6 +145,10 @@ jobs:
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
+          # 既定の true は read-only GITHUB_TOKEN を http.<origin>.extraheader に残し、
+          # claude-code-action が remote URL に埋め込む App token より優先されて
+          # push が 403 になる(#4591)
+          persist-credentials: false
       - name: Run Claude autofix
         id: autofix
         uses: anthropics/claude-code-action@4a3947e8ca609a286ab07d4d048d9ec4016798c1 # v1

--- a/changelog.d/4591-autofix-push-credentials.fixed.md
+++ b/changelog.d/4591-autofix-push-credentials.fixed.md
@@ -1,0 +1,1 @@
+- CI autofix の checkout に `persist-credentials: false` を追加し、残留した read-only GITHUB_TOKEN が App token 認証より優先されて `git push` が 403 になる問題を修正する（#4591）。

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -39,6 +39,14 @@ def _autofix_step(autofix_job: dict[str, object]) -> dict[str, object]:
     return next(step for step in autofix_job["steps"] if step.get("id") == "autofix")
 
 
+def _checkout_step(job: dict[str, object]) -> dict[str, object]:
+    return next(
+        step
+        for step in job["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+
+
 def test_autofix_fires_when_a_pr_gate_workflow_fails() -> None:
     triggers = _triggers(_workflow())
 
@@ -226,11 +234,7 @@ def test_fix_pushes_via_app_token_to_retrigger_ci() -> None:
     # checkout 既定の persist-credentials: true は read-only GITHUB_TOKEN を
     # http.<origin>.extraheader に残し、App token の remote URL 認証より優先されて
     # push が 403 になる(#4591)
-    checkout = next(
-        step
-        for step in workflow["jobs"]["autofix"]["steps"]
-        if str(step.get("uses", "")).startswith("actions/checkout@")
-    )
+    checkout = _checkout_step(workflow["jobs"]["autofix"])
     assert checkout["with"]["persist-credentials"] is False
 
 

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -223,6 +223,16 @@ def test_fix_pushes_via_app_token_to_retrigger_ci() -> None:
     step = _autofix_step(workflow["jobs"]["autofix"])
     assert "github_token" not in step["with"]
 
+    # checkout 既定の persist-credentials: true は read-only GITHUB_TOKEN を
+    # http.<origin>.extraheader に残し、App token の remote URL 認証より優先されて
+    # push が 403 になる(#4591)
+    checkout = next(
+        step
+        for step in workflow["jobs"]["autofix"]["steps"]
+        if str(step.get("uses", "")).startswith("actions/checkout@")
+    )
+    assert checkout["with"]["persist-credentials"] is False
+
 
 def test_autofix_installs_the_pinned_action_with_opus() -> None:
     step = _autofix_step(_workflow()["jobs"]["autofix"])

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -39,8 +39,8 @@ def _autofix_step(autofix_job: dict[str, object]) -> dict[str, object]:
     return next(step for step in autofix_job["steps"] if step.get("id") == "autofix")
 
 
-def _checkout_step(job: dict[str, object]) -> dict[str, object]:
-    return next(step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+def _checkout_step(autofix_job: dict[str, object]) -> dict[str, object]:
+    return next(step for step in autofix_job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
 
 
 def test_autofix_fires_when_a_pr_gate_workflow_fails() -> None:

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -40,11 +40,7 @@ def _autofix_step(autofix_job: dict[str, object]) -> dict[str, object]:
 
 
 def _checkout_step(job: dict[str, object]) -> dict[str, object]:
-    return next(
-        step
-        for step in job["steps"]
-        if str(step.get("uses", "")).startswith("actions/checkout@")
-    )
+    return next(step for step in job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
 
 
 def test_autofix_fires_when_a_pr_gate_workflow_fails() -> None:


### PR DESCRIPTION
## Summary

CI autofix workflow の autofix job で `git push` が 403（`Permission to ... denied to github-actions[bot]`）になり、修正 commit を PR ブランチへ届けられなかった問題を修正する。

`actions/checkout` は既定の `persist-credentials: true` で read-only な `GITHUB_TOKEN` を `http.<origin>.extraheader` に残す。これが claude-code-action が remote URL に埋め込む App token（push 可）より優先され、push が `github-actions[bot]` として拒否されていた。checkout に `persist-credentials: false` を追加して extraheader を残さないことで、App token 認証がそのまま効く。`contents: read` による「GITHUB_TOKEN では push できない」機械担保は維持される。

## Changes

- `.github/workflows/ci-autofix.yml`: checkout step に `persist-credentials: false` を追加
- `tests/repo/test_ci_autofix_workflow.py`: `test_fix_pushes_via_app_token_to_retrigger_ci` に `persist-credentials: false` の契約 assertion を追加
- `changelog.d/4591-autofix-push-credentials.fixed.md`: fixed エントリ追加

Closes #4591

🤖 Generated with [Claude Code](https://claude.com/claude-code)