### PR TITLE
docs(configuration): 公開 API docstring を __all__ と同期する (#4594)

### DIFF
--- a/changelog.d/4594-configuration-docstring-sync.fixed.md
+++ b/changelog.d/4594-configuration-docstring-sync.fixed.md
@@ -1,0 +1,1 @@
+- `configuration` package docstring の公開 API 一覧へ `load_schedule_config` / `ScheduleConfig` を追記し `__all__` と同期する（#4594）。

--- a/src/youtube_automation/configuration/__init__.py
+++ b/src/youtube_automation/configuration/__init__.py
@@ -2,6 +2,7 @@
 
 公開 API:
     load_config() -> ChannelConfig   # シングルトン取得（初回に glob ロード + .env ロード）
+    load_schedule_config()           # config/channel/schedule.json の型付きローダー
     channel_dir() -> Path            # config/channel/ を含むプロジェクトルート解決
     explicit_channel_selection()     # CLI の明示 channel slug を参照
     find_workspace_root()            # cwd 祖先から workspace root を検出
@@ -13,6 +14,7 @@
     Shorts                           # `shorts` セクション（型ヒント用）
     PinnedComment                    # `pinned_comment` セクション（型ヒント用）
     Distrokid                        # `distrokid` セクション（型ヒント用）
+    ScheduleConfig                   # `schedule` セクション（型ヒント用）
 """
 
 from youtube_automation.configuration.community_draft import CommunityDraft


### PR DESCRIPTION
Closes #4594

#4438 で `configuration` package の公開 surface に追加された `load_schedule_config` / `ScheduleConfig` を、`src/youtube_automation/configuration/__init__.py` 冒頭 docstring の「公開 API:」一覧へ追記し、`__all__`（14 symbol）と同期する。挙動変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)