### PR TITLE
fix(system): 進捗図hookはコレクション未解決時に無出力にする (#4416)

### DIFF
--- a/changelog.d/4416-progress-hook-silent.fixed.md
+++ b/changelog.d/4416-progress-hook-silent.fixed.md
@@ -1,0 +1,1 @@
+- 進捗図 hook がコレクションを解決できないとき（`collections/` 無し・コレクション 0 件・`workflow-state.json` 破損）は何も表示せず、実態と無関係な固定進捗図を描かないようにした ([#4416](https://github.com/daiki-beppu/youtube-automation/issues/4416))

--- a/src/youtube_automation/commands/system/progress_hook/__init__.py
+++ b/src/youtube_automation/commands/system/progress_hook/__init__.py
@@ -12,7 +12,10 @@ from dataclasses import dataclass
 from typing import TextIO
 
 from youtube_automation.commands.system.progress_hook.workflow_state import STAGES as _STAGES
-from youtube_automation.commands.system.progress_hook.workflow_state import load_progress_snapshot
+from youtube_automation.commands.system.progress_hook.workflow_state import (
+    ProgressSnapshot,
+    load_progress_snapshot,
+)
 
 _STAGE_COMMANDS = {
     "音源生成": (
@@ -100,33 +103,21 @@ def _unclassified_detail(invocation: _Invocation) -> str:
     return f"{kind} — {description}" if description is not None else kind
 
 
-def _render(invocation: _Invocation) -> str:
+def _render(invocation: _Invocation, snapshot: ProgressSnapshot) -> str:
     completed = invocation.event == "PostToolUse"
-    command = _nonempty_string(invocation.tool_input.get("command"))
-    snapshot = load_progress_snapshot(invocation.cwd, command)
     lines = ["```"]
     if invocation.stage is None:
-        for index, stage in enumerate(_STAGES):
-            marker = (
-                "✓"
-                if (snapshot is not None and stage in snapshot.completed_stages) or (snapshot is None and index <= 2)
-                else "○"
-            )
+        for stage in _STAGES:
+            marker = "✓" if stage in snapshot.completed_stages else "○"
             lines.append(f"  {marker}  {stage}")
         lines.append(f"  ⋯  {_unclassified_detail(invocation)}")
     else:
         current_index = _STAGES.index(invocation.stage)
         for index, stage in enumerate(_STAGES):
-            if snapshot is not None and not completed and index == current_index:
-                marker = "▸"
-            elif snapshot is not None:
-                marker = "✓" if stage in snapshot.completed_stages else "○"
-            elif index < current_index or (completed and index == current_index):
-                marker = "✓"
-            elif index == current_index:
+            if not completed and index == current_index:
                 marker = "▸"
             else:
-                marker = "○"
+                marker = "✓" if stage in snapshot.completed_stages else "○"
             detail = f" — {invocation.command_name}" if index == current_index else ""
             lines.append(f"  {marker}  {stage}{detail}")
     lines.append("```")
@@ -145,6 +136,11 @@ def main(argv: Sequence[str] | None = None, *, stdin: TextIO | None = None) -> i
         return 0
 
     invocation = _parse_invocation(payload)
-    if invocation is not None and _should_display(invocation):
-        print(json.dumps({"systemMessage": _render(invocation)}, ensure_ascii=False))
+    if invocation is None or not _should_display(invocation):
+        return 0
+    command = _nonempty_string(invocation.tool_input.get("command"))
+    snapshot = load_progress_snapshot(invocation.cwd, command)
+    if snapshot is None:
+        return 0
+    print(json.dumps({"systemMessage": _render(invocation, snapshot)}, ensure_ascii=False))
     return 0

--- a/src/youtube_automation/commands/system/progress_hook/workflow_state.py
+++ b/src/youtube_automation/commands/system/progress_hook/workflow_state.py
@@ -145,7 +145,7 @@ def _completed_stages(root: Path, collection: Path, state: WorkflowState) -> fro
 
 
 def load_progress_snapshot(cwd: str | None, command: str | None) -> ProgressSnapshot | None:
-    """コレクションが無い、または状態を安全に読めない場合は fallback を指示する。"""
+    """コレクションが無い、または状態を安全に読めない場合は None を返し、表示可否の判定を呼び出し側へ委ねる。"""
 
     if cwd is None:
         return None

--- a/tests/commands/system/test_progress_hook.py
+++ b/tests/commands/system/test_progress_hook.py
@@ -83,9 +83,11 @@ def _progress_message(
 
 
 def test_should_emit_progress_system_message_when_background_bash_starts(
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    payload = json.dumps({"tool_name": "Bash", "tool_input": {"run_in_background": True}})
+    _write_collection(tmp_path, "planning", "in-progress", {"phase": "prepared", "assets": {"raw_master": None}})
+    payload = json.dumps({"cwd": str(tmp_path), "tool_name": "Bash", "tool_input": {"run_in_background": True}})
 
     exit_code, stdout, stderr = _run(payload, capsys)
 
@@ -106,15 +108,55 @@ def test_should_emit_nothing_when_foreground_bash_starts(capsys: pytest.CaptureF
     assert stderr == ""
 
 
-def test_should_keep_fixed_pipeline_when_repository_has_no_collections(
+def test_should_emit_nothing_when_repository_has_no_collections(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    message = _progress_message(tmp_path, capsys, command="gh pr checks 42")
+    payload = json.dumps(
+        {
+            "cwd": str(tmp_path),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Agent",
+            "tool_input": {"subagent_type": "Explore", "description": "調査"},
+        }
+    )
 
-    assert "  ✓  マスター化" in message
-    assert "  ○  動画化" in message
-    assert "  ⋯  gh" in message
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
+
+
+def test_should_emit_nothing_when_no_collection_has_workflow_state(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "collections" / "planning" / "initialization-interrupted").mkdir(parents=True)
+    payload = json.dumps(
+        {
+            "cwd": str(tmp_path),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "uv run yt-generate-master"},
+        }
+    )
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
+
+
+def test_should_emit_nothing_when_payload_has_no_cwd(capsys: pytest.CaptureFixture[str]) -> None:
+    payload = json.dumps({"tool_name": "Bash", "tool_input": {"run_in_background": True}})
+
+    exit_code, stdout, stderr = _run(payload, capsys)
+
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
 
 
 def test_should_mark_real_asset_stages_from_workflow_state(
@@ -434,7 +476,7 @@ def test_should_not_complete_post_publish_for_other_video_or_analysis_before_pub
 
 
 @pytest.mark.parametrize("bad_state", ["not-json", "[]", '{"phase":"prepared","assets":[]}'])
-def test_should_fall_back_to_fixed_pipeline_when_workflow_state_is_invalid(
+def test_should_emit_nothing_when_workflow_state_is_invalid(
     tmp_path: Path,
     bad_state: str,
     capsys: pytest.CaptureFixture[str],
@@ -442,13 +484,20 @@ def test_should_fall_back_to_fixed_pipeline_when_workflow_state_is_invalid(
     collection = tmp_path / "collections" / "planning" / "broken"
     collection.mkdir(parents=True)
     (collection / "workflow-state.json").write_text(bad_state, encoding="utf-8")
+    payload = json.dumps(
+        {
+            "cwd": str(tmp_path),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "gh pr checks 42", "run_in_background": True},
+        }
+    )
 
-    message = _progress_message(tmp_path, capsys, command="gh pr checks 42")
+    exit_code, stdout, stderr = _run(payload, capsys)
 
-    assert "  ✓  企画" in message
-    assert "  ✓  マスター化" in message
-    assert "  ○  動画化" in message
-    assert "  ⋯  gh" in message
+    assert exit_code == 0
+    assert stdout == ""
+    assert stderr == ""
 
 
 @pytest.mark.parametrize(
@@ -480,9 +529,18 @@ def test_should_fall_back_to_fixed_pipeline_when_workflow_state_is_invalid(
 def test_should_mark_classified_stage_for_long_foreground_command(
     command: str,
     stage: str,
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    payload = json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Bash", "tool_input": {"command": command}})
+    _write_collection(tmp_path, "planning", "in-progress", {"phase": "planning", "assets": {"raw_master": None}})
+    payload = json.dumps(
+        {
+            "cwd": str(tmp_path),
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+        }
+    )
 
     exit_code, stdout, stderr = _run(payload, capsys)
 
@@ -494,10 +552,13 @@ def test_should_mark_classified_stage_for_long_foreground_command(
 
 
 def test_should_emit_unclassified_agent_work_with_description(
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    _write_collection(tmp_path, "planning", "in-progress", {"phase": "prepared", "assets": {"raw_master": None}})
     payload = json.dumps(
         {
+            "cwd": str(tmp_path),
             "hook_event_name": "PreToolUse",
             "tool_name": "Agent",
             "tool_input": {"subagent_type": "Explore", "description": "hook 定義箇所を調査"},
@@ -525,9 +586,18 @@ def test_should_use_nonempty_fallback_for_unclassified_work(
     tool_name: str,
     tool_input: dict[str, object],
     expected: str,
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    payload = json.dumps({"hook_event_name": "PreToolUse", "tool_name": tool_name, "tool_input": tool_input})
+    _write_collection(tmp_path, "planning", "in-progress", {"phase": "prepared", "assets": {"raw_master": None}})
+    payload = json.dumps(
+        {
+            "cwd": str(tmp_path),
+            "hook_event_name": "PreToolUse",
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+        }
+    )
 
     exit_code, stdout, stderr = _run(payload, capsys)
 
@@ -538,10 +608,21 @@ def test_should_use_nonempty_fallback_for_unclassified_work(
 
 
 def test_should_mark_classified_stage_complete_after_displayed_command_returns(
+    tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    _write_collection(
+        tmp_path,
+        "planning",
+        "video-generated",
+        {
+            "phase": "prepared",
+            "assets": {"raw_master": "raw.wav", "master_audio": "master.wav", "master_video": "master.mp4"},
+        },
+    )
     payload = json.dumps(
         {
+            "cwd": str(tmp_path),
             "hook_event_name": "PostToolUse",
             "tool_name": "Bash",
             "tool_input": {"command": "ffmpeg -i input.mp3 output.mp4"},


### PR DESCRIPTION
## Summary

進捗図 hook (`yt-progress-hook`) が `load_progress_snapshot` でコレクションを解決できないとき（`collections/` 無し・workflow-state を持つコレクション 0 件・`workflow-state.json` 破損）、「企画〜マスター化が完了済み」という実態と無関係な固定進捗図を描いていた。snapshot 未解決時は stdout に何も出さず exit 0 で終了する。

- snapshot の解決を `_render` 内部から `main` の境界へ移動し、未解決なら描画せず終了する
- `_render` から `snapshot is None` の fallback 分岐と `index <= 2` のハードコードを削除し、非 None の `ProgressSnapshot` を受け取る純粋なレンダラーにする
- `cwd` 無し payload に依存していた描画系テストをチャンネル fixture 前提へ移し、未解決 3 ケース + `cwd` 無しの無出力を回帰テストで固定する

Closes #4416