### PR TITLE
ci(lint): pyscn の構造品質ゲートを lint ジョブに追加する (#4615)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
           - name: Ruff format check
             if: needs.changes.outputs.python == 'true'
             run: nix develop --command uv run ruff format --check .
+          - name: pyscn check
+            if: needs.changes.outputs.python == 'true'
+            run: nix develop --command uv run pyscn check src/youtube_automation
       - name: Skill catalog check
         if: needs.changes.outputs.python == 'true'
         run: nix develop --command uv run yt-skills catalog --check

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ __pycache__/
 .venv/
 .env
 .direnv/
+# pyscn analyze のローカルレポート出力
+.pyscn/
 
 # Pytest temp（--basetemp などで生成される一時ディレクトリ）
 .tmp_test/

--- a/changelog.d/4615-pyscn-quality-gate.added.md
+++ b/changelog.d/4615-pyscn-quality-gate.added.md
@@ -1,0 +1,1 @@
+- CI の lint ジョブに pyscn の構造品質ゲート（`pyscn check src/youtube_automation`）を追加。複雑度・関数長は導入時点の実測値を `[tool.pyscn]` の閾値に固定して既存債務を通し、dead code・循環 import は即時 fail で新規の悪化だけを検出する

--- a/docs/development.md
+++ b/docs/development.md
@@ -62,7 +62,7 @@ python .github/scripts/run-affected-tests.py                              # work
 
 | 変更 | 最初に実行 | PR 前の追加確認 |
 |---|---|---|
-| Python product code | behavioral fast lane + 変更 module の直接 test | unit-only full suite |
+| Python product code | behavioral fast lane + 変更 module の直接 test | unit-only full suite + `uv run pyscn check src/youtube_automation` |
 | skill / skill reference script | production-importing test は `docs/architecture/tests-layout.md` の鏡像規則、repository-only 契約は `tests/repo/` | repository contract lane + unit-only full suite |
 | docs / CI / packaging / hook | repository contract lane + 対応 file の直接 test | slow lane（tool 契約を含む場合）+ unit-only full suite |
 | extensions | 対象 workspace の既存 pnpm lint / type / Vitest / Playwright | Extensions CI（pytest marker 対象外） |
@@ -274,14 +274,15 @@ uv run pytest tests/repo/test_skills_sync_installed_wheel.py -q
 
 品質ゲートはローカル git hook ではなく CI（`.github/workflows/ci.yml`）で一元的に担保する（issue #2534 で lefthook を廃止。sandbox 化された worker が `.git/hooks` へ書き込めず bootstrap が反復失敗していたため、ローカル hook は持たない）。
 
-- **lint ジョブ**: `ruff check` / `ruff format --check`（旧 pre-commit と同等）
+- **lint ジョブ**: `ruff check` / `ruff format --check`（旧 pre-commit と同等）/ `pyscn check src/youtube_automation`（構造品質ゲート。Fallow の Python 対応物として issue #4615 で導入）
+  - **pyscn の閾値方針**: 複雑度（`max_complexity`）と関数長（`function_sloc_critical_threshold`）は導入時点の `src/youtube_automation` 実測最大値を `pyproject.toml::[tool.pyscn]` に固定してあり、既存債務は通しつつ実測値を超える新規の悪化だけを fail させる。dead code と循環 import は導入時点で 0 件のため即時 fail が有効。債務返済で実測値が下がったら閾値も追随して締め直す。code clone の検出は informational（fail しない）
 - **changelog ジョブ**: 実コード（`src/youtube_automation/` / `.claude/skills/` / `.claude/CLAUDE.template.md` / `pyproject.toml`）を変更したのに `changelog.d/` の fragment 追加または `CHANGELOG.md` の更新が無ければ fail する。fragment の書式は `changelog.d/README.md` を参照する。意図的に省く場合は PR に `skip-changelog` ラベルを付与する
 - **any-gate ジョブ**: 広すぎる型注釈ゲート。基準点からの新規追加行だけを対象に、ディレクトリを問わず全 `*.py` / `*.ts` / `*.tsx` の Python の typing module 経由の Any 型、または TypeScript の any 型注釈を検出したら fail する。既存行は対象外。ロジック本体は `.github/scripts/any-usage-gate.sh`（ローカルでも `bash .github/scripts/any-usage-gate.sh` で単体実行できる）
   - **基準点の解決順**: `PRE_PUSH_DIFF_BASE`（CI の any-gate ジョブが PR の base sha を渡す）→ `origin/main` → `main`。実際の diff 基準は解決した ref と HEAD の merge-base。`main` へのフォールバックは、remote を 1 つも持たない隔離クローンで takt がタスクを実行するため（クローンのローカル `main` はクローン時点の main そのものなので基準点は変わらない）。この経路が無いと `ci_verify` が push 前に再現すべき 4 ゲートのうち any-gate だけが常に self-skip する（issue #3048）。どの ref も解決できないときは、試した ref を列挙して skip する。解決順そのものは `tests/repo/test_any_usage_gate.py` が機械担保する
   - **Python**: `.github/scripts/any_usage_python_resolver.py` が `ast` でファイルを解析し、`typing.Any` の修飾アクセス（`import typing` / `import typing as t` 経由）と `from typing import Any`（複数行の括弧 import・`as` alias 含む）の直接 import 経由の裸 `Any` の両方を、実際に参照されている行番号として解決する。コメント・docstring・文字列リテラル中の "Any" は AST 上に現れないため誤検知しない。`python3` が無い場合は警告を出して Python 側の検出のみ省略する
   - **TypeScript**: `: any` 直書きに加え、`Array<any>` / `Record<string, any>` のようなジェネリック引数、union / intersection、tuple 要素、型エイリアス代入（`type X = any;`）、アロー関数戻り値（`() => any`）、型アサーション（`value as any`）などの型位置の `any` を検出する。正規表現で候補行を検出したのち `.github/scripts/any_usage_ts_line_cleaner.py` で行コメント（`//...`）と文字列・テンプレートリテラルの中身を取り除いてから再判定するため、コメントや文字列リテラル中の "any"（型注釈っぽい表記を含む）は誤検知しない
 
-Python 側の未使用コード検出は、追加依存なしで CI に載っている Ruff `F` 系（未使用 import / 変数、未定義名など）を継続採用する。vulture は新規依存追加が必要で、Ruff `ARG` は既存コードに多数の既存違反があるため #1510 では採用しない。
+Python 側の未使用コード検出は、追加依存なしで CI に載っている Ruff `F` 系（未使用 import / 変数、未定義名など）を継続採用する。vulture は新規依存追加が必要で、Ruff `ARG` は既存コードに多数の既存違反があるため #1510 では採用しない。#4615 以降は lint ジョブの pyscn が CFG ベースの到達不能コード検出（return / raise 後のコードなど）を併用する。
 
 devShell の運用:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,21 @@ ignore = ["RUF001", "RUF002", "RUF003"]
 # pytest.raises(match=...) の正規表現メタ文字警告はテスト可読性を優先して抑制
 "tests/**" = ["RUF043"]
 
+[tool.pyscn.complexity]
+enabled = true
+# 導入時点（issue #4615）の src/youtube_automation 実測最大値で固定し、既存債務は通しつつ
+# それを超える新規の悪化だけを fail させる。債務返済で下がったら実測値へ追随して締め直す
+max_complexity = 42
+function_sloc_critical_threshold = 544
+
+[tool.pyscn.dead_code]
+enabled = true
+min_severity = "warning"
+
+[tool.pyscn.dependencies]
+enabled = true
+detect_cycles = true
+
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "failed"
 markers = [
@@ -216,6 +231,7 @@ markers = [
 
 [dependency-groups]
 dev = [
+    "pyscn>=1.29,<2",
     "pytest>=9,<10",
     "pytest-xdist>=3.8,<4",
     "ruff>=0.15,<1",

--- a/tests/repo/test_actions_parallel_workflows.py
+++ b/tests/repo/test_actions_parallel_workflows.py
@@ -22,6 +22,7 @@ _CI_PATH_CLASSIFIER = _REPO_ROOT / ".github" / "scripts" / "classify-ci-paths.sh
 _CI_LINT_PARALLEL_STEPS = {
     "Ruff check": "nix develop --command uv run ruff check .",
     "Ruff format check": "nix develop --command uv run ruff format --check .",
+    "pyscn check": "nix develop --command uv run pyscn check src/youtube_automation",
 }
 
 _SUNO_FAST_PARALLEL_STEPS = {

--- a/uv.lock
+++ b/uv.lock
@@ -1462,6 +1462,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pyscn"
+version = "1.29.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/bba2b75c3ce677b96cbc34ac82acfc3fc61e402ab8e2fb6e44cec4af298f/pyscn-1.29.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:eefcbc1388a3a573c20f404241df2ea4d38c4f3fa8ea59034039d90d8a49e02d", size = 10026460, upload-time = "2026-08-16T03:22:51.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e6/b311086e861ec5f4d7b4fe2a112cc1a41039506c7453dca47bd0a0815cd3/pyscn-1.29.1-py3-none-manylinux_2_17_x86_64.whl", hash = "sha256:adeff99afd3a1df1ae711463712c1122fc66e494f80c53c8d8f1826a14126ce1", size = 10948738, upload-time = "2026-08-16T03:22:53.259Z" },
+    { url = "https://files.pythonhosted.org/packages/79/bc/1ae38573b5503613453c5b2db8d907060720489ed52cdc7d1b20a62e6efb/pyscn-1.29.1-py3-none-win_amd64.whl", hash = "sha256:61c4d3fe6d82988b9776932ccedfbe4f6c9150eea274666eb01776b3f29b1450", size = 11408077, upload-time = "2026-08-16T03:22:54.915Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.1.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1851,6 +1861,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "pyscn" },
     { name = "pytest" },
     { name = "pytest-xdist" },
     { name = "ruff" },
@@ -1878,6 +1889,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pyscn", specifier = ">=1.29,<2" },
     { name = "pytest", specifier = ">=9,<10" },
     { name = "pytest-xdist", specifier = ">=3.8,<4" },
     { name = "ruff", specifier = ">=0.15,<1" },


### PR DESCRIPTION
## Summary

Python 本体の CI に、Fallow（`extensions/` の TS 品質ゲート）の Python 対応物として [pyscn](https://github.com/ludo-technologies/pyscn) の構造品質ゲートを追加する。

- `[dependency-groups] dev` に `pyscn>=1.29,<2` を追加（PyPI platform wheel のため既存の `uv sync` 経路にそのまま乗る）
- `pyproject.toml::[tool.pyscn]` に閾値を新設。複雑度 `max_complexity = 42`・関数長 `function_sloc_critical_threshold = 544` は導入時点の `src/youtube_automation` 実測最大値で固定し、既存債務を通しつつ新規の悪化だけを fail させる。dead code・循環 import は実測 0 件のため即時 fail が有効
- `ci.yml` の lint ジョブの parallel group に `pyscn check src/youtube_automation` step を追加（既存の `needs.changes.outputs.python == 'true'` 条件に乗せ、extension-only 変更では起動しない）
- lint parallel group の契約テスト（`tests/repo/test_actions_parallel_workflows.py::_CI_LINT_PARALLEL_STEPS`）を追従
- `docs/development.md` の品質ゲート節と変更種別ごとの最小入口に pyscn を追記
- `pyscn analyze` のローカルレポート出力 `.pyscn/` を gitignore

## 検証

- `uv run pyscn check src/youtube_automation` → exit 0（既存債務では red にならない）
- `uv run pyscn check --max-complexity 1 src/youtube_automation` → exit 1（ゲートが実際に効く）
- ruff check / ruff format --check / `uv sync --frozen` / repo_contract lane（742 passed）すべて green

base 差分ゲート化（Fallow の `audit.gate: new-only` 相当）と既存 finding の債務返済はスコープ外（issue 記載どおり後続 issue へ分離）。

Closes #4615