### PR TITLE
docs: ツール導入をインストール先行に更新する (#4535)

### DIFF
--- a/changelog.d/4535-install-first-guide.changed.md
+++ b/changelog.d/4535-install-first-guide.changed.md
@@ -1,0 +1,2 @@
+- `docs/tool-setup.md` を、automation package と skill の同期後に新しい Claude Code セッションで setup wizard を開始する、インストール先行の手順へ更新
+- `docs/oauth-setup.md` の手順番号を `docs/tool-setup.md` の 4 ステップに続く 5 / 6 へ振り直し、各ステップへ `**目的:**` 行を追加

--- a/changelog.d/4535-install-first-guide.docs.md
+++ b/changelog.d/4535-install-first-guide.docs.md
@@ -1,1 +1,0 @@
-`docs/tool-setup.md` を、automation package と skill の同期後に新しい Claude Code セッションで setup wizard を開始する、インストール先行の手順へ更新しました。

--- a/changelog.d/4535-install-first-guide.docs.md
+++ b/changelog.d/4535-install-first-guide.docs.md
@@ -1,0 +1,1 @@
+`docs/tool-setup.md` を、automation package と skill の同期後に新しい Claude Code セッションで setup wizard を開始する、インストール先行の手順へ更新しました。

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -15,8 +15,6 @@ skill / CLI ごとの実効 scope と read-only token の設計は [`oauth-scope
 
 ### 5. GCP / ADC / OAuth を完了する
 
-**目的:** YouTube と Vertex AI を使うための GCP project と認証を、setup の案内どおりに整える。
-
 setup は project 選択、Billing 紐付け、必要 API の有効化、ADC quota project、IAM、Reporting job を診断順に進める。外部の GCP 状態を変える前には、対象 project・account・実行コマンドを表示して承認を求める。
 
 認証 CLI は setup 自身が対話 session で起動する。利用者がターミナルへ別途コマンドをコピーして実行する必要はない。
@@ -41,8 +39,6 @@ uv run yt-doctor --apply --json
 ```
 
 ### 6. 完了を確認する
-
-**目的:** 認証セットアップが終わったことを、診断結果で確かめる。
 
 `uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed` となり、次がすべて確認できれば `/setup --tool` は完了である。
 

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -13,7 +13,9 @@ skill / CLI ごとの実効 scope と read-only token の設計は [`oauth-scope
 
 ## 推奨ルート: `/setup --tool`
 
-### 3. GCP / ADC / OAuth を完了する
+### 5. GCP / ADC / OAuth を完了する
+
+**目的:** YouTube と Vertex AI を使うための GCP project と認証を、setup の案内どおりに整える。
 
 setup は project 選択、Billing 紐付け、必要 API の有効化、ADC quota project、IAM、Reporting job を診断順に進める。外部の GCP 状態を変える前には、対象 project・account・実行コマンドを表示して承認を求める。
 
@@ -38,7 +40,9 @@ uv run yt-doctor --fix-client-secrets
 uv run yt-doctor --apply --json
 ```
 
-### 4. 完了を確認する
+### 6. 完了を確認する
+
+**目的:** 認証セットアップが終わったことを、診断結果で確かめる。
 
 `uv run yt-doctor --apply --json` の `apply.stop_reason` が `completed` となり、次がすべて確認できれば `/setup --tool` は完了である。
 

--- a/docs/tool-setup.md
+++ b/docs/tool-setup.md
@@ -1,22 +1,25 @@
 # ツール導入
 
-空のチャンネル用フォルダへ automation ツールと skill を導入するための**運営者向け正本**。以下を上から順に進める。
+空のチャンネル用フォルダへ automation ツールと skill（Claude Code に作業手順を教えるファイル）を導入するための**運営者向け正本**。コマンドの意味が分からなくても、以下を上から順に進めればよい。
 
 > [!WARNING]
 > 本 Python 版はメンテナンスモードである。新規導入前に [`migration/python-to-tayk.md`](migration/python-to-tayk.md) の移行方針も確認する。
 
-## 推奨ルート: 空フォルダから `/setup --tool`
+## 推奨ルート: Claude Code に導入を任せる
 
-### 1. 開始条件
+### 1. 作業フォルダを開く
+
+**目的:** このチャンネル専用のファイルを、他の作業と混ざらない場所に置く。
+
+事前に用意するもの:
 
 - macOS または Linux（Windows は WSL2 を推奨）
 - Google アカウントと、セットアップ対象の YouTube チャンネル
 - [Claude Code](https://claude.ai/code)
-- Python 3.11 以上、FFmpeg、Google Cloud SDK (`gcloud`)
-- [uv](https://docs.astral.sh/uv/)。未導入なら `/setup --tool` が公式手順を案内する
-- Vertex AI を使う GCP project には Billing account が必要
+- Python 3.11 以上、FFmpeg（動画・音声を処理するツール）、Google Cloud SDK（Google Cloud を操作するツール）
+- Vertex AI（Google Cloud の AI サービス）を使う GCP project には Billing account（課金先）が必要
 
-作業用の空フォルダを作り、そこで Claude Code を起動する。
+空のフォルダを作り、そこで Claude Code を起動する。
 
 ```bash
 mkdir my-youtube-channel
@@ -24,11 +27,50 @@ cd my-youtube-channel
 claude
 ```
 
-`config/channel/*.json` はまだ不要であり、ここでは `/setup --channel` を実行しない。
+`config/channel/*.json` はまだ不要である。
 
-### 2. automation と skill を導入する
+### 2. 導入プロンプトを貼る
 
-Claude Code で **`/setup --tool`** と依頼する。setup は空フォルダを許容し、次を順番に実行する。
+**目的:** 必要なツールと skill を、Claude Code に正しい順序で導入させる。
+
+uv（Python ツールの導入と実行を管理するアプリ）を含め、必要な確認とコマンド実行は Claude Code に任せる。次のプロンプトをそのまま貼る。
+
+```text
+この空のチャンネル用フォルダに YouTube automation ツールを導入してください。
+
+1. まず uv が入っているか確認し、入っていなければ uv の公式手順 https://docs.astral.sh/uv/getting-started/installation/ に従って導入してください。
+2. `uv init` で Python project を初期化してください。
+3. `uv add git+https://github.com/daiki-beppu/youtube-automation.git` で automation package を追加してください。
+4. 次の 3 コマンドを順に実行し、skill、Claude Code 用の運営方針、認証ファイルのひな形を同期してください。
+   - `uv run yt-skills sync --asset skills --force`
+   - `uv run yt-skills sync --asset claude-md`
+   - `uv run yt-skills sync --asset auth-template`
+5. `uv run yt-setup-dirs` で必要な作業フォルダを作ってください。
+6. `uv run yt-doctor --json` で導入状態を診断し、結果を要約してください。ここでは `--apply` を実行せず、診断だけで止めてください。
+
+既に完了している手順は再作成せず、エラーが出たら原因と次に必要な操作を日本語で説明してください。
+```
+
+### 3. Claude Code を新しいセッションで開き直す
+
+**目的:** 同期した skill を Claude Code に読み込ませる。
+
+Claude Code は project の skill をセッション開始時に検出するため、同期しただけでは現在のセッションに新しいコマンドが現れない場合がある。必ず現在のセッションを終了して `claude` を再実行するか、Claude Code を再起動する。
+
+### 4. 認証セットアップを始める
+
+**目的:** GCP（Google Cloud Platform）、OAuth（YouTube へ安全にアクセスするための認証）、ADC（Google Cloud ツールが使うローカル認証情報）を対話形式で設定する。
+
+新しいセッションで **`/setup --tool`** と依頼する。セットアップが診断結果を読み、必要な操作だけを順に案内する。
+
+## 手動コマンド（補助）
+
+<details>
+<summary>Claude Code に任せず、ターミナルへ自分で入力する場合</summary>
+
+**目的:** 推奨プロンプトと同じ導入処理を手動で行う。
+
+uv が無い場合は、先に [uv の公式導入手順](https://docs.astral.sh/uv/getting-started/installation/) に従う。その後、作業フォルダで次を順に実行する。
 
 ```bash
 uv init
@@ -40,8 +82,10 @@ uv run yt-setup-dirs
 uv run yt-doctor --json
 ```
 
-既に作成済みの `pyproject.toml` や導入済み package は再作成しない。`yt-skills sync` により `.claude/skills/` と運営方針が同期され、`yt-setup-dirs` により `auth/` などの最小ディレクトリが作られる。doctor が示す変更 plan を確認して承認すると、setup が `uv run yt-doctor --apply --json` を進める。
+実行後は、推奨ルートの手順 3 と 4 へ進む。
+
+</details>
 
 ## 次の工程
 
-ツールと skill の導入が完了したら、次に [`GCP / YouTube API セットアップ`](oauth-setup.md) へ進む。
+ツールと skill の導入が完了し、認証セットアップを開始したら、[`GCP / YouTube API セットアップ`](oauth-setup.md) の画面別手順も参照する。

--- a/docs/tool-setup.md
+++ b/docs/tool-setup.md
@@ -17,7 +17,7 @@
 - Google アカウントと、セットアップ対象の YouTube チャンネル
 - [Claude Code](https://claude.ai/code)
 - Python 3.11 以上、FFmpeg（動画・音声を処理するツール）、Google Cloud SDK（Google Cloud を操作するツール）
-- Vertex AI（Google Cloud の AI サービス）を使う GCP project には Billing account（課金先）が必要
+- Vertex AI（Google Cloud の AI サービス）を使う GCP（Google Cloud Platform）project には Billing account（課金先）が必要
 
 空のフォルダを作り、そこで Claude Code を起動する。
 
@@ -59,7 +59,7 @@ Claude Code は project の skill をセッション開始時に検出するた�
 
 ### 4. 認証セットアップを始める
 
-**目的:** GCP（Google Cloud Platform）、OAuth（YouTube へ安全にアクセスするための認証）、ADC（Google Cloud ツールが使うローカル認証情報）を対話形式で設定する。
+**目的:** GCP、OAuth（YouTube へ安全にアクセスするための認証）、ADC（Google Cloud ツールが使うローカル認証情報）を対話形式で設定する。
 
 新しいセッションで **`/setup --tool`** と依頼する。セットアップが診断結果を読み、必要な操作だけを順に案内する。
 
@@ -82,7 +82,7 @@ uv run yt-setup-dirs
 uv run yt-doctor --json
 ```
 
-実行後は、推奨ルートの手順 3 と 4 へ進む。
+実行後は、推奨ルートの「Claude Code を新しいセッションで開き直す」と「認証セットアップを始める」へ進む。
 
 </details>
 

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1377,11 +1377,19 @@ def test_public_setup_guide_owns_installation_and_oauth_completion() -> None:
     recommended = oauth_setup.split("## 推奨ルート", 1)[1].split("## 上級者向け", 1)[0]
 
     for expected in (
+        "uv が入っているか確認",
+        "公式手順",
         "uv init",
         "uv add git+https://github.com/daiki-beppu/youtube-automation.git",
         "uv run yt-skills sync --asset skills --force",
+        "uv run yt-skills sync --asset claude-md",
+        "uv run yt-skills sync --asset auth-template",
+        "uv run yt-setup-dirs",
+        "uv run yt-doctor --json",
     ):
         assert expected in tool_setup
+    assert tool_setup.index("yt-skills sync") < tool_setup.index("新しいセッション")
+    assert tool_setup.index("新しいセッション") < tool_setup.index("/setup --tool")
 
     for expected in (
         "/setup --tool",


### PR DESCRIPTION
公開ツール導入ページを、コピペ用プロンプトによるインストールと skill 同期を先行する手順へ更新します。手動コマンドは補助ルートとして整理し、契約テストで手順順序を固定します。

Closes #4535