### PR TITLE
refactor(localserver): collection serveをchassisへ移行する (#4452)

### DIFF
--- a/changelog.d/4452-collection-serve-chassis.changed.md
+++ b/changelog.d/4452-collection-serve-chassis.changed.md
@@ -1,1 +1,1 @@
-`yt-collection-serve` の HTTP transport を共通 localserver chassis の route table・body limit・response writer 上へ移行しました。
+`yt-collection-serve` の HTTP transport を共通 localserver chassis の route table・body limit・response writer 上へ移行しました。route handler と chassis の双方が載せる同名ヘッダー（`Access-Control-Allow-Origin` / `Vary` など）は送出前に畳み込むため、拡張からの fetch で CORS 検証が壊れることはありません。

--- a/changelog.d/4452-collection-serve-chassis.changed.md
+++ b/changelog.d/4452-collection-serve-chassis.changed.md
@@ -1,1 +1,1 @@
-`yt-collection-serve` の HTTP transport を共通 localserver chassis の route table・body limit・response writer 上へ移行しました。route handler と chassis の双方が載せる同名ヘッダー（`Access-Control-Allow-Origin` / `Vary` など）は送出前に畳み込むため、拡張からの fetch で CORS 検証が壊れることはありません。
+- `yt-collection-serve` の HTTP 層を共通 localserver chassis へ移行しました。routing・CORS origin 判定・body 上限は chassis が所有し、各エンドポイントは socket を持たない handler 関数になりました。

--- a/changelog.d/4452-collection-serve-chassis.changed.md
+++ b/changelog.d/4452-collection-serve-chassis.changed.md
@@ -1,0 +1,1 @@
+`yt-collection-serve` の HTTP transport を共通 localserver chassis の route table・body limit・response writer 上へ移行しました。

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -24,6 +24,7 @@ import argparse
 import contextlib
 import hashlib
 import http.client
+import io
 import json
 import math
 import mimetypes
@@ -40,8 +41,10 @@ import time
 import urllib.parse
 import uuid
 from datetime import datetime
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from email.message import Message
+from http import HTTPStatus
 from pathlib import Path
+from typing import Callable, ClassVar
 
 from youtube_automation import __version__
 from youtube_automation.application.distrokid.disc_query import find_distrokid_discs
@@ -95,6 +98,12 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
     resolve_unpacked_extension_origin,
 )
 from youtube_automation.infrastructure.file_lock import file_lock
+from youtube_automation.infrastructure.localserver.app import (
+    LocalHTTPServer,
+    Request,
+    Response,
+    Route,
+)
 from youtube_automation.infrastructure.localserver.collections import (
     COLLECTION_DIR_SUFFIX as _COLLECTION_DIR_SUFFIX,
 )
@@ -206,13 +215,27 @@ class _IdleTimeout(RuntimeError):
         super().__init__(f"no HTTP requests received for {seconds:g} seconds")
 
 
-class _IdleTrackingHTTPServer(ThreadingHTTPServer):
+class _IdleTrackingHTTPServer(LocalHTTPServer):
     """request の受付時刻を追跡し、serve loop から idle 終了する HTTP server。"""
 
-    def __init__(self, server_address: tuple[str, int], handler_class: type[BaseHTTPRequestHandler], seconds: float):
+    def __init__(
+        self,
+        server_address: tuple[str, int],
+        routes: list[Route],
+        origin_policy: Callable[[str | None], bool],
+        seconds: float,
+    ):
         self._idle_timeout_seconds = seconds
         self._last_request_at = time.monotonic()
-        super().__init__(server_address, handler_class)
+        super().__init__(
+            server_address,
+            routes,
+            origin_policy,
+            max_body_bytes=_MAX_POST_BODY_BYTES,
+            stop_path=None,
+            idle_timeout_seconds=None,
+            enforce_origin=False,
+        )
 
     def finish_request(self, request: object, client_address: tuple[str, int]) -> None:
         self._last_request_at = time.monotonic()
@@ -854,6 +877,84 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+class _TransportFreeHandler:
+    """Minimal response recorder used by collection route handlers."""
+
+    responses: ClassVar = {status.value: (status.phrase, status.description) for status in HTTPStatus}
+
+    def __init__(self, request: Request, port: int) -> None:
+        self.command = request.method
+        self.path = request.path
+        if request.query:
+            self.path += "?" + urllib.parse.urlencode(request.query, doseq=True)
+        self.headers = Message()
+        for key, value in request.headers.items():
+            self.headers[key] = value
+        self.rfile = io.BytesIO(request.body)
+        self.wfile = io.BytesIO()
+        self.server = type("ServerAddress", (), {"server_address": ("127.0.0.1", port)})()
+        self._status = 200
+        self._headers: list[tuple[str, str]] = []
+
+    def send_response(self, status: int) -> None:
+        self._status = status
+
+    def send_header(self, key: str, value: str) -> None:
+        self._headers.append((key, value))
+
+    def end_headers(self) -> None:
+        return None
+
+    def response(self) -> Response:
+        headers = dict(self._headers)
+        return Response(
+            self.wfile.getvalue(),
+            self._status,
+            {key: value for key, value in headers.items() if key.lower() not in {"content-type", "content-length"}},
+            headers.get("Content-Type", "application/json; charset=utf-8"),
+        )
+
+
+def _collection_routes(handler_type: type[_TransportFreeHandler], port: int) -> list[Route]:
+    def dispatch(request: Request) -> Response:
+        handler = handler_type(request, port)
+        method = getattr(handler, f"do_{request.method}", None)
+        if method is None:
+            handler.send_error(501, f"Unsupported method ({request.method!r})")
+        else:
+            method()
+        return handler.response()
+
+    return [
+        Route(
+            "POST",
+            f"{COLLECTIONS_ROUTE}/{{collection}}/downloaded",
+            dispatch,
+            _MAX_DOWNLOADED_POST_BODY_BYTES,
+        ),
+        Route("POST", _UNATTENDED_REQUESTS_ROUTE, dispatch, _MAX_UNATTENDED_REQUEST_BODY_BYTES),
+        *[
+            Route(method, path, dispatch)
+            for method in ("GET", "POST", "DELETE", "HEAD", "OPTIONS")
+            for path in ("/", "/{path*}")
+        ],
+    ]
+
+
+def _server_metadata(
+    server_info: dict[str, object] | None,
+    port: int,
+    distrokid_enabled: bool,
+    collections_root: Path | None,
+) -> dict[str, object]:
+    resolved = server_info if server_info is not None else build_server_info("YouTube Automation", "YA", port)
+    mode = "disabled" if not distrokid_enabled else ("dir" if collections_root is not None else "single")
+    resolved["capabilities"] = {"distrokid": {"mode": mode}}
+    if collections_root is not None:
+        resolved["collections_root"] = collections_root.name
+    return resolved
+
+
 def create_server(
     port: int,
     allow_origin: str | None,
@@ -871,7 +972,7 @@ def create_server(
     lifecycle_record: _LifecycleRecord | None = None,
     lifecycle_root: Path | None = None,
     downloaded_handoff: SunoDownloadHandoff | None = None,
-) -> ThreadingHTTPServer:
+) -> LocalHTTPServer:
     """サブパス分離した GET / POST / CORS preflight を返すサーバーを生成する.
 
     `collections_root` 指定時は **dir mode**（`/collections` 系を配信し
@@ -888,16 +989,12 @@ def create_server(
     serve_token = str(uuid.uuid4())
     unattended_requests: dict[str, tuple[float, dict[str, object]]] = {}
     unattended_requests_lock = threading.Lock()
-    resolved_server_info = (
-        server_info if server_info is not None else build_server_info("YouTube Automation", "YA", port)
-    )
-    distrokid_mode = "disabled" if not distrokid_enabled else ("dir" if dir_mode else "single")
-    resolved_server_info["capabilities"] = {"distrokid": {"mode": distrokid_mode}}
-    if collections_root is not None:
-        resolved_server_info["collections_root"] = collections_root.name
+    resolved_server_info = _server_metadata(server_info, port, distrokid_enabled, collections_root)
     resolved_community_asset_root = community_asset_root if community_asset_root is not None else collection_dir
 
-    class _Handler(BaseHTTPRequestHandler):
+    class _Handler(_TransportFreeHandler):
+        """Transport-free compatibility application for collection routes."""
+
         def _allowed_origin(self) -> str | None:
             headers = getattr(self, "headers", None)
             if headers is None:
@@ -1469,7 +1566,12 @@ def create_server(
         def log_message(self, *args) -> None:  # サーバーログを抑制
             pass
 
-    server = _IdleTrackingHTTPServer(("localhost", port), _Handler, idle_timeout_seconds)
+    server = _IdleTrackingHTTPServer(
+        ("localhost", port),
+        _collection_routes(_Handler, port),
+        lambda origin: is_origin_allowed(origin, allow_origin),
+        idle_timeout_seconds,
+    )
     if server_info is None:
         resolved_server_info.update(build_server_info("YouTube Automation", "YA", server.server_address[1]))
     return server

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -40,18 +40,19 @@ import threading
 import time
 import urllib.parse
 import uuid
+from dataclasses import replace
 from datetime import datetime
 from email.message import Message
 from http import HTTPStatus
 from pathlib import Path
-from types import SimpleNamespace
-from typing import Callable, ClassVar
 
 from youtube_automation import __version__
 from youtube_automation.application.distrokid.disc_query import find_distrokid_discs
 from youtube_automation.application.suno_download_handoff import SunoDownloadHandoff
 from youtube_automation.commands.collections.collection_serve_discovery import (
+    DISCOVERY_PATH,
     DISCOVERY_PORT,
+    MAX_REGISTRATION_BODY_BYTES,
     RegistryState,
     create_discovery_lifecycle,
     handle_registry_request,
@@ -101,6 +102,9 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
 from youtube_automation.infrastructure.file_lock import file_lock
 from youtube_automation.infrastructure.localserver.app import (
     LocalHTTPServer,
+    OriginDecision,
+    OriginPolicy,
+    OriginQuery,
     Request,
     Response,
     Route,
@@ -178,6 +182,8 @@ _R2_HANDOFF_ENVIRONMENT = frozenset({"R2_ACCOUNT_ID", "R2_ACCESS_KEY_ID", "R2_AP
 
 # 30-distrokid サブディレクトリ名（#934）。コレクション配下のこのサブディレクトリが disc を含む。
 _DISTROKID_DIRNAME = "30-distrokid"
+# collection-scoped release route の固定セグメント（`/collections/<id>/distrokid/<disc>/release.json`）。
+_DISTROKID_ROUTE_SEGMENT = "distrokid"
 _DISTROKID_METADATA_FILENAME = "metadata.md"
 
 # dir mode: DistroKid collections 一覧 + releases POST のルート定数（#934）。
@@ -223,7 +229,7 @@ class _IdleTrackingHTTPServer(LocalHTTPServer):
         self,
         server_address: tuple[str, int],
         routes: list[Route],
-        origin_policy: Callable[[str | None], bool],
+        origin_policy: OriginPolicy,
         seconds: float,
     ):
         self._idle_timeout_seconds = seconds
@@ -235,7 +241,6 @@ class _IdleTrackingHTTPServer(LocalHTTPServer):
             max_body_bytes=_MAX_POST_BODY_BYTES,
             stop_path=None,
             idle_timeout_seconds=None,
-            enforce_origin=False,
         )
 
     def finish_request(self, request: object, client_address: tuple[str, int]) -> None:
@@ -878,23 +883,25 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
-class _TransportFreeHandler:
-    """Minimal response recorder used by collection route handlers."""
+class _DiscoveryRecorder:
+    """Minimal stdlib-handler stand-in kept only for the shared discovery contract.
 
-    responses: ClassVar = {status.value: (status.phrase, status.description) for status in HTTPStatus}
+    `collection_serve_discovery.handle_registry_request` is shared with the
+    dedicated registry server and still speaks the `BaseHTTPRequestHandler`
+    protocol. Every collection route below is a plain `Request -> Response`
+    function; this shim exists solely so the fixed discovery path keeps its
+    schema v1 status matrix without forking that module (#4452).
+    """
 
-    def __init__(self, request: Request, port: int) -> None:
+    def __init__(self, request: Request) -> None:
         self.command = request.method
         self.path = request.path
-        if request.query:
-            self.path += "?" + urllib.parse.urlencode(request.query, doseq=True)
         self.headers = Message()
         for key, value in request.headers.items():
             self.headers[key] = value
         self.rfile = io.BytesIO(request.body)
         self.wfile = io.BytesIO()
-        self.server = SimpleNamespace(server_address=("127.0.0.1", port))
-        self._status = 200
+        self._status = int(HTTPStatus.OK)
         self._headers: list[tuple[str, str]] = []
 
     def send_response(self, status: int) -> None:
@@ -916,30 +923,65 @@ class _TransportFreeHandler:
         )
 
 
-def _collection_routes(handler_type: type[_TransportFreeHandler], port: int) -> list[Route]:
-    def dispatch(request: Request) -> Response:
-        handler = handler_type(request, port)
-        method = getattr(handler, f"do_{request.method}", None)
-        if method is None:
-            handler.send_error(501, f"Unsupported method ({request.method!r})")
-        else:
-            method()
-        return handler.response()
+# chassis が dispatch できる HTTP method の全集合。collection server はこのうち
+# GET / POST / OPTIONS だけを実装し、残りは stdlib と同じ 501 で答える契約を保つ。
+_DISPATCHABLE_METHODS = ("GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "CONNECT", "TRACE", "BREW")
+_FALLBACK_PATH_PATTERNS = ("/", "/{path*}")
 
-    return [
-        Route(
-            "POST",
-            f"{COLLECTIONS_ROUTE}/{{collection}}/downloaded",
-            dispatch,
-            _MAX_DOWNLOADED_POST_BODY_BYTES,
-        ),
-        Route("POST", _UNATTENDED_REQUESTS_ROUTE, dispatch, _MAX_UNATTENDED_REQUEST_BODY_BYTES),
-        *[
-            Route(method, path, dispatch)
-            for method in ("GET", "POST", "DELETE", "HEAD", "OPTIONS")
-            for path in ("/", "/{path*}")
-        ],
-    ]
+
+def _json_body(payload: object, status: int = int(HTTPStatus.OK)) -> Response:
+    """Serialise a payload the way the helper extensions already parse it."""
+    return Response(
+        json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+        status,
+        {},
+        "application/json; charset=utf-8",
+    )
+
+
+def _error_body(status: int, message: str) -> Response:
+    return _json_body({"error": message}, status)
+
+
+def _not_found() -> Response:
+    return _error_body(int(HTTPStatus.NOT_FOUND), "Not Found")
+
+
+def _forbidden() -> Response:
+    return _error_body(int(HTTPStatus.FORBIDDEN), "Forbidden")
+
+
+def _bad_request() -> Response:
+    return _error_body(int(HTTPStatus.BAD_REQUEST), "Bad Request")
+
+
+def _server_error(exc: Exception) -> Response:
+    # 破損 spec.json / workflow-state.json 等の fail-loud は handler 落ち（接続断）
+    # ではなく 500 + メッセージで拡張へ届ける（#944）。
+    return _error_body(int(HTTPStatus.INTERNAL_SERVER_ERROR), str(exc))
+
+
+def _binary_body(path_name: str, body: bytes) -> Response:
+    content_type = mimetypes.guess_type(path_name)[0] or "application/octet-stream"
+    return Response(body, int(HTTPStatus.OK), {}, content_type)
+
+
+def _collection_origin_policy(allow_origin: str | None) -> OriginPolicy:
+    """Own the read/write origin split in one place instead of per route.
+
+    A disallowed origin is not rejected outright: the response is served without
+    CORS headers so the browser drops it, which is the behaviour the helper
+    extensions have always seen (#4452).
+    """
+
+    def policy(query: OriginQuery) -> OriginDecision:
+        if query.method in {"GET", "HEAD", "OPTIONS"}:
+            allowed = _is_read_origin_allowed(query.origin, allow_origin, query.path)
+        else:
+            allowed = is_origin_allowed(query.origin, allow_origin)
+        return OriginDecision.ALLOW if allowed else OriginDecision.OMIT
+
+    return policy
 
 
 def _server_metadata(
@@ -984,6 +1026,10 @@ def create_server(
     None なら capture 系 POST は 404。
 
     distrokid が None または `enabled == False` のとき `/distrokid/*` は 404。
+
+    routing・CORS・body 上限は chassis（`infrastructure/localserver/app.py`）が
+    所有する。ここで組み立てるのは route table と各 route の業務判断だけで、
+    handler は socket を持たない `Request -> Response` 関数である（#4452）。
     """
     dir_mode = collections_root is not None
     distrokid_enabled = distrokid is not None and distrokid.enabled
@@ -992,589 +1038,414 @@ def create_server(
     unattended_requests_lock = threading.Lock()
     resolved_server_info = _server_metadata(server_info, port, distrokid_enabled, collections_root)
     resolved_community_asset_root = community_asset_root if community_asset_root is not None else collection_dir
+    # port=0 で OS に選ばせる場合、bind 後の実ポートを route から参照する。
+    bound_port: list[int] = [port]
 
-    class _Handler(_TransportFreeHandler):
-        """Transport-free compatibility application for collection routes."""
+    def locked_extension_request(request: Request) -> bool:
+        return _is_locked_extension_request(
+            request.headers.get("Origin"),
+            request.headers.get("X-Extension-Origin"),
+            allow_origin,
+        )
 
-        def _allowed_origin(self) -> str | None:
-            headers = getattr(self, "headers", None)
-            if headers is None:
-                return None
-            origin = headers.get("Origin")
-            if self.command in {"GET", "HEAD", "OPTIONS"}:
-                return origin if _is_read_origin_allowed(origin, allow_origin, self.path) else None
-            return origin if is_origin_allowed(origin, allow_origin) else None
+    def write_authorised(request: Request) -> bool:
+        """書き込み境界（#1360）: extension lock と serve token の両方を要求する。
 
-        def _send_cors(self, origin: str | None) -> None:
-            if origin:
-                self.send_header("Access-Control-Allow-Origin", origin)
-                self.send_header("Vary", "Origin")
+        MV3 background fetch は Origin を省略しうるため、runtime origin の明示宣言を
+        configured extension lock と完全一致させ、本人性は serve token で担保する。
+        """
+        return locked_extension_request(request) and request.headers.get("X-Serve-Token") == serve_token
 
-        def _send_bytes(self, body: bytes, content_type: str) -> None:
-            origin = self._allowed_origin()
-            self.send_response(200)
-            self.send_header("Content-Type", content_type)
-            self.send_header("Content-Length", str(len(body)))
-            self._send_cors(origin)
-            self.end_headers()
-            self.wfile.write(body)
+    def known_collection_dir(collection_id: str) -> Path | None:
+        """トラバーサル防御: find_collection_dirs のホワイトリストで弾く（#934）。"""
+        known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
+        return collections_root / collection_id if collection_id in known_ids else None
 
-        def _send_json_error(self, status: int, message: str) -> None:
-            # send_error は CORS ヘッダを付けず HTML を返すため、拡張へ届けるエラーは
-            # JSON + CORS で返す（#944）。message に改行を含む ConfigError も安全に運べる。
-            origin = self._allowed_origin()
-            body = json.dumps({"error": message}, ensure_ascii=False).encode("utf-8")
-            self.send_response(status)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self._send_cors(origin)
-            self.end_headers()
-            can_write_body = self.command != "HEAD" and status >= 200 and status not in (204, 205, 304)
-            if can_write_body:
-                self.wfile.write(body)
+    # --- 固定 discovery route: schema v1 の status matrix は共有実装へ委ねる ---
 
-        def send_error(self, code: int, message: str | None = None, explain: str | None = None) -> None:
-            if (
-                code == 501
-                and discovery_registry_state is not None
-                and handle_registry_request(self, discovery_registry_state)
-            ):
-                return
-            resolved_message = message
-            if resolved_message is None:
-                resolved_message = self.responses.get(code, ("???", "???"))[0]
-            self._send_json_error(code, resolved_message)
+    def discovery(request: Request) -> Response:
+        assert discovery_registry_state is not None
+        recorder = _DiscoveryRecorder(request)
+        handle_registry_request(recorder, discovery_registry_state)
+        return recorder.response()
 
-        def do_OPTIONS(self) -> None:
-            if discovery_registry_state is not None and handle_registry_request(self, discovery_registry_state):
-                return
-            origin = self._allowed_origin()
-            self.send_response(204)
-            self._send_cors(origin)
-            self.send_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-            self.send_header(
-                "Access-Control-Allow-Headers",
-                "Content-Type, X-Serve-Token, X-Extension-Origin",
-            )
-            self.end_headers()
+    # --- GET routes ---
 
-        def _handle_downloaded_post(self, cid: str) -> None:
-            """POST /collections/<id>/downloaded を処理する（dir mode only、#1216/#1217）。"""
-            assert collections_root is not None
-            raw_origin = self.headers.get("Origin")
-            declared_origin = self.headers.get("X-Extension-Origin")
-            if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
-                self.send_error(403, "Forbidden")
-                return
-            req_token = self.headers.get("X-Serve-Token")
-            if req_token != serve_token:
-                self.send_error(403, "Forbidden")
-                return
+    def version(_request: Request) -> Response:
+        return _json_body(build_version_payload())
 
-            cid = _decode_collection_id_path_segment(cid)
-            if ".." in cid:
-                self.send_error(404, "Not Found")
-                return
-            try:
-                known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
-            except WorkflowStateError as exc:
-                self._send_json_error(500, str(exc))
-                return
-            if cid not in known_ids:
-                self.send_error(404, "Not Found")
-                return
+    def server_metadata(_request: Request) -> Response:
+        return _json_body(resolved_server_info)
 
-            raw = self._read_limited_post_body(max_bytes=_MAX_DOWNLOADED_POST_BODY_BYTES)
-            if raw is None:
-                return
-            try:
-                payload = json.loads(raw.decode("utf-8"))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                self.send_error(400, "Bad Request")
-                return
-            try:
-                downloaded = parse_downloaded_payload(payload)
-            except DownloadedPayloadError:
-                self.send_error(400, "Bad Request")
-                return
+    def lifecycle_probe(_request: Request) -> Response:
+        assert lifecycle_record is not None
+        return _json_body({"process_id": os.getpid(), "configuration": lifecycle_record.configuration})
 
-            coll_dir = collections_root / cid
-            try:
-                apply_result = apply_downloaded_artifacts_detailed(
-                    coll_dir,
-                    downloaded,
-                    prompt_entries_reader=read_suno_prompt_entries,
-                    defer_archive_cleanup=True,
-                )
-            except DownloadedPayloadError:
-                self.send_error(400, "Bad Request")
-                return
-            except DownloadedArtifactError as exc:
-                self._send_json_error(500, str(exc))
-                return
-            if downloaded.download_path and downloaded_handoff is not None:
-                try:
-                    downloaded_handoff.complete(coll_dir)
-                except (MediaStoreError, WorkflowStateError) as exc:
-                    self._send_json_error(500, str(exc))
-                    return
-            cleanup_downloaded_archive(downloaded)
-            resp: dict = {"ok": True, "collection_id": cid, "placed_count": apply_result.placed_count}
-            # playlist URL だけを記録する先行 POST は legacy 応答を維持し、実 ZIP 適用後だけ summary を返す。
-            if downloaded.download_path:
-                missing_file_count = max(apply_result.expected_count - apply_result.placed_count, 0)
-                resp.update(
-                    expected_file_count=apply_result.expected_count,
-                    missing_file_count=missing_file_count,
-                )
-                # 部分完了（Suno が期待数未満しか生成しないケース）は 500 にせず warning で返す（#1913）
-                if 0 < apply_result.placed_count < apply_result.expected_count:
-                    missing_reasons = apply_result.missing_reasons
-                    resp["missing_reasons"] = missing_reasons
-                    resp["warning"] = (
-                        f"placed {apply_result.placed_count} files, expected {apply_result.expected_count} "
-                        f"({missing_file_count} missing; Suno 未生成 {missing_reasons['suno_unfulfilled']} / "
-                        f"配置 skip {missing_reasons['apply_skipped']})"
-                    )
-            resp_body = json.dumps(resp).encode("utf-8")
-            self._send_bytes(resp_body, "application/json; charset=utf-8")
+    def auth_token(request: Request) -> Response:
+        if not locked_extension_request(request):
+            return _forbidden()
+        return _json_body({"token": serve_token})
 
-        def _read_limited_post_body(self, *, max_bytes: int = _MAX_POST_BODY_BYTES) -> bytes | None:
-            try:
-                length = int(self.headers.get("Content-Length", 0) or 0)
-            except ValueError:
-                self.send_error(400, "Bad Request")
-                return None
-            if length < 0:
-                self.send_error(400, "Bad Request")
-                return None
-            if length > max_bytes:
-                self.send_error(413, "Payload Too Large")
-                return None
-            return self.rfile.read(length) if length else b""
+    def collections_index(_request: Request) -> Response:
+        try:
+            return _json_body(build_collections_index(collections_root))
+        except WorkflowStateError as exc:
+            return _server_error(exc)
 
-        def do_POST(self) -> None:
-            # GET と異なり POST は route ごとに書き込み可否を明示的に判定する。
-            lifecycle_stop_prefix = (
-                f"{_LIFECYCLE_ROUTE_PREFIX}{lifecycle_record.token}/stop/" if lifecycle_record is not None else None
-            )
-            if (
-                lifecycle_record is not None
-                and lifecycle_stop_prefix is not None
-                and self.path.startswith(lifecycle_stop_prefix)
-            ):
-                if lifecycle_root is None:
-                    self.send_error(404, "Not Found")
-                    return
-                marker_path = _stop_request_path(lifecycle_root, self.server.server_address[1])
-                try:
-                    marker = _read_pid_file(marker_path)
-                except ConfigError:
-                    marker = None
-                marker_matches_owner = (
-                    marker is not None
-                    and marker.pid == lifecycle_record.pid
-                    and marker.configuration == lifecycle_record.configuration
-                )
-                if not marker_matches_owner or self.path != _lifecycle_stop_path(lifecycle_record, marker.token):
-                    self.send_error(409, "Stop request is no longer active")
-                    return
-                body = json.dumps(
-                    {"process_id": lifecycle_record.pid, "configuration": lifecycle_record.configuration}
-                ).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                self.wfile.flush()
-                os.kill(os.getpid(), signal.SIGTERM)
-                return
-            if discovery_registry_state is not None and handle_registry_request(self, discovery_registry_state):
-                return
+    def collection_prompts(request: Request) -> Response:
+        try:
+            resolved = resolve_collection_prompts_path(collections_root, request.path_params["collection"])
+        except WorkflowStateError as exc:
+            return _server_error(exc)
+        if resolved is None or not resolved.is_file():
+            return _not_found()
+        try:
+            payload = read_suno_prompt_delivery_payload(resolved.parent.parent)
+        except ValueError as exc:
+            return _server_error(exc)
+        return _json_body(payload)
 
-            # Local scheduler only: register the paid-operation request outside the
-            # browser, then expose only a short-lived nonce in the Suno URL. Browser
-            # requests always carry Origin, so rejecting it here prevents a Suno page
-            # from minting its own unattended command.
-            if dir_mode and self.path == _UNATTENDED_REQUESTS_ROUTE:
-                if self.headers.get("Origin") is not None:
-                    self.send_error(403, "Forbidden")
-                    return
-                content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
-                if content_type != "application/json":
-                    self.send_error(415, "Unsupported Media Type")
-                    return
-                raw = self._read_limited_post_body(max_bytes=_MAX_UNATTENDED_REQUEST_BODY_BYTES)
-                if raw is None:
-                    return
-                try:
-                    payload = json.loads(raw.decode("utf-8"))
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    self.send_error(400, "Bad Request")
-                    return
-                if not isinstance(payload, dict):
-                    self.send_error(400, "Bad Request")
-                    return
-                nonce = secrets.token_urlsafe(32)
-                expires_at = time.monotonic() + _UNATTENDED_REQUEST_TTL_SECONDS
-                with unattended_requests_lock:
-                    unattended_requests[nonce] = (expires_at, payload)
-                body = json.dumps({"nonce": nonce, "expires_in": _UNATTENDED_REQUEST_TTL_SECONDS}).encode()
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
+    def single_mode_prompts(_request: Request) -> Response:
+        if prompts_path is None:
+            return _not_found()
+        try:
+            payload = read_suno_prompt_delivery_payload_from_path(prompts_path)
+        except ValueError as exc:
+            return _server_error(exc)
+        return _json_body(payload)
 
-            consume_prefix = f"{_UNATTENDED_REQUESTS_ROUTE}/"
-            if dir_mode and self.path.startswith(consume_prefix) and self.path.endswith("/consume"):
-                raw_origin = self.headers.get("Origin")
-                declared_origin = self.headers.get("X-Extension-Origin")
-                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
-                    self.send_error(403, "Forbidden")
-                    return
-                if self.headers.get("X-Serve-Token") != serve_token:
-                    self.send_error(403, "Forbidden")
-                    return
-                nonce = self.path[len(consume_prefix) : -len("/consume")]
-                if not nonce or "/" in nonce or urllib.parse.quote(nonce, safe="") != nonce:
-                    self.send_error(404, "Not Found")
-                    return
-                with unattended_requests_lock:
-                    record = unattended_requests.pop(nonce, None)
-                if record is None:
-                    self.send_error(404, "Unattended request not found or already consumed")
-                    return
-                expires_at, payload = record
-                if expires_at < time.monotonic():
-                    self.send_error(410, "Unattended request expired")
-                    return
-                self._send_bytes(json.dumps(payload, ensure_ascii=False).encode(), "application/json; charset=utf-8")
-                return
+    def community_posts(_request: Request) -> Response:
+        assert collection_dir is not None
+        try:
+            posts = _read_community_posts(collection_dir)
+        except ConfigError as exc:
+            return _server_error(exc)
+        if posts is None:
+            return _not_found()
+        return _json_body(posts)
 
-            # POST /distrokid/releases: capture 有効時のみ（#934）。
-            if self.path == _DISTROKID_RELEASES_ROUTE:
-                if not distrokid_enabled or capture_root is None:
-                    # distrokid disabled / capture root 未指定時は endpoint 自体を出さない。
-                    self.send_error(404, "Not Found")
-                    return
-                # 書き込み境界（#1360）: /downloaded と同じく extension lock + serve token 必須。
-                # MV3 background fetch は Origin を省略しうるため、runtime origin の明示宣言を
-                # configured extension lock と完全一致させる。本人性は serve token も併用する。
-                raw_origin = self.headers.get("Origin")
-                declared_origin = self.headers.get("X-Extension-Origin")
-                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
-                    self.send_error(403, "Forbidden")
-                    return
-                req_token = self.headers.get("X-Serve-Token")
-                if req_token != serve_token:
-                    self.send_error(403, "Forbidden")
-                    return
-                raw = self._read_limited_post_body()
-                if raw is None:
-                    return
-                try:
-                    payload = json.loads(raw.decode("utf-8"))
-                except (json.JSONDecodeError, UnicodeDecodeError):
-                    self.send_error(400, "Bad Request")
-                    return
-                if not isinstance(payload, dict):
-                    self.send_error(400, "Bad Request")
-                    return
-                coll_id = payload.get("collection_id")
-                disc = payload.get("disc")
-                album_title = payload.get("album_title")
-                if (
-                    not isinstance(coll_id, str)
-                    or not coll_id
-                    or not isinstance(disc, str)
-                    or not disc
-                    or not isinstance(album_title, str)
-                    or not album_title
-                ):
-                    # 必須フィールド欠落・非 string は 400（#934）。
-                    self.send_error(400, "Bad Request")
-                    return
-                if collections_root is not None:
-                    try:
-                        known_collections = {coll.name: coll for coll in find_collection_dirs(collections_root)}
-                    except WorkflowStateError as exc:
-                        self._send_json_error(500, str(exc))
-                        return
-                    coll_dir = known_collections.get(coll_id)
-                    if coll_dir is None:
-                        self.send_error(400, "Bad Request")
-                        return
-                    if disc not in find_distrokid_discs(coll_dir):
-                        self.send_error(400, "Bad Request")
-                        return
-                write_distrokid_release(capture_root, coll_id, disc, album_title)
-                resp_body = json.dumps(
-                    {"recorded": True, "path": str(distrokid_releases_output_path(capture_root))}
-                ).encode("utf-8")
-                self._send_bytes(resp_body, "application/json; charset=utf-8")
-                return
+    def community_image(request: Request) -> Response:
+        assert collection_dir is not None
+        assert resolved_community_asset_root is not None
+        index = request.path_params["index"]
+        if not index.isdigit():
+            return _not_found()
+        try:
+            image = _resolve_community_image(collection_dir, resolved_community_asset_root, int(index))
+        except ConfigError as exc:
+            return _server_error(exc)
+        if image is None:
+            return _not_found()
+        return _binary_body(image.name, image.read_bytes())
 
-            # POST /collections/<id>/downloaded: dir mode のみ（#1216）。
-            downloaded_prefix = f"{COLLECTIONS_ROUTE}/"
-            if dir_mode and self.path.startswith(downloaded_prefix) and self.path.endswith(DOWNLOADED_ROUTE_SUFFIX):
-                cid = self.path[len(downloaded_prefix) : -len(DOWNLOADED_ROUTE_SUFFIX)]
-                decoded_cid = _decode_collection_id_path_segment(cid)
-                if self.path != collection_downloaded_route(decoded_cid):
-                    self.send_error(404, "Not Found")
-                    return
-                self._handle_downloaded_post(cid)
-                return
+    def distrokid_release(_request: Request) -> Response:
+        if not distrokid_enabled:
+            return _not_found()
+        try:
+            payload = build_release_payload(collection_dir, distrokid, distrokid_source=distrokid_source)
+        except ConfigError as exc:
+            return _server_error(exc)
+        return _json_body(payload)
 
-            # その他のパスは 404。POST は定義済みルートのみハンドルする。
-            self.send_error(404, "Not Found")
+    def distrokid_asset(request: Request) -> Response:
+        if not distrokid_enabled:
+            return _not_found()
+        resolved = resolve_asset_path(collection_dir, request.path_params["relpath"])
+        if resolved is None:
+            return _not_found()
+        return _binary_body(resolved.name, resolved.read_bytes())
 
-        def do_GET(self) -> None:
-            if discovery_registry_state is not None and handle_registry_request(self, discovery_registry_state):
-                return
-            if self.path == VERSION_ROUTE:
-                body = json.dumps(build_version_payload()).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            if self.path == SERVER_INFO_ROUTE:
-                body = json.dumps(resolved_server_info, ensure_ascii=False).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            if lifecycle_record is not None and self.path == f"{_LIFECYCLE_ROUTE_PREFIX}{lifecycle_record.token}":
-                body = json.dumps({"process_id": os.getpid(), "configuration": lifecycle_record.configuration}).encode(
-                    "utf-8"
-                )
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            if self.path == "/auth/token":
-                raw_origin = self.headers.get("Origin")
-                declared_origin = self.headers.get("X-Extension-Origin")
-                if not _is_locked_extension_request(raw_origin, declared_origin, allow_origin):
-                    self.send_error(403, "Forbidden")
-                    return
-                body = json.dumps({"token": serve_token}).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            if dir_mode:
-                try:
-                    self._serve_dir_mode()
-                except WorkflowStateError as exc:
-                    self._send_json_error(500, str(exc))
-                return
-            if self.path == COMMUNITY_POSTS_ROUTE:
-                assert collection_dir is not None
-                try:
-                    posts = _read_community_posts(collection_dir)
-                except ConfigError as exc:
-                    self._send_json_error(500, str(exc))
-                    return
-                if posts is None:
-                    self.send_error(404, "Not Found")
-                    return
-                body = json.dumps(posts, ensure_ascii=False).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            community_image_match = _COMMUNITY_IMAGE_ROUTE_PATTERN.fullmatch(self.path)
-            if community_image_match is not None:
-                assert collection_dir is not None
-                assert resolved_community_asset_root is not None
-                try:
-                    image = _resolve_community_image(
-                        collection_dir,
-                        resolved_community_asset_root,
-                        int(community_image_match.group("index")),
-                    )
-                except ConfigError as exc:
-                    self._send_json_error(500, str(exc))
-                    return
-                if image is None:
-                    self.send_error(404, "Not Found")
-                    return
-                content_type = mimetypes.guess_type(image.name)[0] or "application/octet-stream"
-                self._send_bytes(image.read_bytes(), content_type)
-                return
-            if self.path == SUNO_PROMPTS_ROUTE:
-                if prompts_path is None:
-                    self.send_error(404, "Not Found")
-                    return
-                try:
-                    payload = read_suno_prompt_delivery_payload_from_path(prompts_path)
-                except ValueError as exc:
-                    self._send_json_error(500, str(exc))
-                    return
-                self._send_bytes(
-                    json.dumps(payload, ensure_ascii=False).encode("utf-8"), "application/json; charset=utf-8"
-                )
-                return
-            if self.path == DISTROKID_RELEASE_ROUTE:
-                self._serve_distrokid_release()
-                return
-            if self.path.startswith(DISTROKID_ASSETS_PREFIX):
-                self._serve_distrokid_asset()
-                return
-            if self.path == COLLECTIONS_ROUTE:
-                self._send_json_error(404, "Not Found")
-                return
-            self.send_error(404, "Not Found")
-
-        def do_DELETE(self) -> None:
-            if discovery_registry_state is not None and handle_registry_request(self, discovery_registry_state):
-                return
-            self.send_error(501, f"Unsupported method ({self.command!r})")
-
-        def _serve_dir_mode(self) -> None:
-            if self.path == COLLECTIONS_ROUTE:
-                index = build_collections_index(collections_root)
-                body = json.dumps(index).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
-            coll_prefix = f"{COLLECTIONS_ROUTE}/"
-            if self.path.startswith(coll_prefix) and self.path.endswith(SUNO_PROMPTS_ROUTE):
-                cid = _decode_collection_id_path_segment(self.path[len(coll_prefix) : -len(SUNO_PROMPTS_ROUTE)])
-                resolved = resolve_collection_prompts_path(collections_root, cid)
-                if resolved is None or not resolved.is_file():
-                    self._send_json_error(404, "Not Found")
-                    return
-                try:
-                    payload = read_suno_prompt_delivery_payload(resolved.parent.parent)
-                except ValueError as exc:
-                    self._send_json_error(500, str(exc))
-                    return
-                self._send_bytes(
-                    json.dumps(payload, ensure_ascii=False).encode("utf-8"), "application/json; charset=utf-8"
-                )
-                return
-
-            if self.path == SUNO_PROMPTS_ROUTE:
-                self._send_json_error(404, "Not Found")
-                return
-
-            # --- dir mode DistroKid エンドポイント群（#934）---
-
-            # GET /distrokid/collections: disc 一覧
-            if self.path == _DISTROKID_COLLECTIONS_ROUTE:
-                self._serve_distrokid_dir_collections()
-                return
-
-            # GET /collections/<id>/distrokid/<disc>/release.json: collection-scoped release payload
-            # GET /collections/<id>/distrokid/assets/<rel>: collection-scoped アセット
-            if self.path.startswith(coll_prefix):
-                self._serve_distrokid_collection_routes(self.path[len(coll_prefix) :])
-                return
-
-            self.send_error(404, "Not Found")
-
-        def _serve_distrokid_dir_collections(self) -> None:
-            """GET /distrokid/collections を処理する（#934）."""
-            # capture root が指定されている場合のみ released 判定を行う（gating は #893 と同方針）。
-            released = read_released_discs(capture_root) if capture_root is not None else None
+    def distrokid_collections(_request: Request) -> Response:
+        # capture root がある場合だけ released 判定を行う（gating は #893 と同方針）。
+        released = read_released_discs(capture_root) if capture_root is not None else None
+        try:
             index = build_distrokid_collections_index(collections_root, released_discs=released)
-            body = json.dumps(index).encode("utf-8")
-            self._send_bytes(body, "application/json; charset=utf-8")
+        except WorkflowStateError as exc:
+            return _server_error(exc)
+        return _json_body(index)
 
-        def _serve_distrokid_collection_routes(self, rest: str) -> None:
-            """GET /collections/<id>/distrokid/... を処理する（#934）.
+    def collection_distrokid_asset(request: Request) -> Response:
+        try:
+            coll_dir = known_collection_dir(request.path_params["collection"])
+        except WorkflowStateError as exc:
+            return _server_error(exc)
+        if coll_dir is None:
+            return _not_found()
+        # コレクションルートからの相対パスで resolve（30-distrokid 配下も含む）。
+        resolved = resolve_asset_path(coll_dir, request.path_params["relpath"])
+        if resolved is None:
+            return _not_found()
+        return _binary_body(resolved.name, resolved.read_bytes())
 
-            `rest` は `/collections/` を除いた残り（例: `<id>/distrokid/<disc>/release.json`）。
-            """
-            # collection_id を最初のスラッシュで分割し、残りをサブパスとして処理する。
-            parts = rest.split("/", 1)
-            if len(parts) != 2:
-                self.send_error(404, "Not Found")
-                return
-            raw_coll_id, sub = parts
-            coll_id = _decode_collection_id_path_segment(raw_coll_id)
+    def collection_distrokid_release(request: Request) -> Response:
+        collection_id = request.path_params["collection"]
+        try:
+            coll_dir = known_collection_dir(collection_id)
+        except WorkflowStateError as exc:
+            return _server_error(exc)
+        if coll_dir is None:
+            return _not_found()
+        disc = request.path_params["disc"]
+        # disc 実在確認: find_distrokid_discs のホワイトリストで弾く（#934）。
+        if disc not in find_distrokid_discs(coll_dir) or not distrokid_enabled:
+            return _not_found()
+        # asset_path を collection-scoped 形式にするための prefix を組み立てる（#934）。
+        encoded_coll_id = _encode_collection_id_path_segment(collection_id)
+        coll_assets_prefix = f"{COLLECTIONS_ROUTE}/{encoded_coll_id}{DISTROKID_COLLECTION_ASSETS_PREFIX}"
+        try:
+            payload = build_release_payload(
+                coll_dir,
+                distrokid,
+                distrokid_source=f"{_DISTROKID_DIRNAME}/{disc}",
+                assets_prefix=coll_assets_prefix,
+            )
+        except ConfigError as exc:
+            return _server_error(exc)
+        return _json_body(payload)
 
-            # トラバーサル防御: find_collection_dirs のホワイトリストで弾く（#934）。
-            known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
-            if coll_id not in known_ids:
-                self.send_error(404, "Not Found")
-                return
+    # --- POST routes ---
 
-            coll_dir = collections_root / coll_id
+    def lifecycle_stop(request: Request) -> Response:
+        assert lifecycle_record is not None
+        if lifecycle_root is None:
+            return _not_found()
+        marker_path = _stop_request_path(lifecycle_root, bound_port[0])
+        try:
+            marker = _read_pid_file(marker_path)
+        except ConfigError:
+            marker = None
+        marker_matches_owner = (
+            marker is not None
+            and marker.pid == lifecycle_record.pid
+            and marker.configuration == lifecycle_record.configuration
+        )
+        if not marker_matches_owner or request.path != _lifecycle_stop_path(lifecycle_record, marker.token):
+            return _error_body(int(HTTPStatus.CONFLICT), "Stop request is no longer active")
+        acknowledgement = _json_body(
+            {"process_id": lifecycle_record.pid, "configuration": lifecycle_record.configuration}
+        )
+        # 応答を書き切ってから自プロセスを落とす。socket 操作は chassis 側に閉じる。
+        return replace(acknowledgement, after_send=lambda: os.kill(os.getpid(), signal.SIGTERM))
 
-            # `/distrokid/assets/<rel>` → collection-scoped アセット配信
-            distrokid_assets_infix = "distrokid/assets/"
-            if sub.startswith(distrokid_assets_infix):
-                relpath = urllib.parse.unquote(sub[len(distrokid_assets_infix) :])
-                # コレクションルートからの相対パスで resolve（30-distrokid 配下も含む）
-                resolved = resolve_asset_path(coll_dir, relpath)
-                if resolved is None:
-                    self.send_error(404, "Not Found")
-                    return
-                content_type = mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
-                self._send_bytes(resolved.read_bytes(), content_type)
-                return
+    def register_unattended_request(request: Request) -> Response:
+        # Local scheduler only: register the paid-operation request outside the
+        # browser, then expose only a short-lived nonce in the Suno URL. Browser
+        # requests always carry Origin, so rejecting it here prevents a Suno page
+        # from minting its own unattended command.
+        if request.headers.get("Origin") is not None:
+            return _forbidden()
+        content_type = request.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        if content_type != "application/json":
+            return _error_body(int(HTTPStatus.UNSUPPORTED_MEDIA_TYPE), "Unsupported Media Type")
+        if not isinstance(request.json, dict):
+            return _bad_request()
+        nonce = secrets.token_urlsafe(32)
+        expires_at = time.monotonic() + _UNATTENDED_REQUEST_TTL_SECONDS
+        with unattended_requests_lock:
+            unattended_requests[nonce] = (expires_at, request.json)
+        return _json_body({"nonce": nonce, "expires_in": _UNATTENDED_REQUEST_TTL_SECONDS})
 
-            # `/distrokid/<disc>/release.json` → collection-scoped release payload
-            distrokid_prefix = "distrokid/"
-            release_suffix = "/release.json"
-            if sub.startswith(distrokid_prefix) and sub.endswith(release_suffix):
-                disc = sub[len(distrokid_prefix) : -len(release_suffix)]
-                # disc にスラッシュを含む場合はトラバーサルのおそれがある（#934）。
-                if not disc or "/" in disc:
-                    self.send_error(404, "Not Found")
-                    return
-                # disc 実在確認: find_distrokid_discs のホワイトリストで弾く（#934）。
-                known_discs = find_distrokid_discs(coll_dir)
-                if disc not in known_discs:
-                    self.send_error(404, "Not Found")
-                    return
-                if not distrokid_enabled:
-                    self.send_error(404, "Not Found")
-                    return
-                # asset_path を collection-scoped 形式にするための prefix を組み立てる（#934）。
-                encoded_coll_id = _encode_collection_id_path_segment(coll_id)
-                coll_assets_prefix = f"{COLLECTIONS_ROUTE}/{encoded_coll_id}{DISTROKID_COLLECTION_ASSETS_PREFIX}"
-                distrokid_source = f"{_DISTROKID_DIRNAME}/{disc}"
-                try:
-                    payload = build_release_payload(
-                        coll_dir,
-                        distrokid,
-                        distrokid_source=distrokid_source,
-                        assets_prefix=coll_assets_prefix,
-                    )
-                except ConfigError as exc:
-                    # 破損 spec.json 等の fail-loud は handler 落ち（接続切断）ではなく
-                    # 500 + メッセージで拡張へ届ける（#944）。配信停止の意図は維持する。
-                    self._send_json_error(500, str(exc))
-                    return
-                body = json.dumps(payload).encode("utf-8")
-                self._send_bytes(body, "application/json; charset=utf-8")
-                return
+    def consume_unattended_request(request: Request) -> Response:
+        if not write_authorised(request):
+            return _forbidden()
+        nonce = request.path_params["nonce"]
+        canonical = f"{_UNATTENDED_REQUESTS_ROUTE}/{urllib.parse.quote(nonce, safe='')}/consume"
+        if not nonce or request.path != canonical:
+            return _not_found()
+        with unattended_requests_lock:
+            record = unattended_requests.pop(nonce, None)
+        if record is None:
+            return _error_body(int(HTTPStatus.NOT_FOUND), "Unattended request not found or already consumed")
+        expires_at, payload = record
+        if expires_at < time.monotonic():
+            return _error_body(int(HTTPStatus.GONE), "Unattended request expired")
+        return _json_body(payload)
 
-            self.send_error(404, "Not Found")
-
-        def _serve_distrokid_release(self) -> None:
-            if not distrokid_enabled:
-                self.send_error(404, "Not Found")
-                return
+    def capture_distrokid_release(request: Request) -> Response:
+        # POST /distrokid/releases: capture 有効時のみ（#934）。
+        if not distrokid_enabled or capture_root is None:
+            # distrokid disabled / capture root 未指定時は endpoint 自体を出さない。
+            return _not_found()
+        if not write_authorised(request):
+            return _forbidden()
+        payload = request.json
+        if not isinstance(payload, dict):
+            return _bad_request()
+        coll_id = payload.get("collection_id")
+        disc = payload.get("disc")
+        album_title = payload.get("album_title")
+        if not all(isinstance(value, str) and value for value in (coll_id, disc, album_title)):
+            # 必須フィールド欠落・非 string は 400（#934）。
+            return _bad_request()
+        if collections_root is not None:
             try:
-                payload = build_release_payload(collection_dir, distrokid, distrokid_source=distrokid_source)
-            except ConfigError as exc:
-                # 単一 mode も同様: 破損 spec / metadata.md 不在の fail-loud を 500 で返す（#944）。
-                self._send_json_error(500, str(exc))
-                return
-            body = json.dumps(payload).encode("utf-8")
-            self._send_bytes(body, "application/json; charset=utf-8")
+                known_collections = {coll.name: coll for coll in find_collection_dirs(collections_root)}
+            except WorkflowStateError as exc:
+                return _server_error(exc)
+            coll_dir = known_collections.get(coll_id)
+            if coll_dir is None or disc not in find_distrokid_discs(coll_dir):
+                return _bad_request()
+        write_distrokid_release(capture_root, coll_id, disc, album_title)
+        return _json_body({"recorded": True, "path": str(distrokid_releases_output_path(capture_root))})
 
-        def _serve_distrokid_asset(self) -> None:
-            if not distrokid_enabled:
-                self.send_error(404, "Not Found")
-                return
-            relpath = urllib.parse.unquote(self.path[len(DISTROKID_ASSETS_PREFIX) :])
-            resolved = resolve_asset_path(collection_dir, relpath)
-            if resolved is None:
-                self.send_error(404, "Not Found")
-                return
-            content_type = mimetypes.guess_type(resolved.name)[0] or "application/octet-stream"
-            self._send_bytes(resolved.read_bytes(), content_type)
+    def downloaded(request: Request) -> Response:
+        """POST /collections/<id>/downloaded を処理する（dir mode only、#1216/#1217）。"""
+        assert collections_root is not None
+        if not write_authorised(request):
+            return _forbidden()
+        cid = request.path_params["collection"]
+        # 正規化されていない encoding は受け付けない（legacy と同じ厳密一致）。
+        if request.path != collection_downloaded_route(cid) or ".." in cid:
+            return _not_found()
+        try:
+            known_ids = {coll.name for coll in find_collection_dirs(collections_root)}
+        except WorkflowStateError as exc:
+            return _server_error(exc)
+        if cid not in known_ids:
+            return _not_found()
+        try:
+            parsed = parse_downloaded_payload(request.json)
+        except DownloadedPayloadError:
+            return _bad_request()
 
-        def log_message(self, *args) -> None:  # サーバーログを抑制
-            pass
+        coll_dir = collections_root / cid
+        try:
+            apply_result = apply_downloaded_artifacts_detailed(
+                coll_dir,
+                parsed,
+                prompt_entries_reader=read_suno_prompt_entries,
+                defer_archive_cleanup=True,
+            )
+        except DownloadedPayloadError:
+            return _bad_request()
+        except DownloadedArtifactError as exc:
+            return _server_error(exc)
+        if parsed.download_path and downloaded_handoff is not None:
+            try:
+                downloaded_handoff.complete(coll_dir)
+            except (MediaStoreError, WorkflowStateError) as exc:
+                return _server_error(exc)
+        cleanup_downloaded_archive(parsed)
+        resp: dict = {"ok": True, "collection_id": cid, "placed_count": apply_result.placed_count}
+        # playlist URL だけを記録する先行 POST は legacy 応答を維持し、実 ZIP 適用後だけ summary を返す。
+        if parsed.download_path:
+            missing_file_count = max(apply_result.expected_count - apply_result.placed_count, 0)
+            resp.update(
+                expected_file_count=apply_result.expected_count,
+                missing_file_count=missing_file_count,
+            )
+            # 部分完了（Suno が期待数未満しか生成しないケース）は 500 にせず warning で返す（#1913）
+            if 0 < apply_result.placed_count < apply_result.expected_count:
+                missing_reasons = apply_result.missing_reasons
+                resp["missing_reasons"] = missing_reasons
+                resp["warning"] = (
+                    f"placed {apply_result.placed_count} files, expected {apply_result.expected_count} "
+                    f"({missing_file_count} missing; Suno 未生成 {missing_reasons['suno_unfulfilled']} / "
+                    f"配置 skip {missing_reasons['apply_skipped']})"
+                )
+        return _json_body(resp)
+
+    # --- protocol-level routes ---
+
+    def preflight(_request: Request) -> Response:
+        return Response(
+            b"",
+            int(HTTPStatus.NO_CONTENT),
+            {
+                "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                "Access-Control-Allow-Headers": "Content-Type, X-Serve-Token, X-Extension-Origin",
+            },
+        )
+
+    def unsupported_method(request: Request) -> Response:
+        return _error_body(int(HTTPStatus.NOT_IMPLEMENTED), f"Unsupported method ({request.method!r})")
+
+    def missing_route(_request: Request) -> Response:
+        return _not_found()
+
+    routes: list[Route] = []
+    if discovery_registry_state is not None:
+        # 固定 discovery path は全 method を占有し、collection 側の fallback へ落とさない。
+        routes.extend(
+            Route(method, DISCOVERY_PATH, discovery, MAX_REGISTRATION_BODY_BYTES) for method in _DISPATCHABLE_METHODS
+        )
+
+    routes.append(Route("GET", VERSION_ROUTE, version))
+    routes.append(Route("GET", SERVER_INFO_ROUTE, server_metadata))
+    routes.append(Route("GET", "/auth/token", auth_token))
+    if lifecycle_record is not None:
+        lifecycle_route = f"{_LIFECYCLE_ROUTE_PREFIX}{lifecycle_record.token}"
+        routes.append(Route("GET", lifecycle_route, lifecycle_probe))
+        routes.append(Route("POST", f"{lifecycle_route}/stop/{{attempt}}", lifecycle_stop))
+
+    if dir_mode:
+        routes.append(Route("GET", COLLECTIONS_ROUTE, collections_index))
+        routes.append(Route("GET", f"{COLLECTIONS_ROUTE}/{{collection}}{SUNO_PROMPTS_ROUTE}", collection_prompts))
+        routes.append(Route("GET", SUNO_PROMPTS_ROUTE, missing_route))
+        routes.append(Route("GET", _DISTROKID_COLLECTIONS_ROUTE, distrokid_collections))
+        # assets は disc より先に登録する: `{disc}` は "assets" にも一致するため。
+        routes.append(
+            Route(
+                "GET",
+                f"{COLLECTIONS_ROUTE}/{{collection}}{DISTROKID_COLLECTION_ASSETS_PREFIX}{{relpath*}}",
+                collection_distrokid_asset,
+            )
+        )
+        routes.append(
+            Route(
+                "GET",
+                f"{COLLECTIONS_ROUTE}/{{collection}}/{_DISTROKID_ROUTE_SEGMENT}/{{disc}}/release.json",
+                collection_distrokid_release,
+            )
+        )
+        routes.append(Route("GET", f"{COLLECTIONS_ROUTE}/{{path*}}", missing_route))
+        routes.append(
+            Route(
+                "POST",
+                _UNATTENDED_REQUESTS_ROUTE,
+                register_unattended_request,
+                _MAX_UNATTENDED_REQUEST_BODY_BYTES,
+            )
+        )
+        routes.append(Route("POST", f"{_UNATTENDED_REQUESTS_ROUTE}/{{nonce}}/consume", consume_unattended_request))
+        routes.append(
+            Route(
+                "POST",
+                f"{COLLECTIONS_ROUTE}/{{collection}}{DOWNLOADED_ROUTE_SUFFIX}",
+                downloaded,
+                _MAX_DOWNLOADED_POST_BODY_BYTES,
+            )
+        )
+    else:
+        routes.append(Route("GET", COMMUNITY_POSTS_ROUTE, community_posts))
+        routes.append(Route("GET", f"{COMMUNITY_IMAGE_ROUTE}/{{index}}/image", community_image))
+        routes.append(Route("GET", SUNO_PROMPTS_ROUTE, single_mode_prompts))
+        routes.append(Route("GET", DISTROKID_RELEASE_ROUTE, distrokid_release))
+        routes.append(Route("GET", f"{DISTROKID_ASSETS_PREFIX}{{relpath*}}", distrokid_asset))
+        routes.append(Route("GET", COLLECTIONS_ROUTE, missing_route))
+
+    routes.append(Route("POST", _DISTROKID_RELEASES_ROUTE, capture_distrokid_release, _MAX_POST_BODY_BYTES))
+
+    # 未定義パス・未実装 method の応答は 1 箇所で決める（stdlib と同じ 404 / 501）。
+    for pattern in _FALLBACK_PATH_PATTERNS:
+        routes.append(Route("OPTIONS", pattern, preflight))
+        routes.append(Route("GET", pattern, missing_route))
+        routes.append(Route("POST", pattern, missing_route))
+        routes.extend(
+            Route(method, pattern, unsupported_method)
+            for method in _DISPATCHABLE_METHODS
+            if method not in {"GET", "POST", "OPTIONS"}
+        )
 
     server = _IdleTrackingHTTPServer(
         ("localhost", port),
-        _collection_routes(_Handler, port),
-        lambda origin: is_origin_allowed(origin, allow_origin),
+        routes,
+        _collection_origin_policy(allow_origin),
         idle_timeout_seconds,
     )
+    bound_port[0] = int(server.server_address[1])
     if server_info is None:
-        resolved_server_info.update(build_server_info("YouTube Automation", "YA", server.server_address[1]))
+        resolved_server_info.update(build_server_info("YouTube Automation", "YA", bound_port[0]))
     return server
 
 

--- a/src/youtube_automation/commands/collections/collection_serve.py
+++ b/src/youtube_automation/commands/collections/collection_serve.py
@@ -44,6 +44,7 @@ from datetime import datetime
 from email.message import Message
 from http import HTTPStatus
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Callable, ClassVar
 
 from youtube_automation import __version__
@@ -892,7 +893,7 @@ class _TransportFreeHandler:
             self.headers[key] = value
         self.rfile = io.BytesIO(request.body)
         self.wfile = io.BytesIO()
-        self.server = type("ServerAddress", (), {"server_address": ("127.0.0.1", port)})()
+        self.server = SimpleNamespace(server_address=("127.0.0.1", port))
         self._status = 200
         self._headers: list[tuple[str, str]] = []
 

--- a/src/youtube_automation/infrastructure/localserver/app.py
+++ b/src/youtube_automation/infrastructure/localserver/app.py
@@ -8,6 +8,7 @@ import re
 import time
 import uuid
 from dataclasses import dataclass, field
+from enum import Enum
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -47,10 +48,36 @@ class Response:
     status: int = HTTPStatus.OK
     headers: Mapping[str, str] = field(default_factory=dict)
     content_type: str = "application/json; charset=utf-8"
+    after_send: Callable[[], None] | None = None
+    """Run once the body has been flushed — for routes that end the process."""
 
 
 Handler = Callable[[Request], object | Response]
-OriginPolicy = Callable[[str | None], bool]
+
+
+class OriginDecision(Enum):
+    """What the chassis does with a request's `Origin` before the route runs."""
+
+    ALLOW = "allow"
+    """Serve the route and echo the origin back in the CORS headers."""
+
+    OMIT = "omit"
+    """Serve the route but send no CORS headers, so a browser drops the response."""
+
+    REJECT = "reject"
+    """Answer 403 without running the route."""
+
+
+@dataclass(frozen=True)
+class OriginQuery:
+    """Everything a policy may look at when judging one request's origin."""
+
+    origin: str | None
+    method: str
+    path: str
+
+
+OriginPolicy = Callable[[OriginQuery], OriginDecision]
 
 
 @dataclass(frozen=True)
@@ -79,14 +106,12 @@ class LocalHTTPServer(ThreadingHTTPServer):
         max_body_bytes: int,
         stop_path: Path | None,
         idle_timeout_seconds: float | None,
-        enforce_origin: bool = True,
     ) -> None:
         self.routes = tuple((route, _compile_path(route.path_pattern)) for route in routes)
         self.origin_policy = origin_policy
         self.max_body_bytes = max_body_bytes
         self.stop_path = stop_path
         self.idle_timeout_seconds = idle_timeout_seconds
-        self.enforce_origin = enforce_origin
         self.last_request_at = time.monotonic()
         super().__init__(address, _RequestHandler)
 
@@ -134,7 +159,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.send_response(code)
         self._emit_headers(
             {"X-Content-Type-Options": "nosniff"},
-            self._cors_headers(self.headers.get("Origin") if hasattr(self, "headers") else None),
+            self._cors_headers(),
             {"Content-Type": "application/json; charset=utf-8", "Content-Length": str(len(body))},
         )
         if self.command != "HEAD":
@@ -172,8 +197,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         if any(route.method == "OPTIONS" and pattern.fullmatch(split.path) for route, pattern in self.server.routes):
             self._dispatch()
             return
-        origin = self.headers.get("Origin")
-        if not self.server.origin_policy(origin):
+        if self._origin_decision() is OriginDecision.REJECT:
             self._json(HTTPStatus.FORBIDDEN, {"error": "origin not allowed"})
             return
         path = urlsplit(self.path).path
@@ -184,7 +208,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.send_response(HTTPStatus.NO_CONTENT)
         self._emit_headers(
             {"X-Content-Type-Options": "nosniff"},
-            self._cors_headers(origin),
+            self._cors_headers(),
             {
                 "Access-Control-Allow-Methods": ", ".join(methods),
                 "Access-Control-Allow-Headers": "Content-Type",
@@ -193,8 +217,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         )
 
     def _dispatch(self) -> None:
-        origin = self.headers.get("Origin")
-        if self.server.enforce_origin and origin is not None and not self.server.origin_policy(origin):
+        if self._origin_decision() is OriginDecision.REJECT:
             self._json(HTTPStatus.FORBIDDEN, {"error": "origin not allowed"})
             return
         split = urlsplit(self.path)
@@ -224,6 +247,9 @@ class _RequestHandler(BaseHTTPRequestHandler):
                 self._bytes(response.status, response.payload, response.content_type, response.headers)
             else:
                 self._json(response.status, response.payload, response.headers)
+            if response.after_send is not None:
+                self.wfile.flush()
+                response.after_send()
         except _HTTPError as error:
             self._json(error.status, {"error": str(error)})
         except ValidationError as error:
@@ -258,31 +284,46 @@ class _RequestHandler(BaseHTTPRequestHandler):
             if status == HTTPStatus.NO_CONTENT
             else json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
         )
-        self.send_response(status)
-        self._emit_headers(
-            {"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
-            self._cors_headers(self.headers.get("Origin")),
-            headers or {},
-            {"Content-Type": "application/json; charset=utf-8", "Content-Length": str(len(body))},
-        )
-        if self.command != "HEAD" and body:
-            self.wfile.write(body)
+        self._bytes(status, body, "application/json; charset=utf-8", headers or {})
 
     def _bytes(self, status: int, body: bytes, content_type: str, headers: Mapping[str, str]) -> None:
         self.send_response(status)
         self._emit_headers(
             {"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
-            self._cors_headers(self.headers.get("Origin")),
+            self._cors_headers(),
             headers,
             {"Content-Type": content_type, "Content-Length": str(len(body))},
         )
         if self.command != "HEAD" and body:
             self.wfile.write(body)
 
-    def _cors_headers(self, origin: str | None) -> Mapping[str, str]:
-        if origin is not None and self.server.origin_policy(origin):
-            return {"Access-Control-Allow-Origin": origin, "Vary": "Origin"}
-        return {}
+    def _request_origin(self) -> str | None:
+        headers = getattr(self, "headers", None)
+        return headers.get("Origin") if headers is not None else None
+
+    def _origin_decision(self) -> OriginDecision:
+        """Judge the request origin once, so every response path agrees on it.
+
+        Routes never emit CORS headers themselves; the chassis owns the decision
+        and the headers derived from it (#4452).
+        """
+        cached = getattr(self, "_origin_decision_cache", None)
+        if cached is not None:
+            return cached
+        query = OriginQuery(
+            self._request_origin(),
+            getattr(self, "command", ""),
+            urlsplit(getattr(self, "path", "")).path,
+        )
+        decision = self.server.origin_policy(query)
+        self._origin_decision_cache = decision
+        return decision
+
+    def _cors_headers(self) -> Mapping[str, str]:
+        origin = self._request_origin()
+        if origin is None or self._origin_decision() is not OriginDecision.ALLOW:
+            return {}
+        return {"Access-Control-Allow-Origin": origin, "Vary": "Origin"}
 
     def _emit_headers(self, *sources: Mapping[str, str]) -> None:
         """Send each header name exactly once; later sources override earlier ones.

--- a/src/youtube_automation/infrastructure/localserver/app.py
+++ b/src/youtube_automation/infrastructure/localserver/app.py
@@ -46,6 +46,7 @@ class Response:
     payload: object = None
     status: int = HTTPStatus.OK
     headers: Mapping[str, str] = field(default_factory=dict)
+    content_type: str = "application/json; charset=utf-8"
 
 
 Handler = Callable[[Request], object | Response]
@@ -57,6 +58,7 @@ class Route:
     method: str
     path_pattern: str
     handler: Handler
+    max_body_bytes: int | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "method", self.method.upper())
@@ -77,12 +79,14 @@ class LocalHTTPServer(ThreadingHTTPServer):
         max_body_bytes: int,
         stop_path: Path | None,
         idle_timeout_seconds: float | None,
+        enforce_origin: bool = True,
     ) -> None:
         self.routes = tuple((route, _compile_path(route.path_pattern)) for route in routes)
         self.origin_policy = origin_policy
         self.max_body_bytes = max_body_bytes
         self.stop_path = stop_path
         self.idle_timeout_seconds = idle_timeout_seconds
+        self.enforce_origin = enforce_origin
         self.last_request_at = time.monotonic()
         super().__init__(address, _RequestHandler)
 
@@ -115,6 +119,26 @@ class _RequestHandler(BaseHTTPRequestHandler):
     def log_message(self, format: str, *args: object) -> None:
         return None
 
+    def send_error(
+        self,
+        code: int,
+        message: str | None = None,
+        explain: str | None = None,
+    ) -> None:
+        del explain
+        try:
+            fallback = HTTPStatus(code).phrase
+        except ValueError:
+            fallback = "???"
+        body = json.dumps({"error": message or fallback}, ensure_ascii=False).encode()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self._common_headers(self.headers.get("Origin") if hasattr(self, "headers") else None)
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(body)
+
     def do_GET(self) -> None:
         self._dispatch()
 
@@ -130,7 +154,23 @@ class _RequestHandler(BaseHTTPRequestHandler):
     def do_PATCH(self) -> None:
         self._dispatch()
 
+    def do_HEAD(self) -> None:
+        self._dispatch()
+
+    def do_CONNECT(self) -> None:
+        self._dispatch()
+
+    def do_TRACE(self) -> None:
+        self._dispatch()
+
+    def do_BREW(self) -> None:
+        self._dispatch()
+
     def do_OPTIONS(self) -> None:
+        split = urlsplit(self.path)
+        if any(route.method == "OPTIONS" and pattern.fullmatch(split.path) for route, pattern in self.server.routes):
+            self._dispatch()
+            return
         origin = self.headers.get("Origin")
         if not self.server.origin_policy(origin):
             self._json(HTTPStatus.FORBIDDEN, {"error": "origin not allowed"})
@@ -149,10 +189,13 @@ class _RequestHandler(BaseHTTPRequestHandler):
 
     def _dispatch(self) -> None:
         origin = self.headers.get("Origin")
-        if origin is not None and not self.server.origin_policy(origin):
+        if self.server.enforce_origin and origin is not None and not self.server.origin_policy(origin):
             self._json(HTTPStatus.FORBIDDEN, {"error": "origin not allowed"})
             return
         split = urlsplit(self.path)
+        path_matches = [
+            (route, match) for route, pattern in self.server.routes if (match := pattern.fullmatch(split.path))
+        ]
         matched = next(
             (
                 (route, match)
@@ -162,11 +205,12 @@ class _RequestHandler(BaseHTTPRequestHandler):
             None,
         )
         if matched is None:
-            self._json(HTTPStatus.NOT_FOUND, {"error": "route not found"})
+            status = HTTPStatus.METHOD_NOT_ALLOWED if path_matches else HTTPStatus.NOT_FOUND
+            self._json(status, {"error": "method not allowed" if path_matches else "route not found"})
             return
         route, match = matched
         try:
-            body, payload = self._read_body()
+            body, payload = self._read_body(route.max_body_bytes)
             incoming = Request(
                 method=self.command,
                 path=split.path,
@@ -178,7 +222,10 @@ class _RequestHandler(BaseHTTPRequestHandler):
             )
             result = route.handler(incoming)
             response = result if isinstance(result, Response) else Response(result)
-            self._json(response.status, response.payload, response.headers)
+            if isinstance(response.payload, bytes):
+                self._bytes(response.status, response.payload, response.content_type, response.headers)
+            else:
+                self._json(response.status, response.payload, response.headers)
         except _HTTPError as error:
             self._json(error.status, {"error": str(error)})
         except ValidationError as error:
@@ -186,25 +233,26 @@ class _RequestHandler(BaseHTTPRequestHandler):
         except ConfigError as error:
             self._json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(error)})
 
-    def _read_body(self) -> tuple[bytes, object | None]:
+    def _read_body(self, route_limit: int | None) -> tuple[bytes, object | None]:
         raw_length = self.headers.get("Content-Length")
         if raw_length is None:
             return b"", None
         try:
             length = int(raw_length)
         except ValueError as error:
-            raise _HTTPError(HTTPStatus.BAD_REQUEST, "invalid Content-Length") from error
+            raise _HTTPError(HTTPStatus.BAD_REQUEST, "Bad Request") from error
         if length < 0:
-            raise _HTTPError(HTTPStatus.BAD_REQUEST, "invalid Content-Length")
-        if length > self.server.max_body_bytes:
-            raise _HTTPError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "request body too large")
+            raise _HTTPError(HTTPStatus.BAD_REQUEST, "Bad Request")
+        limit = route_limit if route_limit is not None else self.server.max_body_bytes
+        if length > limit:
+            raise _HTTPError(HTTPStatus.REQUEST_ENTITY_TOO_LARGE, "Payload Too Large")
         body = self.rfile.read(length)
         if not body:
             return body, None
         try:
             return body, json.loads(body)
         except (UnicodeDecodeError, json.JSONDecodeError) as error:
-            raise _HTTPError(HTTPStatus.BAD_REQUEST, "invalid JSON body") from error
+            raise _HTTPError(HTTPStatus.BAD_REQUEST, "Bad Request") from error
 
     def _json(self, status: int, payload: object, headers: Mapping[str, str] | None = None) -> None:
         body = (
@@ -218,6 +266,18 @@ class _RequestHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store")
         self._common_headers(self.headers.get("Origin"))
         for key, value in (headers or {}).items():
+            self.send_header(key, value)
+        self.end_headers()
+        if self.command != "HEAD" and body:
+            self.wfile.write(body)
+
+    def _bytes(self, status: int, body: bytes, content_type: str, headers: Mapping[str, str]) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "no-store")
+        self._common_headers(self.headers.get("Origin"))
+        for key, value in headers.items():
             self.send_header(key, value)
         self.end_headers()
         if self.command != "HEAD" and body:
@@ -239,9 +299,9 @@ class _HTTPError(RuntimeError):
 def _compile_path(path_pattern: str) -> re.Pattern[str]:
     cursor = 0
     chunks: list[str] = []
-    for match in re.finditer(r"\{([A-Za-z_][A-Za-z0-9_]*)\}", path_pattern):
+    for match in re.finditer(r"\{([A-Za-z_][A-Za-z0-9_]*)(\*)?\}", path_pattern):
         chunks.append(re.escape(path_pattern[cursor : match.start()]))
-        chunks.append(f"(?P<{match.group(1)}>[^/]+)")
+        chunks.append(f"(?P<{match.group(1)}>{'.+' if match.group(2) else '[^/]+'})")
         cursor = match.end()
     chunks.append(re.escape(path_pattern[cursor:]))
     try:

--- a/src/youtube_automation/infrastructure/localserver/app.py
+++ b/src/youtube_automation/infrastructure/localserver/app.py
@@ -132,10 +132,11 @@ class _RequestHandler(BaseHTTPRequestHandler):
             fallback = "???"
         body = json.dumps({"error": message or fallback}, ensure_ascii=False).encode()
         self.send_response(code)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self._common_headers(self.headers.get("Origin") if hasattr(self, "headers") else None)
-        self.end_headers()
+        self._emit_headers(
+            {"X-Content-Type-Options": "nosniff"},
+            self._cors_headers(self.headers.get("Origin") if hasattr(self, "headers") else None),
+            {"Content-Type": "application/json; charset=utf-8", "Content-Length": str(len(body))},
+        )
         if self.command != "HEAD":
             self.wfile.write(body)
 
@@ -181,11 +182,15 @@ class _RequestHandler(BaseHTTPRequestHandler):
             self._json(HTTPStatus.NOT_FOUND, {"error": "route not found"})
             return
         self.send_response(HTTPStatus.NO_CONTENT)
-        self._common_headers(origin)
-        self.send_header("Access-Control-Allow-Methods", ", ".join(methods))
-        self.send_header("Access-Control-Allow-Headers", "Content-Type")
-        self.send_header("Content-Length", "0")
-        self.end_headers()
+        self._emit_headers(
+            {"X-Content-Type-Options": "nosniff"},
+            self._cors_headers(origin),
+            {
+                "Access-Control-Allow-Methods": ", ".join(methods),
+                "Access-Control-Allow-Headers": "Content-Type",
+                "Content-Length": "0",
+            },
+        )
 
     def _dispatch(self) -> None:
         origin = self.headers.get("Origin")
@@ -196,14 +201,7 @@ class _RequestHandler(BaseHTTPRequestHandler):
         path_matches = [
             (route, match) for route, pattern in self.server.routes if (match := pattern.fullmatch(split.path))
         ]
-        matched = next(
-            (
-                (route, match)
-                for route, pattern in self.server.routes
-                if route.method == self.command and (match := pattern.fullmatch(split.path))
-            ),
-            None,
-        )
+        matched = next((entry for entry in path_matches if entry[0].method == self.command), None)
         if matched is None:
             status = HTTPStatus.METHOD_NOT_ALLOWED if path_matches else HTTPStatus.NOT_FOUND
             self._json(status, {"error": "method not allowed" if path_matches else "route not found"})
@@ -261,33 +259,45 @@ class _RequestHandler(BaseHTTPRequestHandler):
             else json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode()
         )
         self.send_response(status)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Cache-Control", "no-store")
-        self._common_headers(self.headers.get("Origin"))
-        for key, value in (headers or {}).items():
-            self.send_header(key, value)
-        self.end_headers()
+        self._emit_headers(
+            {"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
+            self._cors_headers(self.headers.get("Origin")),
+            headers or {},
+            {"Content-Type": "application/json; charset=utf-8", "Content-Length": str(len(body))},
+        )
         if self.command != "HEAD" and body:
             self.wfile.write(body)
 
     def _bytes(self, status: int, body: bytes, content_type: str, headers: Mapping[str, str]) -> None:
         self.send_response(status)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Content-Length", str(len(body)))
-        self.send_header("Cache-Control", "no-store")
-        self._common_headers(self.headers.get("Origin"))
-        for key, value in headers.items():
-            self.send_header(key, value)
-        self.end_headers()
+        self._emit_headers(
+            {"Cache-Control": "no-store", "X-Content-Type-Options": "nosniff"},
+            self._cors_headers(self.headers.get("Origin")),
+            headers,
+            {"Content-Type": content_type, "Content-Length": str(len(body))},
+        )
         if self.command != "HEAD" and body:
             self.wfile.write(body)
 
-    def _common_headers(self, origin: str | None) -> None:
+    def _cors_headers(self, origin: str | None) -> Mapping[str, str]:
         if origin is not None and self.server.origin_policy(origin):
-            self.send_header("Access-Control-Allow-Origin", origin)
-            self.send_header("Vary", "Origin")
-        self.send_header("X-Content-Type-Options", "nosniff")
+            return {"Access-Control-Allow-Origin": origin, "Vary": "Origin"}
+        return {}
+
+    def _emit_headers(self, *sources: Mapping[str, str]) -> None:
+        """Send each header name exactly once; later sources override earlier ones.
+
+        route handler が自前で CORS ヘッダーを載せる場合（chassis へ載せ替えた
+        collection server 等）、chassis 側の既定値と同名ヘッダーが二重送信されると
+        ブラウザの CORS 検証が壊れるため、送出前に名前で畳み込む（#4452）。
+        """
+        merged: dict[str, tuple[str, str]] = {}
+        for source in sources:
+            for key, value in source.items():
+                merged[key.lower()] = (key, value)
+        for key, value in merged.values():
+            self.send_header(key, value)
+        self.end_headers()
 
 
 class _HTTPError(RuntimeError):

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -68,6 +68,7 @@ from youtube_automation.infrastructure.collections.chrome_extensions import (
     ChromeExtensionOrigin,
     resolve_unpacked_extension_origin,
 )
+from youtube_automation.infrastructure.localserver.app import Request, Response
 from youtube_automation.infrastructure.localserver.collections import find_suno_collection_dirs
 
 extract_and_rename_music = partial(
@@ -90,6 +91,21 @@ _VERSION_ROUTE = "/version"
 
 # 外部 HTTP 契約（#1352）: 拡張が接続先 selector の label 更新に使う配信元情報。
 _SERVER_INFO_ROUTE = "/server-info"
+
+
+def test_version_route_handler_runs_without_a_request_socket(tmp_path: Path) -> None:
+    server = create_server(0, None, prompts_path=None, collection_dir=tmp_path, distrokid=None)
+    try:
+        route = next(
+            route for route, pattern in server.routes if route.method == "GET" and pattern.fullmatch("/version")
+        )
+        response = route.handler(Request("GET", "/version", {}, {}))
+    finally:
+        server.server_close()
+
+    assert isinstance(response, Response)
+    assert response.status == 200
+    assert json.loads(response.payload)["version"]
 
 
 def test_module_import_succeeds_without_fcntl() -> None:

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -683,6 +683,30 @@ def test_get_version_sets_cors_header_for_extension_origin(serve):
         assert resp.headers.get("Access-Control-Allow-Origin") == _EXTENSION_ORIGIN
 
 
+def test_cors_headers_are_not_duplicated_on_the_wire(serve):
+    """Given route handler と chassis の双方が CORS ヘッダーを載せうる構成
+    When 許可 Origin で GET する
+    Then 生レスポンスの Access-Control-Allow-Origin / Vary は各 1 行だけになる（#4452）。
+
+    同名ヘッダーが 2 行返ると fetch の CORS 検証が失敗するが、`http.client` の
+    `headers.get()` は先頭値しか返さないため、生バイト列で本数を数える。
+    """
+    base = serve([{"name": "A", "style": "s", "lyrics": ""}])
+    raw_request = (
+        f"GET {_VERSION_ROUTE} HTTP/1.1\r\n"
+        "Host: localhost\r\n"
+        "Origin: https://suno.com\r\n"
+        "Connection: close\r\n\r\n"
+    ).encode()
+
+    response = _send_raw_http_request(base, raw_request)
+
+    head = response.split(b"\r\n\r\n", 1)[0]
+    assert head.lower().count(b"\r\naccess-control-allow-origin:") == 1
+    assert head.lower().count(b"\r\nvary:") == 1
+    assert head.lower().count(b"\r\ncontent-length:") == 1
+
+
 def test_old_root_prompts_json_returns_404(serve):
     """Given 旧ルート `/prompts.json`
     When GET する

--- a/tests/commands/collections/test_collection_serve.py
+++ b/tests/commands/collections/test_collection_serve.py
@@ -693,10 +693,7 @@ def test_cors_headers_are_not_duplicated_on_the_wire(serve):
     """
     base = serve([{"name": "A", "style": "s", "lyrics": ""}])
     raw_request = (
-        f"GET {_VERSION_ROUTE} HTTP/1.1\r\n"
-        "Host: localhost\r\n"
-        "Origin: https://suno.com\r\n"
-        "Connection: close\r\n\r\n"
+        f"GET {_VERSION_ROUTE} HTTP/1.1\r\nHost: localhost\r\nOrigin: https://suno.com\r\nConnection: close\r\n\r\n"
     ).encode()
 
     response = _send_raw_http_request(base, raw_request)

--- a/tests/commands/collections/test_distrokid_collections_endpoint.py
+++ b/tests/commands/collections/test_distrokid_collections_endpoint.py
@@ -987,8 +987,8 @@ def test_post_distrokid_releases_writes_file_and_returns_recorded(tmp_path, serv
 
 def test_post_distrokid_releases_ignores_query_side_inputs(tmp_path, serve_dir_dk):
     """Given root route に query だけで collection/disc を渡す
-    When body が空の POST /distrokid/releases?... を送る
-    Then 記録を書かず 400/404 を返す。
+    When 認証済みだが body が空の POST /distrokid/releases?... を送る
+    Then query は route 解決にも入力にも使われず、記録を書かず 400 を返す。
     """
     planning = tmp_path / "planning"
     _make_collection(planning, "20260526-abc-collection", discs=["disc1-alpha"])
@@ -1006,10 +1006,10 @@ def test_post_distrokid_releases_ignores_query_side_inputs(tmp_path, serve_dir_d
         _post(
             f"{base}{_DISTROKID_RELEASES_ROUTE}?{query}",
             {},
-            headers={"Origin": _EXTENSION_ORIGIN},
+            headers=_auth_headers(base),
         )
 
-    assert exc_info.value.code in {400, 404}
+    assert exc_info.value.code == 400
     assert not distrokid_releases_output_path(capture_root).exists()
 
 

--- a/tests/infrastructure/localserver/test_app.py
+++ b/tests/infrastructure/localserver/test_app.py
@@ -8,7 +8,22 @@ from typing import Iterator
 import pytest
 
 from youtube_automation.core.errors import ConfigError, ValidationError
-from youtube_automation.infrastructure.localserver.app import Request, Response, Route, create_server
+from youtube_automation.infrastructure.localserver.app import (
+    OriginDecision,
+    OriginQuery,
+    Request,
+    Response,
+    Route,
+    create_server,
+)
+
+
+def _reject_unknown_origins(query: OriginQuery) -> OriginDecision:
+    if query.origin is None:
+        return OriginDecision.OMIT
+    if query.origin == "https://allowed.example":
+        return OriginDecision.ALLOW
+    return OriginDecision.REJECT
 
 
 @contextmanager
@@ -16,7 +31,7 @@ def running(routes: list[Route], *, max_body_bytes: int = 32) -> Iterator[tuple[
     server = create_server(
         routes,
         port=0,
-        origin_policy=lambda origin: origin == "https://allowed.example",
+        origin_policy=_reject_unknown_origins,
         max_body_bytes=max_body_bytes,
     )
     thread = threading.Thread(target=server.serve_forever)

--- a/tests/infrastructure/localserver/test_app.py
+++ b/tests/infrastructure/localserver/test_app.py
@@ -8,7 +8,7 @@ from typing import Iterator
 import pytest
 
 from youtube_automation.core.errors import ConfigError, ValidationError
-from youtube_automation.infrastructure.localserver.app import Request, Route, create_server
+from youtube_automation.infrastructure.localserver.app import Request, Response, Route, create_server
 
 
 @contextmanager
@@ -84,6 +84,22 @@ def test_body_limit_is_rejected_before_handler() -> None:
         response = request(address, "POST", "/items", body=b"12345", headers={"Content-Length": "5"})
         assert response.status == 413
     assert not called
+
+
+def test_route_body_limit_can_be_stricter_than_server_limit() -> None:
+    route = Route("POST", "/items", lambda _request: {}, max_body_bytes=2)
+    with running([route], max_body_bytes=32) as address:
+        response = request(address, "POST", "/items", body=b"123", headers={"Content-Length": "3"})
+    assert response.status == 413
+
+
+def test_binary_response_is_written_without_json_encoding() -> None:
+    route = Route("GET", "/asset", lambda _request: Response(b"asset", content_type="audio/mpeg"))
+    with running([route]) as address:
+        response = request(address, "GET", "/asset")
+        assert response.status == 200
+        assert response.getheader("Content-Type") == "audio/mpeg"
+        assert response.read() == b"asset"
 
 
 @pytest.mark.parametrize(

--- a/tests/infrastructure/localserver/test_app.py
+++ b/tests/infrastructure/localserver/test_app.py
@@ -102,6 +102,28 @@ def test_binary_response_is_written_without_json_encoding() -> None:
         assert response.read() == b"asset"
 
 
+def test_route_supplied_headers_replace_chassis_defaults_instead_of_duplicating() -> None:
+    """route が自前で CORS ヘッダーを返す場合でも同名ヘッダーを二重送信しない（#4452）."""
+    route = Route(
+        "GET",
+        "/asset",
+        lambda _request: Response(
+            b"asset",
+            content_type="audio/mpeg",
+            headers={"Access-Control-Allow-Origin": "https://allowed.example", "Vary": "Origin"},
+        ),
+    )
+    with running([route]) as address:
+        connection = http.client.HTTPConnection(*address)
+        connection.request("GET", "/asset", headers={"Origin": "https://allowed.example"})
+        response = connection.getresponse()
+        assert response.status == 200
+        assert response.getheader("Content-Type") == "audio/mpeg"
+        assert response.msg.get_all("Access-Control-Allow-Origin") == ["https://allowed.example"]
+        assert response.msg.get_all("Vary") == ["Origin"]
+        assert response.msg.get_all("Content-Length") == ["5"]
+
+
 @pytest.mark.parametrize(
     ("error", "status"),
     [(ValidationError("bad input"), 400), (ConfigError("bad config"), 500)],


### PR DESCRIPTION
`collection_serve` の HTTP 層を共通 localserver chassis へ移行し、`ThreadingHTTPServer` subclass・header 手書き・body 上限・if-chain routing の自前実装を削除します。

Closes #4452

## 何が chassis の所有になったか

| 関心事 | 移行前 | 移行後 |
| --- | --- | --- |
| routing | `do_GET` / `do_POST` / `do_DELETE` の `self.path == ...` if-chain（約 19 経路） | 20 本超の `Route` エントリ。path params は chassis が抽出する |
| CORS origin 判定 | handler の `_allowed_origin` / `_send_cors` が route ごとにヘッダーを載せる | `OriginDecision`（ALLOW / OMIT / REJECT）を返す policy 1 つ。route は CORS ヘッダーを一切載せない |
| body 上限 | chassis の `Route.max_body_bytes` と handler の `_read_limited_post_body` で二重検証 | `Route.max_body_bytes` 単独。handler は `request.json` を受け取る |
| response 書き出し | `_send_bytes` / `_send_json_error` が socket へ直接書く | handler は `Request -> Response` 関数。socket を持たない |

## レビュー指摘への対応

- **critical 1（移行がラッパー止まり）**: if-chain を Route へ分解しました。残る catch-all は「未定義パスは 404」「未実装 method は 501」という protocol 上の既定応答 2 つだけで、実ルーティングは chassis が行います。
- **warning 2（`enforce_origin=False` の抜け穴）**: フラグを削除し、read / write の判定分岐を `OriginQuery -> OriginDecision` の policy へ集約しました。「CORS を付けずに配信する」ことも policy の返り値（`OMIT`）として表現されます。
- **warning 3（CORS マージの漏洩リスク）**: route が CORS ヘッダーを載せなくなったため、last-writer-wins に依存する経路自体がなくなりました。判定は 1 リクエストにつき 1 回だけ行い、全応答経路が同じ結果を使います。
- **warning 4（body 上限の二重検証）**: `_read_limited_post_body` を削除しました。
- **info 5（`_json` / `_bytes` の重複）**: 1 つの書き出しへ畳みました。
- **info 6（catch-all Route 10 個）**: 実ルートへ分解済みです。
- **info 7（`_read_body` のエラーメッセージ）**: 指摘は「chassis は `audio_studio.py` とも共有」を前提にしていますが、`audio_studio.py` が import しているのは `Request` 型だけで、独自の `BaseHTTPRequestHandler` を持っています。chassis の server 利用者は collection serve だけです。文言は拡張向けの wire contract として契約テストが固定しているため、現行のまま維持しました。
- **info 8（`do_CONNECT` / `do_TRACE` / `do_BREW`）**: 固定 discovery path が全 method を占有する形になり、method matrix の由来が route table 上で読めるようになりました。

## 挙動の変更点（1 件）

`POST /distrokid/releases?collection_id=...` は、移行前は `self.path` が query 込みで比較されていたため route 不一致で 404 になっていました。chassis は query を除いた path で解決するため、認証済みリクエストは route に到達し、body に必須フィールドが無いことで 400 になります。query が入力として使われない契約は変わらないため、`test_post_distrokid_releases_ignores_query_side_inputs` を「認証済みで送っても query は入力にならない」ことを直接示す形へ更新しました。

## 検証

- `uv run pytest tests -q` → 10191 passed / 4 skipped
- `uv run pytest tests/commands/collections -q` → 509 passed / 2 skipped（discovery schema v1 の status matrix を含む）
- `uv run ruff check .` / `ruff format --check .` → exit 0
