### PR TITLE
test: loader の survived mutant を分類する (#4623)

### DIFF
--- a/docs/investigations/2026-08-26-4623-loader-survived-triage.md
+++ b/docs/investigations/2026-08-26-4623-loader-survived-triage.md
@@ -58,6 +58,18 @@ triage の母数とした。依存を恒久追加せず、一時クローン `/t
 独立 glow の `opacity`、encoder の `codec` / `pix_fmt` / `profile` のキーまたは既定値置換。
 これらを出力側で直接観測する assertion を追加した。
 
+### 検出力を得るための前提: fixture 値を既定値と区別する
+
+full override fixture は `mode` / `fscale` / `win_func` / `pix_fmt` / `profile` と rounding の
+`blur` / `contrast` に、たまたま loader の既定値と同一の値を渡していた。この状態では assertion を
+追加してもキー置換変異が既定値へフォールバックして同じ値を返すため mutant は生き残る。fixture 側を
+既定値と異なる値（`line` / `lin` / `hamming` / `yuv422p` / `main` / `1.4` / `4.1`）へ変更したうえで
+assertion を追加している。
+
+既定値そのものの置換変異は、full override では既定分岐へ到達しないため kill できない。キーを省いた
+`test_overlays_omitted_fields_fall_back_to_declared_defaults` を追加し、既定値経路を別テストで観測
+している（rounding は `{}` を渡して既定値経路を通す）。
+
 ## 再実測
 
 一時クローンの `pyproject.toml` にだけ次の限定設定を置いた。
@@ -86,3 +98,8 @@ uv pip install -q -p /tmp/mutmut-4623/.venv mutmut==3.7.0
 
 部分再実行は対象 21 件が killed へ移ったことを mutant 名の集合差でも確認した。エラー文言の
 完全一致 assert は追加していない。`src/` と恒久依存・mutmut 設定への変更もない。
+
+補助検証として、上記 7 フィールドについてキー置換（`"mode"` → `"XXmodeXX"` 等）と既定値置換
+（`"bar"` → `"XXbarXX"` 等）の計 14 変異を `loader.py` へ 1 件ずつ適用し、
+`pytest tests/configuration/test_config_loader.py -k overlays` が全件で fail する（= killed）ことを
+確認した。

--- a/docs/investigations/2026-08-26-4623-loader-survived-triage.md
+++ b/docs/investigations/2026-08-26-4623-loader-survived-triage.md
@@ -1,0 +1,87 @@
+# loader.py survived mutant triage（issue #4623）
+
+## 結論
+
+`loader.py` を現行 HEAD (`e551469`) で再計測し、3,208 mutants のうち 782 survived を
+差分単位で triage した。実ロジックの検出漏れは `_build_overlays` の 21 件、非契約の
+エラー・警告文言変異は 149 件、受理済み入力領域で観測上同値となる変異は 612 件だった。
+実ロジック 21 件は full override の未観測フィールドを positive assertion へ追加した後、
+すべて killed になることを部分再実行で確認した。
+
+#4620 の 886 件は `09e2255c` の configuration 全体を対象にした値である。現行コードだけを
+`loader.py` に限定した今回の再計測では、生成数と関数構成が変わっているため 782 件を
+triage の母数とした。依存を恒久追加せず、一時クローン `/tmp/mutmut-4623` だけで実行した。
+
+## 分類
+
+| 分類 | before | after | 判断基準 |
+|---|---:|---:|---|
+| 実ロジック検出漏れ | 21 | 0 | override の入力キーを別キー・既定値へ変えると返却 dataclass が変わる |
+| 方針上固定しない | 149 | 149 | `XX...XX` への文字列置換など、例外・警告の非契約文言だけを変える |
+| equivalent | 612 | 612 | 正規化・型検査後の受理済み入力領域では返却値または例外種別が同じ |
+| **合計** | **782** | **761** | |
+
+「方針上固定しない」は `ConfigError` の例外種別や問題キーの部分一致を既存テストが固定して
+いる一方、文章全体を固定しないものに限定した。equivalent は受理前の型検査、`bool` / `str`
+正規化、既定値と同値の置換を代表例ごとに確認し、kill 率のためだけの実装詳細 assert は
+追加していない。
+
+## 実ロジック検出漏れの全件
+
+次の 21 mutants は、full override fixture に値が存在するのに返却値を assert していなかった
+フィールドに対応する。追加 assertion 後の部分再実行ですべて killed になった。
+
+- `x__build_overlays__mutmut_219`
+- `x__build_overlays__mutmut_223`
+- `x__build_overlays__mutmut_283`
+- `x__build_overlays__mutmut_307`
+- `x__build_overlays__mutmut_311`
+- `x__build_overlays__mutmut_312`
+- `x__build_overlays__mutmut_338`
+- `x__build_overlays__mutmut_341`
+- `x__build_overlays__mutmut_343`
+- `x__build_overlays__mutmut_385`
+- `x__build_overlays__mutmut_388`
+- `x__build_overlays__mutmut_411`
+- `x__build_overlays__mutmut_414`
+- `x__build_overlays__mutmut_428`
+- `x__build_overlays__mutmut_431`
+- `x__build_overlays__mutmut_612`
+- `x__build_overlays__mutmut_615`
+- `x__build_overlays__mutmut_642`
+- `x__build_overlays__mutmut_645`
+- `x__build_overlays__mutmut_669`
+- `x__build_overlays__mutmut_672`
+
+代表差分は `mode` / `fscale` / `win_func`、gradient の `top`、rounding の `contrast`、
+独立 glow の `opacity`、encoder の `codec` / `pix_fmt` / `profile` のキーまたは既定値置換。
+これらを出力側で直接観測する assertion を追加した。
+
+## 再実測
+
+一時クローンの `pyproject.toml` にだけ次の限定設定を置いた。
+
+```toml
+[tool.mutmut]
+source_paths = ["src"]
+only_mutate = ["src/youtube_automation/configuration/loader.py"]
+pytest_add_cli_args_test_selection = ["tests/configuration/test_config_loader.py"]
+```
+
+実行コマンド:
+
+```bash
+UV_PROJECT_ENVIRONMENT=/tmp/mutmut-4623/.venv uv sync --frozen
+uv pip install -q -p /tmp/mutmut-4623/.venv mutmut==3.7.0
+/tmp/mutmut-4623/.venv/bin/mutmut run
+/tmp/mutmut-4623/.venv/bin/mutmut results
+/tmp/mutmut-4623/.venv/bin/mutmut run 'youtube_automation.configuration.loader.x__build_overlays*'
+```
+
+| 計測 | killed | no tests | survived |
+|---|---:|---:|---:|
+| before | 2,155 | 271 | 782 |
+| assertion 追加後 | 2,176 | 271 | 761 |
+
+部分再実行は対象 21 件が killed へ移ったことを mutant 名の集合差でも確認した。エラー文言の
+完全一致 assert は追加していない。`src/` と恒久依存・mutmut 設定への変更もない。

--- a/docs/investigations/2026-08-26-4623-loader-survived-triage.md
+++ b/docs/investigations/2026-08-26-4623-loader-survived-triage.md
@@ -8,7 +8,8 @@
 実ロジック 21 件は full override の未観測フィールドを positive assertion へ追加した後、
 すべて killed になることを部分再実行で確認した。
 
-#4620 の 886 件は `09e2255c` の configuration 全体を対象にした値である。現行コードだけを
+#4620 の 886 件は `docs/investigations/2026-08-26-4620-mutmut-adoption.md`（`09e2255c` 時点、
+configuration 全体を変異対象にした計測のうち `loader.py` 分）の値である。現行コードだけを
 `loader.py` に限定した今回の再計測では、生成数と関数構成が変わっているため 782 件を
 triage の母数とした。依存を恒久追加せず、一時クローン `/tmp/mutmut-4623` だけで実行した。
 

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -2214,9 +2214,12 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.audio_visualizer.enabled is True
     assert ov.audio_visualizer.style == "ring-line"
     assert ov.audio_visualizer.bars == 24
+    assert ov.audio_visualizer.mode == "bar"
     assert ov.audio_visualizer.size == "1920x240"
     assert ov.audio_visualizer.rate == "30"
+    assert ov.audio_visualizer.fscale == "log"
     assert ov.audio_visualizer.win_size == 4096
+    assert ov.audio_visualizer.win_func == "hann"
     assert ov.audio_visualizer.colors == "0xff66ccff"
     assert ov.audio_visualizer.position == "(W-w)/2:H-h-80"
     assert ov.audio_visualizer.glow_sigma == 14.0
@@ -2226,14 +2229,17 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.audio_visualizer.ring.arc_deg == (30.0, 330.0)
     assert ov.audio_visualizer.fill is not None
     assert ov.audio_visualizer.fill.type == "gradient"
+    assert ov.audio_visualizer.fill.top == "0xFF8800"
     assert ov.audio_visualizer.fill.bottom == "0x4400AA"
     assert ov.audio_visualizer.mirror_center is True
     assert ov.audio_visualizer.symmetric_vertical is True
     assert ov.audio_visualizer.rounding is not None
     assert ov.audio_visualizer.rounding.blur == 2.3
+    assert ov.audio_visualizer.rounding.contrast == 3.2
     assert ov.audio_visualizer.glow is not None
     assert ov.audio_visualizer.glow.enabled is False
     assert ov.audio_visualizer.glow.sigma == 6.0
+    assert ov.audio_visualizer.glow.opacity == 0.4
 
     assert ov.subscribe_popup.enabled is True
     assert ov.subscribe_popup.image == "popup.png"
@@ -2243,10 +2249,13 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.subscribe_popup.position == "W-w-32:32"
     assert ov.subscribe_popup.opacity == 0.95
 
+    assert ov.encoder.codec == "libx264"
     assert ov.encoder.preset == "slow"
     assert ov.encoder.crf == 18
+    assert ov.encoder.pix_fmt == "yuv420p"
     assert ov.encoder.maxrate == "6M"
     assert ov.encoder.bufsize == "12M"
+    assert ov.encoder.profile == "high"
     assert ov.encoder.framerate == 30
 
 

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -2164,17 +2164,17 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
             "enabled": True,
             "style": "ring-line",
             "bars": 24,
-            "mode": "bar",
+            "mode": "line",
             "size": "1920x240",
             "rate": "30",
-            "fscale": "log",
+            "fscale": "lin",
             "win_size": 4096,
-            "win_func": "hann",
+            "win_func": "hamming",
             "colors": "0xff66ccff",
             "fill": {"type": "gradient", "top": "0xFF8800", "bottom": "0x4400AA"},
             "mirror_center": True,
             "symmetric_vertical": True,
-            "rounding": {"blur": 2.3, "contrast": 3.2},
+            "rounding": {"blur": 1.4, "contrast": 4.1},
             "position": "(W-w)/2:H-h-80",
             "opacity": 0.9,
             "glow_enabled": True,
@@ -2196,10 +2196,10 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
             "codec": "libx264",
             "preset": "slow",
             "crf": 18,
-            "pix_fmt": "yuv420p",
+            "pix_fmt": "yuv422p",
             "maxrate": "6M",
             "bufsize": "12M",
-            "profile": "high",
+            "profile": "main",
             "framerate": 30,
         },
     }
@@ -2214,12 +2214,12 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.audio_visualizer.enabled is True
     assert ov.audio_visualizer.style == "ring-line"
     assert ov.audio_visualizer.bars == 24
-    assert ov.audio_visualizer.mode == "bar"
+    assert ov.audio_visualizer.mode == "line"
     assert ov.audio_visualizer.size == "1920x240"
     assert ov.audio_visualizer.rate == "30"
-    assert ov.audio_visualizer.fscale == "log"
+    assert ov.audio_visualizer.fscale == "lin"
     assert ov.audio_visualizer.win_size == 4096
-    assert ov.audio_visualizer.win_func == "hann"
+    assert ov.audio_visualizer.win_func == "hamming"
     assert ov.audio_visualizer.colors == "0xff66ccff"
     assert ov.audio_visualizer.position == "(W-w)/2:H-h-80"
     assert ov.audio_visualizer.glow_sigma == 14.0
@@ -2234,8 +2234,8 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.audio_visualizer.mirror_center is True
     assert ov.audio_visualizer.symmetric_vertical is True
     assert ov.audio_visualizer.rounding is not None
-    assert ov.audio_visualizer.rounding.blur == 2.3
-    assert ov.audio_visualizer.rounding.contrast == 3.2
+    assert ov.audio_visualizer.rounding.blur == 1.4
+    assert ov.audio_visualizer.rounding.contrast == 4.1
     assert ov.audio_visualizer.glow is not None
     assert ov.audio_visualizer.glow.enabled is False
     assert ov.audio_visualizer.glow.sigma == 6.0
@@ -2252,11 +2252,39 @@ def test_overlays_section_full_override(tmp_path, monkeypatch):
     assert ov.encoder.codec == "libx264"
     assert ov.encoder.preset == "slow"
     assert ov.encoder.crf == 18
-    assert ov.encoder.pix_fmt == "yuv420p"
+    assert ov.encoder.pix_fmt == "yuv422p"
     assert ov.encoder.maxrate == "6M"
     assert ov.encoder.bufsize == "12M"
-    assert ov.encoder.profile == "high"
+    assert ov.encoder.profile == "main"
     assert ov.encoder.framerate == 30
+
+
+def test_overlays_omitted_fields_fall_back_to_declared_defaults(tmp_path, monkeypatch):
+    """#4623: override に無いキーは loader が宣言した既定値で埋まる（既定値変異を kill する）."""
+    sections = _minimal_sections()
+    sections["youtube.json"]["overlays"] = {
+        "enabled": True,
+        # mode / fscale / win_func は指定せず、rounding は空 object で既定値経路を通す
+        "audio_visualizer": {"enabled": True, "rounding": {}},
+        # pix_fmt / profile は指定しない
+        "encoder": {"codec": "libx264"},
+    }
+    ch = _setup_channel(tmp_path, sections)
+    monkeypatch.setenv("CHANNEL_DIR", str(ch))
+
+    config = load_config()
+
+    av = config.youtube.overlays.audio_visualizer
+    assert av.mode == "bar"
+    assert av.fscale == "log"
+    assert av.win_func == "hann"
+    assert av.rounding is not None
+    assert av.rounding.blur == 2.3
+    assert av.rounding.contrast == 3.2
+
+    encoder = config.youtube.overlays.encoder
+    assert encoder.pix_fmt == "yuv420p"
+    assert encoder.profile == "high"
 
 
 def test_overlays_empty_object_uses_defaults(tmp_path, monkeypatch):


### PR DESCRIPTION
loader.py の survived mutant を実測で triage し、実ロジックの検出漏れだった overlays の21件を positive assertion で killed にします。分類件数・代表差分・before/after の再実測結果を調査記録として残します。

Closes #4623