### PR TITLE
ci: changelog fragment の type / bullet 体裁を PR ゲートで検証する (#4650)

### DIFF
--- a/.github/scripts/validate-changelog-fragments.py
+++ b/.github/scripts/validate-changelog-fragments.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""changelog.d/ の fragment を release prepare と同じ実装で検証する。
+
+PR CI の changelog job は nix / uv を持たない軽量 job なので、runner の素の python から
+`youtube_automation.commands.system.changelog_fragments.load_fragments` を呼ぶ。これにより
+fragment ファイル名の type 文字列と本文の bullet 体裁が、リリース時ではなく PR 時点で fail する。
+
+規則を再実装せず同 module を直接 import するため、`changelog_fragments` は third-party 依存
+なしで import できる必要がある（`tests/repo/test_changelog_ci_contract.py` で機械担保）。
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+from youtube_automation.commands.system.changelog_fragments import load_fragments  # noqa: E402
+from youtube_automation.core.errors import ConfigError  # noqa: E402
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fragments-dir",
+        type=Path,
+        default=_REPO_ROOT / "changelog.d",
+        help="検証する fragment ディレクトリ",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        load_fragments(args.fragments_dir)
+    except ConfigError as error:
+        # load_fragments は最初の違反で停止するため、複数違反があれば修正のたびに再検出される。
+        print(f"::error::{error}")
+        print("書き方は changelog.d/README.md を参照してください。", file=sys.stderr)
+        return 1
+    print("changelog fragments are valid")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,6 +282,10 @@ jobs:
             exit 1
           fi
           echo "Changelog fragment found"
+      # fragment の存在だけでなく、release prepare が要求する type 文字列と bullet 体裁も
+      # PR 時点で検証する。ラベルや path filter に関係なく changelog.d/ 全件を対象にする。
+      - name: Validate changelog fragments
+        run: python .github/scripts/validate-changelog-fragments.py
 
   adr-numbering:
     needs: changes

--- a/changelog.d/4650-changelog-fragment-ci-gate.changed.md
+++ b/changelog.d/4650-changelog-fragment-ci-gate.changed.md
@@ -1,0 +1,1 @@
+- PR CI の changelog ゲートが fragment の存在だけでなく type 文字列と bullet 体裁も `yt-changelog-compile` と同じ実装で検証するようにし、体裁違反がリリース作業まで滞留しないようにする（#4650）。

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -7,6 +7,10 @@ bullet（`- ` で始まる行）を記述します。issue 番号がない場合
 利用可能な type は `added`、`changed`、`deprecated`、`removed`、`fixed`、
 `security`、`migration` です。
 
+type 文字列が不正な fragment と、`- ` で始まらない行を含む fragment は、PR CI の
+changelog job（`.github/scripts/validate-changelog-fragments.py`）が
+`yt-changelog-compile` と同じ実装で検出して fail します。
+
 リリース時に `yt-changelog-compile` が fragment を type 別に
 `CHANGELOG.md` の `[Unreleased]` へ集約し、集約済みファイルを削除します。
 詳細なセクション契約は [docs/changelog-contract.md](../docs/changelog-contract.md) を

--- a/src/youtube_automation/commands/system/changelog_compile.py
+++ b/src/youtube_automation/commands/system/changelog_compile.py
@@ -7,38 +7,10 @@ import re
 from pathlib import Path
 
 from youtube_automation.commands._shared.cli_harness import run_cli
+from youtube_automation.commands.system.changelog_fragments import SECTION_ORDER, load_fragments
 from youtube_automation.core.errors import ConfigError
 
-_SECTION_ORDER = (
-    "added",
-    "changed",
-    "deprecated",
-    "removed",
-    "fixed",
-    "security",
-    "migration",
-)
-_SECTION_NAMES = {section: section.title() for section in _SECTION_ORDER}
-_FRAGMENT_PATTERN = re.compile(rf"^.+\.(?P<type>{'|'.join(_SECTION_ORDER)})\.md$")
-
-
-def _load_fragments(fragments_dir: Path) -> dict[str, list[tuple[Path, str]]]:
-    grouped = {section: [] for section in _SECTION_ORDER}
-    if not fragments_dir.exists():
-        return grouped
-
-    for path in sorted(fragments_dir.glob("*.md")):
-        if path.name.casefold() == "readme.md":
-            continue
-        match = _FRAGMENT_PATTERN.fullmatch(path.name)
-        if match is None:
-            raise ConfigError(f"不正な changelog fragment ファイル名です: {path.name}")
-        body = path.read_text(encoding="utf-8").strip()
-        lines = [line for line in body.splitlines() if line.strip()]
-        if not lines or any(not line.startswith("- ") for line in lines):
-            raise ConfigError(f"changelog fragment は '- ' で始まる bullet で記述してください: {path.name}")
-        grouped[match.group("type")].append((path, "\n".join(lines)))
-    return grouped
+_SECTION_NAMES = {section: section.title() for section in SECTION_ORDER}
 
 
 def _unreleased_bounds(changelog: str) -> tuple[int, int]:
@@ -56,8 +28,8 @@ def _append_to_section(unreleased: str, section_type: str, bullets: str) -> str:
     match = re.search(rf"^{re.escape(heading)}\s*$", unreleased, re.MULTILINE)
     if match is None:
         insert_at = len(unreleased.rstrip())
-        wanted_index = _SECTION_ORDER.index(section_type)
-        for later_type in _SECTION_ORDER[wanted_index + 1 :]:
+        wanted_index = SECTION_ORDER.index(section_type)
+        for later_type in SECTION_ORDER[wanted_index + 1 :]:
             later = re.search(
                 rf"^### {re.escape(_SECTION_NAMES[later_type])}\s*$",
                 unreleased,
@@ -94,7 +66,7 @@ def _append_to_section(unreleased: str, section_type: str, bullets: str) -> str:
 
 def compile_fragments(changelog_path: Path, fragments_dir: Path, *, dry_run: bool = False) -> str | None:
     """Compile fragments and return the resulting CHANGELOG text, or None when empty."""
-    grouped = _load_fragments(fragments_dir)
+    grouped = load_fragments(fragments_dir)
     fragment_paths = [path for entries in grouped.values() for path, _ in entries]
     if not fragment_paths:
         return None
@@ -102,7 +74,7 @@ def compile_fragments(changelog_path: Path, fragments_dir: Path, *, dry_run: boo
     original = changelog_path.read_text(encoding="utf-8")
     start, end = _unreleased_bounds(original)
     unreleased = original[start:end]
-    for section_type in _SECTION_ORDER:
+    for section_type in SECTION_ORDER:
         entries = grouped[section_type]
         if entries:
             unreleased = _append_to_section(

--- a/src/youtube_automation/commands/system/changelog_fragments.py
+++ b/src/youtube_automation/commands/system/changelog_fragments.py
@@ -1,0 +1,47 @@
+"""changelog fragment のファイル名 type と本文 bullet 体裁の規則。
+
+PR CI の changelog ゲートは nix / uv を持たない軽量 job なので、runner の素の python が
+`.github/scripts/validate-changelog-fragments.py` からこの module を import して fragment を
+検証する。規則を CI 側へ再実装しないための共有 module であり、**module import 時に
+third-party 依存を持ち込んではならない**（`commands._shared.cli_harness` は
+`infrastructure.auth` 経由で google SDK を eager import するため、ここからは参照しない）。
+この制約は `tests/repo/test_changelog_ci_contract.py` が実行で機械担保する。
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from youtube_automation.core.errors import ConfigError
+
+SECTION_ORDER = (
+    "added",
+    "changed",
+    "deprecated",
+    "removed",
+    "fixed",
+    "security",
+    "migration",
+)
+_FRAGMENT_PATTERN = re.compile(rf"^.+\.(?P<type>{'|'.join(SECTION_ORDER)})\.md$")
+
+
+def load_fragments(fragments_dir: Path) -> dict[str, list[tuple[Path, str]]]:
+    """fragment を type 別に読み込み、ファイル名と bullet 体裁を検証する。"""
+    grouped = {section: [] for section in SECTION_ORDER}
+    if not fragments_dir.exists():
+        return grouped
+
+    for path in sorted(fragments_dir.glob("*.md")):
+        if path.name.casefold() == "readme.md":
+            continue
+        match = _FRAGMENT_PATTERN.fullmatch(path.name)
+        if match is None:
+            raise ConfigError(f"不正な changelog fragment ファイル名です: {path.name}")
+        body = path.read_text(encoding="utf-8").strip()
+        lines = [line for line in body.splitlines() if line.strip()]
+        if not lines or any(not line.startswith("- ") for line in lines):
+            raise ConfigError(f"changelog fragment は '- ' で始まる bullet で記述してください: {path.name}")
+        grouped[match.group("type")].append((path, "\n".join(lines)))
+    return grouped

--- a/tests/repo/test_changelog_ci_contract.py
+++ b/tests/repo/test_changelog_ci_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,14 @@ _REPO_ROOT = REPO_ROOT
 _CLAUDE_PATH = _REPO_ROOT / "CLAUDE.md"
 _PR_TEMPLATE_PATH = _REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md"
 _CI_WORKFLOW_PATH = _REPO_ROOT / ".github" / "workflows" / "ci.yml"
+_FRAGMENTS_DIR = _REPO_ROOT / "changelog.d"
+_FRAGMENTS_README_PATH = _FRAGMENTS_DIR / "README.md"
+_FRAGMENT_VALIDATOR_PATH = _REPO_ROOT / ".github" / "scripts" / "validate-changelog-fragments.py"
+_FRAGMENT_VALIDATOR_RELATIVE = ".github/scripts/validate-changelog-fragments.py"
+_FRAGMENT_VALIDATOR_STEP_NAME = "Validate changelog fragments"
+_FRAGMENT_VALIDATOR_COMMAND = f"python {_FRAGMENT_VALIDATOR_RELATIVE}"
+_CHANGELOG_UPDATE_STEP_NAME = "Check CHANGELOG update"
+_FRAGMENT_RULES_MODULE = "youtube_automation.commands.system.changelog_fragments"
 
 _CHANGELOG_LABEL = "skip-changelog"
 
@@ -120,6 +129,23 @@ def _run_changelog_gate(
         capture_output=True,
         text=True,
     )
+
+
+def _run_fragment_validator(fragments_dir: Path) -> subprocess.CompletedProcess[str]:
+    """CI が呼ぶ fragment 検証スクリプトを、指定した fragment 集合に対して実行する。"""
+    return subprocess.run(
+        [sys.executable, str(_FRAGMENT_VALIDATOR_PATH), "--fragments-dir", str(fragments_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_fragment_fixture(tmp_path: Path, name: str, body: str) -> Path:
+    fragments_dir = tmp_path / "changelog.d"
+    fragments_dir.mkdir()
+    (fragments_dir / name).write_text(body, encoding="utf-8")
+    return fragments_dir
 
 
 def test_pull_request_template_matches_issue_485_contract() -> None:
@@ -268,3 +294,95 @@ def test_changelog_gate_paths_match_single_source_in_ci() -> None:
     assert ci_pattern_match.group(1) == _PATH_FILTER_PATTERN, (
         "CI workflow の path filter regex が _CHANGELOG_GATED_PATHS と一致しない"
     )
+
+
+def test_ci_workflow_changelog_job_validates_fragment_format() -> None:
+    """fragment の存在確認だけでなく、type / bullet 体裁の検証 step も持つことを固定する。"""
+    steps = _load_ci_workflow()["jobs"]["changelog"]["steps"]
+    names = [step.get("name") for step in steps]
+
+    assert _FRAGMENT_VALIDATOR_STEP_NAME in names, "fragment 体裁を検証する step が存在しない"
+    assert names.index(_FRAGMENT_VALIDATOR_STEP_NAME) > names.index(_CHANGELOG_UPDATE_STEP_NAME), (
+        "体裁検証は fragment 存在チェックの後に置く"
+    )
+
+    validator_step = steps[names.index(_FRAGMENT_VALIDATOR_STEP_NAME)]
+    assert validator_step.get("run", "").strip() == _FRAGMENT_VALIDATOR_COMMAND
+    # skip-changelog ラベルや path filter で握り潰さず、常に changelog.d/ 全件を検証する。
+    assert "if" not in validator_step
+    assert _FRAGMENT_VALIDATOR_PATH.is_file(), f"{_FRAGMENT_VALIDATOR_RELATIVE} が存在しない"
+
+
+def test_fragment_rules_module_imports_without_third_party_dependencies() -> None:
+    """changelog ゲートは nix / uv 無しで走るため、規則 module に third-party 依存を持たせない。"""
+    code = (
+        f"import sys; sys.path.insert(0, {str(_REPO_ROOT / 'src')!r}); "
+        # 空振りしない保証: site-packages が本当に外れていることを import 前に確かめる。
+        "assert not any('site-packages' in entry for entry in sys.path), sys.path; "
+        f"import {_FRAGMENT_RULES_MODULE}"
+    )
+
+    # -S で site を無効化し、-E で devShell の PYTHONPATH も無視する。依存が増えれば ImportError で落ちる。
+    result = subprocess.run([sys.executable, "-E", "-S", "-c", code], check=False, capture_output=True, text=True)
+
+    assert result.returncode == 0, f"素の python で {_FRAGMENT_RULES_MODULE} を import できない: {result.stderr}"
+
+
+def test_compile_and_ci_share_the_same_fragment_rules() -> None:
+    """release prepare 側が規則を再実装せず、CI と同じ module を使うことを固定する。"""
+    compile_source = _read_text(_REPO_ROOT / "src/youtube_automation/commands/system/changelog_compile.py")
+    validator_source = _read_text(_FRAGMENT_VALIDATOR_PATH)
+
+    assert f"from {_FRAGMENT_RULES_MODULE} import" in compile_source
+    assert f"from {_FRAGMENT_RULES_MODULE} import" in validator_source
+
+
+def test_changelog_fragment_validator_accepts_repository_fragments() -> None:
+    """リポジトリの changelog.d/ 全件が release prepare と同じ規則を満たす（#4649 の回帰防止）。"""
+    result = _run_fragment_validator(_FRAGMENTS_DIR)
+
+    assert result.returncode == 0, f"changelog.d/ に体裁違反がある: {result.stdout}{result.stderr}"
+    assert "changelog fragments are valid" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("fragment_name", "fragment_body", "expected_message"),
+    [
+        ("9-plain.fixed.md", "bullet ではない平文\n", "'- ' で始まる bullet で記述してください"),
+        ("9-continuation.fixed.md", "- 先頭行\n継続行\n", "'- ' で始まる bullet で記述してください"),
+        ("9-empty.fixed.md", "\n", "'- ' で始まる bullet で記述してください"),
+        ("9-unknown.improved.md", "- 本文\n", "不正な changelog fragment ファイル名です"),
+    ],
+)
+def test_changelog_fragment_validator_rejects_invalid_fragments(
+    tmp_path: Path,
+    fragment_name: str,
+    fragment_body: str,
+    expected_message: str,
+) -> None:
+    """type 文字列と bullet 体裁の違反を、いずれも PR 時点で fail させる。"""
+    fragments_dir = _write_fragment_fixture(tmp_path, fragment_name, fragment_body)
+
+    result = _run_fragment_validator(fragments_dir)
+
+    assert result.returncode == 1, f"体裁違反が検出されなかった: stdout={result.stdout!r}"
+    assert "::error::" in result.stdout, "GitHub Actions の error annotation で出力する"
+    assert expected_message in result.stdout
+    assert fragment_name in result.stdout, "違反ファイル名を出力に含める"
+
+
+def test_changelog_fragment_validator_does_not_consume_fragments(tmp_path: Path) -> None:
+    """検証は読み取りのみで、release prepare のように fragment を集約・削除しない。"""
+    fragments_dir = _write_fragment_fixture(tmp_path, "9-valid.fixed.md", "- 正しい bullet\n")
+
+    result = _run_fragment_validator(fragments_dir)
+
+    assert result.returncode == 0, f"正しい fragment が拒否された: {result.stdout}{result.stderr}"
+    assert (fragments_dir / "9-valid.fixed.md").read_text(encoding="utf-8") == "- 正しい bullet\n"
+
+
+def test_changelog_fragments_readme_documents_ci_validation() -> None:
+    """fragment の書き方の正本に、PR 時点で検証される旨を記載しておく。"""
+    readme = _read_text(_FRAGMENTS_README_PATH)
+
+    assert _FRAGMENT_VALIDATOR_RELATIVE in readme


### PR DESCRIPTION
## 概要

PR CI の changelog ゲートは fragment の**存在**しか検証しておらず、ファイル名の type 文字列と本文の bullet 体裁は release prepare 時にしか検出されなかった。その結果 #4649 のように 13 件が滞留し、発見はリリース担当者が `/automation-release` を走らせた時点になる。

fragment の規則を依存ゼロの module へ切り出し、release prepare と CI が同じ実装を共有した上で、changelog job から検証する。

Closes #4650

## 変更内容

- `src/youtube_automation/commands/system/changelog_fragments.py`（新規）— `SECTION_ORDER` と `load_fragments` を移設した規則の単一 owner。third-party 依存を持たない
- `src/youtube_automation/commands/system/changelog_compile.py` — 規則を新 module から import。振る舞いは不変（純粋な抽出）
- `.github/scripts/validate-changelog-fragments.py`（新規）— `load_fragments` を呼び、違反を `::error::` で出力して exit 1
- `.github/workflows/ci.yml` — changelog job に `Validate changelog fragments` step を追加
- `tests/repo/test_changelog_ci_contract.py` — step の契約 / 素の python で import できること / 違反・正常時の挙動を固定
- `changelog.d/README.md` — PR 時点で検証される旨を追記

## 設計判断

**changelog job に置く理由**: `if: github.event_name == 'pull_request'` で全 PR に走り、`skip-changelog` ラベルや path filter で握り潰されない（ラベルは fragment の *追加* を免除するもので、既存 fragment を壊してよい理由にはならない）。検証対象は変更差分ではなく `changelog.d/` 全件なので、#4649 のような滞留も検出できる。

**素の python で動かす理由**: changelog job は nix / uv を持たない軽量 job（現状 10 秒前後）。ここに `install-nix-action` + `uv sync` を足すと毎 PR で数分に伸びるため、runner の `python` だけで完結させる。

**規則 module を切り出した理由**: `changelog_compile` は `cli_harness` → `infrastructure.auth` → google SDK を eager import するため、素の python では `ModuleNotFoundError: No module named 'google'` になる。`cli_harness` の import を関数内へ遅らせる案は `tests/repo/test_cli_harness_gate.py` の「module 直下に共通 harness の import がある」契約に抵触したため、依存ゼロの規則 module を分離する形にした。制約は `python -E -S`（site 無効化 + `PYTHONPATH` 無視）での import 実行テストで機械担保する。テストは import 前に `site-packages` が実際に sys.path から外れていることを assert するので、空振りしない。

## 既知の制限

- `load_fragments` は最初の違反で `ConfigError` を投げるため、複数違反があると 1 件ずつしか報告されない。PR 時点で塞がるので #4649 のような滞留は起きないが、まとめて直したい場合は修正のたびに再実行が必要。
- `.github/scripts/select-affected-tests.py` の `PATH_TEST_MAP` は `.github/workflows/` を `test_actions_parallel_workflows.py` にだけ対応付けているため、`ci.yml` 単独の変更ではこの契約テストが選定されない（本 PR 以前からの挙動）。本 PR は新規 script path を含むため fail-safe で全件実行される。

## 検証

- `nix develop --command uv run pytest -n auto`: **10205 passed, 4 skipped**
- `ruff check .` / `ruff format --check .` / `pyscn check src/youtube_automation` / pyscn 差分ゲート（base `8f16944d`、新規 finding なし）/ `yt-skills catalog --check` すべて green
- 違反 fixture（平文 / 継続行 / 空 / 未知 type）でスクリプトが exit 1 + `::error::` + 違反ファイル名を出すこと、正常時は exit 0 で fragment を消費しないことをテストで確認
- `yt-changelog-compile --dry-run` の正常系と `ConfigError` の error boundary（`❌ changelog fragment compile failed: ...`）が従来どおり動くことを実行で確認

## チェックリスト

- [x] `changelog.d/` に fragment を追加した（`4650-changelog-fragment-ci-gate.changed.md`）
- [x] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
  - 上流の CI / リリース運用のみの変更で、下流チャンネルへの影響はなし
- [x] 必要なテストを追加・更新した

## 関連

- Issue: #4650（#4649 に blocked by）
- 下段 PR: #4651
