### PR TITLE
fix(extensions): 音源転送の64MiB上限を回避する (#4645)

### DIFF
--- a/changelog.d/4645-distrokid-asset-transfer.fixed.md
+++ b/changelog.d/4645-distrokid-asset-transfer.fixed.md
@@ -1,0 +1,1 @@
+- DistroKid Helper の音源転送を 4 MiB chunk と Blob URL に変更し、64 MiB を超える素材でも Chrome messaging 上限に達しないようにした。

--- a/extensions/distrokid-helper/README.md
+++ b/extensions/distrokid-helper/README.md
@@ -21,8 +21,8 @@ WXT + React + TypeScript + Tailwind CSS + [@webext-core/messaging](https://webex
 | `entrypoints/content.ts`    | `distrokid.com/new` での DOM 注入（テキスト + overlay から受け取った File）                                 |
 | `entrypoints/overlay.content.ts` | Shadow DOM overlay を `distrokid.com/new` に mount                                                    |
 | `components/`               | draggable overlay UI + `useDistrokidRunner`（fetch / collection 選択 / 注入 / 停止 / 配信済み記録）       |
-| `lib/api.ts`                | `/distrokid/release.json` / assets の fetch client（`ReleaseUnavailableError`）                             |
-| `lib/asset-transfer.ts`     | overlay で fetch した asset を runner へ渡すための base64 直列化                                           |
+| `lib/api.ts`                | `/distrokid/release.json` の fetch client（`ReleaseUnavailableError`）                             |
+| `lib/asset-transfer.ts`     | Blob URL から注入用 `File` への復元                                           |
 | `lib/distrokid-injector.ts` | React 互換ネイティブイベント注入 + `DataTransfer` ファイル注入 + セレクタ契約                               |
 | `lib/messaging.ts`          | overlay ↔ background ↔ runner の型付き channel（`PHASES` 進捗契約）                                       |
 | `lib/storage.ts`            | 選択中ローカル配信元の永続化（既定 `http://youtube-automation.localhost:7873`）                             |
@@ -186,7 +186,7 @@ Apple Music credits は `profile.artist` を performer / producer の name 欄�
 
 `--allow-extension` は macOS Chrome profile の `Secure Preferences` を優先し、無ければ `Preferences` を読み、`extensions.settings[*].path` が絶対パスかつ basename is `distrokid-helper` の unpacked extension ID から `chrome-extension://<id>` を組み立てる。検出 0 件、複数 ID、Preferences read failure、JSON parse failure の場合だけ、Chrome の `chrome://extensions` で distrokid-helper の拡張 ID を確認し、手動 fallback として `--allow-origin chrome-extension://<EXTENSION_ID>` を指定する。`.output/chrome-mv3/` を直接ロードすると basename is `chrome-mv3` になり `--allow-extension distrokid-helper` では検出できないため、通常は `$HOME/chrome-extensions/distrokid-helper` のような固定パスをロードする。
 
-HTTPS の DistroKid page から loopback HTTP への mixed-content fetch は Chrome が拒否するため、`release.json` と asset（曲 / ジャケット）の GET は background service worker へ委譲する。background は URL を loopback HTTP に限定し、redirect を拒否する。asset は1件ずつ `lib/asset-transfer.ts` の base64 wire に変換して overlay へ返し、さらに同一タブの runner へ転送する。書き込み route は従来どおり background の extension origin + serve token に限定し、content script の注入先は `distrokid.com/new` に限定する。
+HTTPS の DistroKid page から loopback HTTP への mixed-content fetch は Chrome が拒否するため、`release.json` と asset（曲 / ジャケット）の GET は background service worker へ委譲する。background は URL を loopback HTTP に限定し、redirect を拒否する。asset は background から 4 MiB chunk で pull し、overlay で組み立てた Blob URL だけを同一タブの runner へ転送する。注入後は Blob URL を必ず revoke する。書き込み route は従来どおり background の extension origin + serve token に限定し、content script の注入先は `distrokid.com/new` に限定する。
 
 ## スコープ外
 

--- a/extensions/distrokid-helper/entrypoints/background.ts
+++ b/extensions/distrokid-helper/entrypoints/background.ts
@@ -5,7 +5,7 @@
 import { requireSenderTabId } from "@youtube-automation/extensions-shared/tab-relay";
 
 import { recordDistrokidRelease } from "../../shared/api";
-import { fetchLocalAsset, fetchLocalText } from "../lib/local-fetch";
+import { fetchLocalAssetChunk, fetchLocalText } from "../lib/local-fetch";
 import { onMessage, sendMessage } from "../lib/messaging";
 import { migrateServerSourcesStorage } from "../lib/storage";
 
@@ -34,7 +34,7 @@ export default defineBackground(() => {
   });
 
   onMessage("fetchLocalText", ({ data }) => fetchLocalText(data));
-  onMessage("fetchLocalAsset", ({ data }) => fetchLocalAsset(data));
+  onMessage("fetchLocalAssetChunk", ({ data }) => fetchLocalAssetChunk(data));
 
   onMessage("injectStart", ({ data, sender }) =>
     sendMessage("injectStart", data, requireSenderTabId(sender, "injectStart"))

--- a/extensions/distrokid-helper/entrypoints/content.ts
+++ b/extensions/distrokid-helper/entrypoints/content.ts
@@ -2,7 +2,7 @@
 //
 // overlay から同一タブ relay された per-track 分割メッセージ（injectStart → injectTrack* → injectCover? →
 // injectFinish）を受け、静的プロファイル + 動的データのテキスト/SELECT を注入し、
-// overlay が fetch 済みの曲 / ジャケット（直列化済み）を File へ復元して <input type=file> にセットする。
+// overlay が fetch 済みの曲 / ジャケットを Blob URL から File へ復元して <input type=file> にセットする。
 // セッションのロジック（順序保証・範囲検査）は lib/inject-session.ts が担い、ここは DOM 束縛の
 // 注入 primitive とメッセージ配線のみを持つ。
 // 「続ける」等の送信系操作は一切行わない（規約遵守・スコープ外）。

--- a/extensions/distrokid-helper/entrypoints/content.ts
+++ b/extensions/distrokid-helper/entrypoints/content.ts
@@ -7,6 +7,7 @@
 // 注入 primitive とメッセージ配線のみを持つ。
 // 「続ける」等の送信系操作は一切行わない（規約遵守・スコープ外）。
 
+import { blobUrlToFile } from "@/lib/asset-transfer";
 import { createDocumentInjector } from "@/lib/content-injector";
 import { InjectSession } from "@/lib/inject-session";
 import { MANIFEST_CONTENT_SCRIPT_MATCHES } from "@/lib/manifest";
@@ -26,10 +27,17 @@ export default defineContentScript({
     // 各メッセージ handler は例外を握りつぶさず伝播させる。@webext-core/messaging が
     // overlay 側 sendMessage を reject し、overlay が ERROR フェーズへ一元変換する（fail-loud）。
     onMessage("injectStart", ({ data }) => session.start(data.payload));
-    onMessage("injectTrack", ({ data }) =>
-      session.track(data.trackIndex, data.asset)
-    );
-    onMessage("injectCover", ({ data }) => session.cover(data.asset));
+    onMessage("injectTrack", async ({ data }) => {
+      return session.track(
+        data.trackIndex,
+        await blobUrlToFile(data.asset.blobUrl, data.asset.filename)
+      );
+    });
+    onMessage("injectCover", async ({ data }) => {
+      return session.cover(
+        await blobUrlToFile(data.asset.blobUrl, data.asset.filename)
+      );
+    });
     onMessage("injectFinish", () => session.finish());
     onMessage("stop", () => session.stop());
   },

--- a/extensions/distrokid-helper/lib/api.ts
+++ b/extensions/distrokid-helper/lib/api.ts
@@ -7,7 +7,6 @@
 //   - distrokid.enabled=false / 未配置のチャンネルは /distrokid/* が 404（要件 #16）
 
 import { distrokidReleaseRoute } from "../../shared/constants";
-import { encodeAsset, type SerializedAsset } from "./asset-transfer";
 import type { ReleasePayload } from "./types";
 
 type Fetcher = (
@@ -109,19 +108,3 @@ export async function fetchCollectionRelease(
 // asset（曲 / ジャケット）を取得し、content へ転送するため直列化して返す。
 // assetPath は接頭辞 "/distrokid/assets/" または "/collections/<id>/distrokid/assets/" 込みのため
 // baseUrl と連結するだけでよい（dir mode の collection-scoped asset_path も同形式）。
-export async function fetchAsset(
-  baseUrl: string,
-  assetPath: string,
-  filename: string
-): Promise<SerializedAsset> {
-  const url = `${normalizeBaseUrl(baseUrl)}${assetPath}`;
-  const response = await fetch(url, { method: "GET" });
-
-  if (!response.ok) {
-    throw new Error(
-      `asset fetch failed (${assetPath}): HTTP ${response.status}`
-    );
-  }
-
-  return encodeAsset(filename, await response.blob());
-}

--- a/extensions/distrokid-helper/lib/asset-transfer.ts
+++ b/extensions/distrokid-helper/lib/asset-transfer.ts
@@ -1,5 +1,8 @@
-export {
-  decodeAsset,
-  encodeAsset,
-  type SerializedAsset,
-} from "../../shared/asset-transfer";
+// overlay が生成した Blob URL を、同一タブの content script で File に復元する。
+export async function blobUrlToFile(
+  blobUrl: string,
+  filename: string
+): Promise<File> {
+  const blob = await fetch(blobUrl).then((response) => response.blob());
+  return new File([blob], filename, { type: blob.type });
+}

--- a/extensions/distrokid-helper/lib/background-fetch.ts
+++ b/extensions/distrokid-helper/lib/background-fetch.ts
@@ -26,5 +26,23 @@ export async function backgroundFetch(
 }
 
 export async function backgroundFetchAsset(url: string, filename: string) {
-  return sendMessage("fetchLocalAsset", { url, filename });
+  const parts: ArrayBuffer[] = [];
+  let offset = 0;
+  let contentType = "";
+  do {
+    const chunk = await sendMessage("fetchLocalAssetChunk", { url, offset });
+    const binary = atob(chunk.base64);
+    const bytes = Uint8Array.from(binary, (character) =>
+      character.charCodeAt(0)
+    );
+    parts.push(bytes.buffer);
+    offset += bytes.byteLength;
+    contentType = chunk.contentType;
+    if (offset >= chunk.totalSize) break;
+    if (bytes.byteLength === 0)
+      throw new Error("asset chunk fetch made no progress");
+  } while (offset >= 0);
+
+  const blobUrl = URL.createObjectURL(new Blob(parts, { type: contentType }));
+  return { filename, blobUrl, revoke: () => URL.revokeObjectURL(blobUrl) };
 }

--- a/extensions/distrokid-helper/lib/background-fetch.ts
+++ b/extensions/distrokid-helper/lib/background-fetch.ts
@@ -29,7 +29,10 @@ export async function backgroundFetchAsset(url: string, filename: string) {
   const parts: ArrayBuffer[] = [];
   let offset = 0;
   let contentType = "";
-  do {
+  // 総サイズは最初の chunk 応答で確定するため、それまでは未達として扱う。
+  // 終了条件は「受領済み byte が総サイズに達したか」だけに保つ。
+  let totalSize = Number.POSITIVE_INFINITY;
+  while (offset < totalSize) {
     const chunk = await sendMessage("fetchLocalAssetChunk", { url, offset });
     const binary = atob(chunk.base64);
     const bytes = Uint8Array.from(binary, (character) =>
@@ -38,10 +41,11 @@ export async function backgroundFetchAsset(url: string, filename: string) {
     parts.push(bytes.buffer);
     offset += bytes.byteLength;
     contentType = chunk.contentType;
-    if (offset >= chunk.totalSize) break;
-    if (bytes.byteLength === 0)
+    totalSize = chunk.totalSize;
+    // 未達なのに 0 byte しか返らないと進まないため、無限ループにせず打ち切る。
+    if (offset < totalSize && bytes.byteLength === 0)
       throw new Error("asset chunk fetch made no progress");
-  } while (offset >= 0);
+  }
 
   const blobUrl = URL.createObjectURL(new Blob(parts, { type: contentType }));
   return { filename, blobUrl, revoke: () => URL.revokeObjectURL(blobUrl) };

--- a/extensions/distrokid-helper/lib/inject-runner.ts
+++ b/extensions/distrokid-helper/lib/inject-runner.ts
@@ -9,25 +9,29 @@
 // asset は 1 track ずつ fetch → 送信 → 解放を逐次実行し、overlay memory を track 数に対し
 // O(1) に保つ。全 track を 1 メッセージで送ると Base64 化後に 64MiB 上限を超えるため分割する。
 
-import type { SerializedAsset } from "./asset-transfer";
+import type { BlobAssetReference } from "./messaging";
 import type { ReleasePayload } from "./types";
 
 // 注入オーケストレーションの境界（transport / 停止判定 / 進捗表示）。
 export interface InjectChannel {
   // serverUrl 上の 1 asset を overlay から取得して直列化する。
-  fetchAsset(assetPath: string, filename: string): Promise<SerializedAsset>;
+  fetchAsset(assetPath: string, filename: string): Promise<AssetHandle>;
   // content へ注入セッションを開始する（テキスト / SELECT 系のみ、asset なし）。
   start(payload: ReleasePayload): Promise<void>;
   // content へ 1 track の曲ファイルを注入する。
-  track(trackIndex: number, asset: SerializedAsset): Promise<void>;
+  track(trackIndex: number, asset: BlobAssetReference): Promise<void>;
   // content へジャケットを注入する。
-  cover(asset: SerializedAsset): Promise<void>;
+  cover(asset: BlobAssetReference): Promise<void>;
   // content の注入セッションを完了する（AI 開示注入 + DONE）。
   finish(): Promise<void>;
   // 進捗メッセージを UI へ反映する。
   setMessage(message: string): void;
   // 停止要求の確認（ループ境界・send 直前で参照する）。
   isStopped(): boolean;
+}
+
+export interface AssetHandle extends BlobAssetReference {
+  revoke(): void;
 }
 
 // 注入を逐次実行する。停止要求はループ境界と各 send 直前で確認し、確認後は以降の送信を
@@ -46,13 +50,12 @@ export async function runInjection(
     const track = release.tracks[i];
     channel.setMessage(`アセットを取得中: ${track.filename}`);
     const asset = await channel.fetchAsset(track.asset_path, track.filename);
-    // fetch 中に停止された場合、content は既に session を破棄している。ここで送ると
-    // injectTrack が null セッションへ届き fail-loud で throw し、STOPPED を ERROR で
-    // 上書きしてしまうため send 直前に再チェックする。
-    if (channel.isStopped()) {
-      return;
+    try {
+      if (channel.isStopped()) return;
+      await channel.track(i, asset);
+    } finally {
+      asset.revoke();
     }
-    await channel.track(i, asset);
   }
 
   if (channel.isStopped()) {
@@ -64,11 +67,12 @@ export async function runInjection(
       release.cover.asset_path,
       release.cover.filename
     );
-    // track ループと同様、fetch 中の停止に備えて send 直前に再チェックする。
-    if (channel.isStopped()) {
-      return;
+    try {
+      if (channel.isStopped()) return;
+      await channel.cover(asset);
+    } finally {
+      asset.revoke();
     }
-    await channel.cover(asset);
   }
 
   if (channel.isStopped()) {

--- a/extensions/distrokid-helper/lib/inject-runner.ts
+++ b/extensions/distrokid-helper/lib/inject-runner.ts
@@ -7,14 +7,15 @@
 // transport を、テストは fake を渡す）。
 //
 // asset は 1 track ずつ fetch → 送信 → 解放を逐次実行し、overlay memory を track 数に対し
-// O(1) に保つ。全 track を 1 メッセージで送ると Base64 化後に 64MiB 上限を超えるため分割する。
+// O(1) に保つ。送信するのは Blob URL 参照だけで asset 本体は運ばないため（#4645）、
+// メッセージサイズは素材サイズに依らず 64MiB 上限へ届かない。
 
 import type { BlobAssetReference } from "./messaging";
 import type { ReleasePayload } from "./types";
 
 // 注入オーケストレーションの境界（transport / 停止判定 / 進捗表示）。
 export interface InjectChannel {
-  // serverUrl 上の 1 asset を overlay から取得して直列化する。
+  // serverUrl 上の 1 asset を overlay から取得し、Blob URL 参照として handle 化する。
   fetchAsset(assetPath: string, filename: string): Promise<AssetHandle>;
   // content へ注入セッションを開始する（テキスト / SELECT 系のみ、asset なし）。
   start(payload: ReleasePayload): Promise<void>;
@@ -34,6 +35,24 @@ export interface AssetHandle extends BlobAssetReference {
   revoke(): void;
 }
 
+// fetch 済み asset の「停止判定 → 送信 → 解放」を 1 箇所に束ねる。send が reject しても
+// finally で必ず Blob URL を解放し、overlay に URL を残さない（#4645）。track / cover で
+// 同型の try/finally を重複させると、片方だけ解放漏れする退行を招くため共有する。
+async function sendAndRevoke(
+  channel: InjectChannel,
+  asset: AssetHandle,
+  send: (asset: BlobAssetReference) => Promise<void>
+): Promise<void> {
+  try {
+    if (channel.isStopped()) {
+      return;
+    }
+    await send(asset);
+  } finally {
+    asset.revoke();
+  }
+}
+
 // 注入を逐次実行する。停止要求はループ境界と各 send 直前で確認し、確認後は以降の送信を
 // 打ち切る（return）。fetch 中の停止に備えて send 直前で再チェックするのが停止 race 修正の核。
 export async function runInjection(
@@ -50,12 +69,8 @@ export async function runInjection(
     const track = release.tracks[i];
     channel.setMessage(`アセットを取得中: ${track.filename}`);
     const asset = await channel.fetchAsset(track.asset_path, track.filename);
-    try {
-      if (channel.isStopped()) return;
-      await channel.track(i, asset);
-    } finally {
-      asset.revoke();
-    }
+    // fetch 中に停止された場合は send せずに解放し、次のループ境界で return する。
+    await sendAndRevoke(channel, asset, (handle) => channel.track(i, handle));
   }
 
   if (channel.isStopped()) {
@@ -67,12 +82,7 @@ export async function runInjection(
       release.cover.asset_path,
       release.cover.filename
     );
-    try {
-      if (channel.isStopped()) return;
-      await channel.cover(asset);
-    } finally {
-      asset.revoke();
-    }
+    await sendAndRevoke(channel, asset, (handle) => channel.cover(handle));
   }
 
   if (channel.isStopped()) {

--- a/extensions/distrokid-helper/lib/inject-session.ts
+++ b/extensions/distrokid-helper/lib/inject-session.ts
@@ -9,7 +9,6 @@
 // エラーは握りつぶさず throw する。content は onMessage handler でそのまま伝播させ、
 // @webext-core/messaging が overlay 側の sendMessage を reject する（fail-loud）。
 
-import { decodeAsset, type SerializedAsset } from "./asset-transfer";
 import { PHASES, type Phase } from "./messaging";
 import type { ReleasePayload } from "./types";
 
@@ -44,21 +43,21 @@ export class InjectSession {
     this.payload = payload;
   }
 
-  track(trackIndex: number, asset: SerializedAsset): void {
+  track(trackIndex: number, file: File): void {
     const { tracks } = this.requirePayload().release;
     if (trackIndex < 0 || trackIndex >= tracks.length) {
       throw new Error(
         `trackIndex が範囲外です: ${trackIndex}（tracks=${tracks.length}）`
       );
     }
-    this.report(PHASES.INJECTING, `曲ファイルを注入中: ${asset.filename}`);
-    this.injector.injectTrackFile(trackIndex, decodeAsset(asset));
+    this.report(PHASES.INJECTING, `曲ファイルを注入中: ${file.name}`);
+    this.injector.injectTrackFile(trackIndex, file);
   }
 
-  cover(asset: SerializedAsset): void {
+  cover(file: File): void {
     this.requirePayload();
-    this.report(PHASES.INJECTING, `ジャケットを注入中: ${asset.filename}`);
-    this.injector.injectCover(decodeAsset(asset));
+    this.report(PHASES.INJECTING, `ジャケットを注入中: ${file.name}`);
+    this.injector.injectCover(file);
   }
 
   async finish(): Promise<void> {

--- a/extensions/distrokid-helper/lib/local-fetch.ts
+++ b/extensions/distrokid-helper/lib/local-fetch.ts
@@ -1,5 +1,3 @@
-import { encodeAsset, type SerializedAsset } from "./asset-transfer";
-
 export interface LocalFetchRequest {
   url: string;
 }
@@ -11,9 +9,18 @@ export interface LocalFetchTextResponse {
   statusText: string;
 }
 
-export interface LocalFetchAssetRequest extends LocalFetchRequest {
-  filename: string;
+export interface LocalFetchAssetChunkRequest extends LocalFetchRequest {
+  offset: number;
 }
+
+export interface LocalFetchAssetChunkResponse {
+  base64: string;
+  contentType: string;
+  totalSize: number;
+}
+
+export const ASSET_CHUNK_SIZE = 4 * 1024 * 1024;
+const assetCache = new Map<string, Promise<Blob>>();
 
 function assertLoopbackHttpUrl(value: string): URL {
   const url = new URL(value);
@@ -51,12 +58,48 @@ export async function fetchLocalText(
   };
 }
 
-export async function fetchLocalAsset(
-  request: LocalFetchAssetRequest
-): Promise<SerializedAsset> {
-  const response = await fetchLoopback(request.url);
-  if (!response.ok) {
-    throw new Error(`asset fetch failed: HTTP ${response.status}`);
+function bytesToBase64(bytes: Uint8Array): string {
+  const chunks: string[] = [];
+  for (let offset = 0; offset < bytes.length; offset += 0x8000) {
+    chunks.push(
+      String.fromCharCode(...bytes.subarray(offset, offset + 0x8000))
+    );
   }
-  return encodeAsset(request.filename, await response.blob());
+  return btoa(chunks.join(""));
+}
+
+async function loadAsset(url: string): Promise<Blob> {
+  const response = await fetchLoopback(url);
+  if (!response.ok)
+    throw new Error(`asset fetch failed: HTTP ${response.status}`);
+  return response.blob();
+}
+
+export async function fetchLocalAssetChunk(
+  request: LocalFetchAssetChunkRequest
+): Promise<LocalFetchAssetChunkResponse> {
+  if (!Number.isSafeInteger(request.offset) || request.offset < 0) {
+    throw new Error("asset chunk offset must be a non-negative integer");
+  }
+  const key = assertLoopbackHttpUrl(request.url).href;
+  const pending = assetCache.get(key) ?? loadAsset(key);
+  assetCache.set(key, pending);
+  try {
+    const blob = await pending;
+    if (request.offset > blob.size)
+      throw new Error("asset chunk offset exceeds asset size");
+    const end = Math.min(request.offset + ASSET_CHUNK_SIZE, blob.size);
+    const bytes = new Uint8Array(
+      await blob.slice(request.offset, end).arrayBuffer()
+    );
+    if (end >= blob.size) assetCache.delete(key);
+    return {
+      base64: bytesToBase64(bytes),
+      contentType: blob.type,
+      totalSize: blob.size,
+    };
+  } catch (error) {
+    assetCache.delete(key);
+    throw error;
+  }
 }

--- a/extensions/distrokid-helper/lib/messaging.ts
+++ b/extensions/distrokid-helper/lib/messaging.ts
@@ -4,8 +4,9 @@
 // 3 者が解釈を共有する進捗フェーズは PHASES で固定する（状態の正規化）。
 //
 // asset（曲 / ジャケット）は 1 メッセージ 1 件で per-track 分割して送る（#871）。
-// 全 track を 1 メッセージにまとめると Base64 化後のバイト列が chrome.tabs.sendMessage の
-// 64MiB 上限を超えるため、overlay・runner とも常時 1 asset 分のみメモリ保持する設計にする。
+// overlay・runner とも常時 1 asset 分のみメモリ保持する設計にする。
+// メッセージが運ぶのは Blob URL 参照だけで、asset 本体は chrome.tabs.sendMessage の
+// 64MiB 上限がある境界を跨がせない（#4645。取得は fetchLocalAssetChunk の chunk 往復）。
 
 import { defineExtensionMessaging } from "@webext-core/messaging";
 
@@ -36,7 +37,8 @@ export interface InjectStartRequest {
 }
 
 // overlay -> runner: 1 track の曲ファイルを注入する。
-// asset は overlay 側で fetch 済みのものを直列化して渡す（asset-transfer.ts 参照）。
+// asset は overlay 側で fetch 済みの Blob を指す URL 参照で渡し、runner が File へ復元する
+// （asset-transfer.ts 参照）。
 // trackIndex は payload.release.tracks の 0-indexed 位置。
 // fetchAsset は取得失敗時に throw する（null を返さない）ため asset に欠落は生じない。
 export interface InjectTrackRequest {

--- a/extensions/distrokid-helper/lib/messaging.ts
+++ b/extensions/distrokid-helper/lib/messaging.ts
@@ -10,9 +10,9 @@
 import { defineExtensionMessaging } from "@webext-core/messaging";
 
 import type { DistrokidReleaseRecord } from "../../shared/api";
-import type { SerializedAsset } from "./asset-transfer";
 import type {
-  LocalFetchAssetRequest,
+  LocalFetchAssetChunkRequest,
+  LocalFetchAssetChunkResponse,
   LocalFetchRequest,
   LocalFetchTextResponse,
 } from "./local-fetch";
@@ -41,12 +41,17 @@ export interface InjectStartRequest {
 // fetchAsset は取得失敗時に throw する（null を返さない）ため asset に欠落は生じない。
 export interface InjectTrackRequest {
   trackIndex: number;
-  asset: SerializedAsset;
+  asset: BlobAssetReference;
 }
 
 // overlay -> runner: ジャケットを注入する（release.cover !== null のときのみ送信）。
 export interface InjectCoverRequest {
-  asset: SerializedAsset;
+  asset: BlobAssetReference;
+}
+
+export interface BlobAssetReference {
+  filename: string;
+  blobUrl: string;
 }
 
 // runner -> overlay の進捗通知。
@@ -63,7 +68,9 @@ export interface ProtocolMap {
   // overlay -> background: HTTPS page から直接読めない loopback HTTP JSON を取得する。
   fetchLocalText(request: LocalFetchRequest): LocalFetchTextResponse;
   // overlay -> background: loopback HTTP asset を1件ずつ取得・直列化する。
-  fetchLocalAsset(request: LocalFetchAssetRequest): SerializedAsset;
+  fetchLocalAssetChunk(
+    request: LocalFetchAssetChunkRequest
+  ): LocalFetchAssetChunkResponse;
   // overlay -> runner: テキスト / SELECT 系を一括注入し、セッションを開始する。
   injectStart(request: InjectStartRequest): void;
   // overlay -> runner: 1 track の曲ファイルを注入する。

--- a/extensions/distrokid-helper/package.json
+++ b/extensions/distrokid-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "distrokid-helper",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "description": "DistroKid 登録フォーム自動入力 Chrome 拡張 (WXT + React)",
   "type": "module",

--- a/extensions/distrokid-helper/tests/api.test.ts
+++ b/extensions/distrokid-helper/tests/api.test.ts
@@ -20,10 +20,8 @@ import {
 import {
   fetchRelease,
   fetchCollectionRelease,
-  fetchAsset,
   ReleaseUnavailableError,
 } from "../lib/api";
-import { decodeAsset } from "../lib/asset-transfer";
 import type { ReleasePayload } from "../lib/types";
 
 const SAMPLE_PAYLOAD: ReleasePayload = {
@@ -66,14 +64,6 @@ function jsonResponse(status: number, body: unknown): Response {
     ok: status >= 200 && status < 300,
     status,
     json: async () => body,
-  } as unknown as Response;
-}
-
-function blobResponse(status: number, blob: Blob): Response {
-  return {
-    ok: status >= 200 && status < 300,
-    status,
-    blob: async () => blob,
   } as unknown as Response;
 }
 
@@ -302,67 +292,6 @@ describe("fetchCollectionRelease", () => {
     );
     await expect(promise).rejects.toThrow();
     await expect(promise).rejects.not.toBeInstanceOf(ReleaseUnavailableError);
-  });
-});
-
-describe("fetchAsset", () => {
-  it("asset を取得し filename / MIME 型 / base64 を持つ SerializedAsset を返す", async () => {
-    // Given: audio/mpeg の blob を返すサーバー
-    const blob = new Blob(["abc"], { type: "audio/mpeg" });
-    fetchMock.mockResolvedValue(blobResponse(200, blob));
-
-    // When
-    const asset = await fetchAsset(
-      "http://localhost:7873",
-      "/distrokid/assets/track-01.mp3",
-      "track-01.mp3"
-    );
-
-    // Then: 転送用に直列化されている（File ではなく base64）
-    expect(asset.filename).toBe("track-01.mp3");
-    expect(asset.mimeType).toBe("audio/mpeg");
-    expect(asset.base64).toBe(btoa("abc"));
-
-    // Then: content 側 decodeAsset で元バイト列の File に復元できる
-    const file = decodeAsset(asset);
-    expect(file).toBeInstanceOf(File);
-    expect(file.name).toBe("track-01.mp3");
-    expect(file.type).toBe("audio/mpeg");
-    expect(file.size).toBe(3);
-  });
-
-  it("asset_path は接頭辞込みのため baseUrl と連結して fetch する", async () => {
-    // Given
-    const blob = new Blob(["x"], { type: "image/png" });
-    fetchMock.mockResolvedValue(blobResponse(200, blob));
-
-    // When
-    await fetchAsset(
-      "http://localhost:7873/",
-      "/distrokid/assets/main.png",
-      "main.png"
-    );
-
-    // Then: 末尾スラッシュ正規化 + asset_path 連結（二重スラッシュ無し）
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:7873/distrokid/assets/main.png",
-      expect.anything()
-    );
-  });
-
-  it("非 OK では Error を throw する", async () => {
-    // Given
-    const blob = new Blob([""], { type: "application/octet-stream" });
-    fetchMock.mockResolvedValue(blobResponse(404, blob));
-
-    // When / Then
-    await expect(
-      fetchAsset(
-        "http://localhost:7873",
-        "/distrokid/assets/missing.mp3",
-        "missing.mp3"
-      )
-    ).rejects.toThrow();
   });
 });
 

--- a/extensions/distrokid-helper/tests/api.test.ts
+++ b/extensions/distrokid-helper/tests/api.test.ts
@@ -8,8 +8,8 @@
 // 設計契約（draft が実装する前提）:
 //   - fetchRelease(baseUrl): 200 で ReleasePayload を返す。404 は ReleaseUnavailableError（要件 #16）。
 //     その他の非 OK は汎用 Error。baseUrl 末尾スラッシュは正規化して二重スラッシュを作らない。
-//   - fetchAsset(baseUrl, assetPath, filename): blob を取得し SerializedAsset
-//     （filename / mimeType / base64）を返す。content へは直列化して転送する（CORS 回避）。
+//   - asset は API client を通さず background の chunk 取得（lib/background-fetch.ts）で運ぶ。
+//     一括 base64 直列化は 64MiB messaging 上限に当たるため撤去した（#4645）。
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 

--- a/extensions/distrokid-helper/tests/asset-transfer.test.ts
+++ b/extensions/distrokid-helper/tests/asset-transfer.test.ts
@@ -1,70 +1,38 @@
-// `lib/asset-transfer.ts` の直列化契約テスト。
-//
-// asset fetch は popup 側（`chrome-extension://` origin）で行い、取得した File を base64 で
-// content へ転送して復元する（SUP-NEW-asset-fetch-cors の修正）。#896 でサーバーが
-// distrokid.com origin もデフォルト許可したが、content script fetch への書き換えは
-// #896 のスコープ外のため popup fetch 構成を維持する。
-// ここでは「転送往復でバイト列が壊れないこと」と「fetch 経路が content に残っていないこと」を固定する。
-
+// Blob URL を content 側で File に復元する境界の契約テスト。
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { encodeAsset, decodeAsset } from "../lib/asset-transfer";
+import { blobUrlToFile } from "../lib/asset-transfer";
 
 const here = dirname(fileURLToPath(import.meta.url));
+afterEach(() => vi.unstubAllGlobals());
 
-describe("encodeAsset / decodeAsset 往復", () => {
-  it("バイナリ全域（0..255）を往復しても完全一致する", async () => {
-    // Given: 非 ASCII を含む全バイト値の blob（base64 化で壊れやすい領域）
-    const original = new Uint8Array(256);
-    for (let i = 0; i < 256; i += 1) {
-      original[i] = i;
-    }
-    const blob = new Blob([original], { type: "image/png" });
-
-    // When: popup 側で直列化 → content 側で復元
-    const serialized = await encodeAsset("main.png", blob);
-    const file = decodeAsset(serialized);
-
-    // Then: メタと全バイトが保たれる
-    expect(file.name).toBe("main.png");
-    expect(file.type).toBe("image/png");
-    const restored = new Uint8Array(await file.arrayBuffer());
-    expect(Array.from(restored)).toEqual(Array.from(original));
+describe("Blob URL asset transfer", () => {
+  it("Blob URL の byte と metadata を File に復元する", async () => {
+    const original = Uint8Array.from({ length: 256 }, (_, index) => index);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(original, { headers: { "Content-Type": "audio/flac" } })
+      )
+    );
+    const file = await blobUrlToFile("blob:track", "track.flac");
+    expect(file.name).toBe("track.flac");
+    expect(file.type).toBe("audio/flac");
+    expect(new Uint8Array(await file.arrayBuffer())).toEqual(original);
   });
 
-  it("CHUNK 境界（0x8000）を跨ぐサイズでも壊れない", async () => {
-    // Given: bytesToBase64 の chunk 処理が複数回走るサイズ
-    const size = 0x8000 * 2 + 123;
-    const original = new Uint8Array(size);
-    for (let i = 0; i < size; i += 1) {
-      original[i] = i % 256;
-    }
-    const blob = new Blob([original], { type: "audio/mpeg" });
-
-    // When
-    const file = decodeAsset(await encodeAsset("track-01.mp3", blob));
-
-    // Then
-    const restored = new Uint8Array(await file.arrayBuffer());
-    expect(restored.length).toBe(size);
-    expect(Array.from(restored)).toEqual(Array.from(original));
-  });
-});
-
-describe("fetch 経路の境界（CORS 回帰防止）", () => {
-  // content script は asset を直接 fetch してはならない（ページ origin で CORS 遮断されるため）。
-  // popup 側で fetch した直列化 asset を受け取るだけにする。
-  it("content.ts は API client を import せず fetch も呼ばない", () => {
+  it("content.ts は API client と base64 経路を持たない", () => {
     const source = readFileSync(
       join(here, "..", "entrypoints", "content.ts"),
       "utf8"
     );
     expect(source).not.toContain("@/lib/api");
-    expect(source).not.toContain("fetchAsset");
+    expect(source).not.toContain("base64");
     expect(source).not.toMatch(/\bfetch\s*\(/);
   });
 });

--- a/extensions/distrokid-helper/tests/background-fetch.test.ts
+++ b/extensions/distrokid-helper/tests/background-fetch.test.ts
@@ -75,23 +75,39 @@ describe("background fetch adapter", () => {
     }
   );
 
-  it("relays one asset request and returns the serialized wire unchanged", async () => {
-    const wire = {
-      filename: "track.mp3",
-      mimeType: "audio/mpeg",
-      base64: "AQID",
-    };
-    vi.mocked(sendMessage).mockResolvedValueOnce(wire);
-
-    await expect(
-      backgroundFetchAsset(
-        "http://localhost:7873/distrokid/assets/track.mp3",
-        "track.mp3"
-      )
-    ).resolves.toBe(wire);
-    expect(sendMessage).toHaveBeenCalledWith("fetchLocalAsset", {
-      url: "http://localhost:7873/distrokid/assets/track.mp3",
-      filename: "track.mp3",
+  it("assembles chunks into a Blob URL and exposes an explicit revoke handle", async () => {
+    vi.stubGlobal("URL", {
+      createObjectURL: vi.fn(() => "blob:asset"),
+      revokeObjectURL: vi.fn(),
     });
+    vi.mocked(sendMessage)
+      .mockResolvedValueOnce({
+        base64: "AQI=",
+        contentType: "audio/mpeg",
+        totalSize: 3,
+      })
+      .mockResolvedValueOnce({
+        base64: "Aw==",
+        contentType: "audio/mpeg",
+        totalSize: 3,
+      });
+    const handle = await backgroundFetchAsset(
+      "http://localhost:7873/track.mp3",
+      "track.mp3"
+    );
+    expect(handle).toMatchObject({
+      filename: "track.mp3",
+      blobUrl: "blob:asset",
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(1, "fetchLocalAssetChunk", {
+      url: "http://localhost:7873/track.mp3",
+      offset: 0,
+    });
+    expect(sendMessage).toHaveBeenNthCalledWith(2, "fetchLocalAssetChunk", {
+      url: "http://localhost:7873/track.mp3",
+      offset: 2,
+    });
+    handle.revoke();
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith("blob:asset");
   });
 });

--- a/extensions/distrokid-helper/tests/content-entrypoint.test.ts
+++ b/extensions/distrokid-helper/tests/content-entrypoint.test.ts
@@ -58,6 +58,10 @@ describe("distrokid content entrypoint", () => {
 
   it("registers exact handlers, preserves payloads/order, and relays progress", async () => {
     vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new Blob(["asset"])))
+    );
+    vi.stubGlobal(
       "defineContentScript",
       (definition: typeof contentMocks.definition) => {
         contentMocks.definition = definition;
@@ -75,23 +79,28 @@ describe("distrokid content entrypoint", () => {
       "stop",
     ]);
     const payload = { release: { tracks: [] } };
-    const trackAsset = { filename: "track.mp3", base64: "AQID" };
-    const coverAsset = { filename: "main.png", base64: "BAUG" };
+    const trackAsset = { filename: "track.mp3", blobUrl: "blob:track" };
+    const coverAsset = { filename: "main.png", blobUrl: "blob:cover" };
     await contentMocks.handlers.get("injectStart")!({
       data: { payload },
     });
-    contentMocks.handlers.get("injectTrack")!({
+    await contentMocks.handlers.get("injectTrack")!({
       data: { trackIndex: 2, asset: trackAsset },
     });
-    contentMocks.handlers.get("injectCover")!({
+    await contentMocks.handlers.get("injectCover")!({
       data: { asset: coverAsset },
     });
     await contentMocks.handlers.get("injectFinish")!();
     contentMocks.handlers.get("stop")!();
 
     expect(contentMocks.start).toHaveBeenCalledWith(payload);
-    expect(contentMocks.track).toHaveBeenCalledWith(2, trackAsset);
-    expect(contentMocks.cover).toHaveBeenCalledWith(coverAsset);
+    expect(contentMocks.track).toHaveBeenCalledWith(
+      2,
+      expect.objectContaining({ name: "track.mp3" })
+    );
+    expect(contentMocks.cover).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "main.png" })
+    );
     expect(contentMocks.finish).toHaveBeenCalledOnce();
     expect(contentMocks.stop).toHaveBeenCalledOnce();
     expect(contentMocks.start.mock.invocationCallOrder[0]).toBeLessThan(
@@ -121,6 +130,10 @@ describe("distrokid content entrypoint", () => {
     "stop",
   ])("propagates %s handler rejection to the message caller", async (name) => {
     vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(new Blob(["asset"])))
+    );
+    vi.stubGlobal(
       "defineContentScript",
       (definition: typeof contentMocks.definition) => {
         contentMocks.definition = definition;
@@ -142,7 +155,7 @@ describe("distrokid content entrypoint", () => {
       data: {
         payload: {},
         trackIndex: 0,
-        asset: { filename: "asset" },
+        asset: { filename: "asset", blobUrl: "blob:asset" },
       },
     });
     await expect(Promise.resolve(result)).rejects.toThrow(`${name} rejected`);

--- a/extensions/distrokid-helper/tests/inject-runner.test.ts
+++ b/extensions/distrokid-helper/tests/inject-runner.test.ts
@@ -7,7 +7,6 @@
 
 import { describe, it, expect } from "vitest";
 
-import type { SerializedAsset } from "../lib/asset-transfer";
 import { runInjection, type InjectChannel } from "../lib/inject-runner";
 import type { ReleasePayload } from "../lib/types";
 
@@ -61,15 +60,21 @@ function makeChannel(options?: { onFetch?: (assetPath: string) => void }): {
   calls: ChannelCall[];
   fetched: string[];
   stop: () => void;
+  revoked: string[];
 } {
   const calls: ChannelCall[] = [];
   const fetched: string[] = [];
+  const revoked: string[] = [];
   let stopped = false;
   const channel: InjectChannel = {
-    fetchAsset: async (assetPath, filename): Promise<SerializedAsset> => {
+    fetchAsset: async (assetPath, filename) => {
       fetched.push(assetPath);
       options?.onFetch?.(assetPath);
-      return { filename, mimeType: "audio/mpeg", base64: btoa("audio") };
+      return {
+        filename,
+        blobUrl: `blob:${filename}`,
+        revoke: () => revoked.push(filename),
+      };
     },
     start: async (payload) => {
       calls.push({ kind: "start", trackIndex: payload.release.tracks.length });
@@ -90,6 +95,7 @@ function makeChannel(options?: { onFetch?: (assetPath: string) => void }): {
     channel,
     calls,
     fetched,
+    revoked,
     stop: () => {
       stopped = true;
     },
@@ -99,7 +105,7 @@ function makeChannel(options?: { onFetch?: (assetPath: string) => void }): {
 describe("runInjection", () => {
   it("start → track*N → cover → finish の順で送信する", async () => {
     // Given: 2 track + cover あり
-    const { channel, calls } = makeChannel();
+    const { channel, calls, revoked } = makeChannel();
 
     // When
     await runInjection(makePayload(2, true), channel);
@@ -112,6 +118,7 @@ describe("runInjection", () => {
       { kind: "cover", filename: "main.png" },
       { kind: "finish" },
     ]);
+    expect(revoked).toEqual(["track-01.mp3", "track-02.mp3", "main.png"]);
   });
 
   it("cover が null なら cover を送らず finish に進む", async () => {
@@ -236,7 +243,7 @@ describe("runInjection", () => {
           const step = filename === "main.png" ? "coverFetch" : "trackFetch";
           events.push(`fetch:${filename}`);
           if (failure === step) throw new Error(`${failure} failed`);
-          return { filename, mimeType: "audio/mpeg", base64: "AQID" };
+          return { filename, blobUrl: `blob:${filename}`, revoke: () => {} };
         },
         track: async () => rejectAt("track"),
         cover: async () => rejectAt("cover"),

--- a/extensions/distrokid-helper/tests/inject-runner.test.ts
+++ b/extensions/distrokid-helper/tests/inject-runner.test.ts
@@ -185,10 +185,21 @@ describe("runInjection", () => {
     expect(made.fetched).toEqual([]);
   });
 
+  // 失敗系でも fetch 済み asset は必ず解放される。revoke も events に混ぜて記録し、
+  // 「送信が reject した直後に revoke される」順序ごと固定する（finally 除去の退行検出）。
   it.each([
     ["start", ["start"]],
     ["trackFetch", ["start", "message:track-01.mp3", "fetch:track-01.mp3"]],
-    ["track", ["start", "message:track-01.mp3", "fetch:track-01.mp3", "track"]],
+    [
+      "track",
+      [
+        "start",
+        "message:track-01.mp3",
+        "fetch:track-01.mp3",
+        "track",
+        "revoke:track-01.mp3",
+      ],
+    ],
     [
       "coverFetch",
       [
@@ -196,6 +207,7 @@ describe("runInjection", () => {
         "message:track-01.mp3",
         "fetch:track-01.mp3",
         "track",
+        "revoke:track-01.mp3",
         "message:main.png",
         "fetch:main.png",
       ],
@@ -207,9 +219,11 @@ describe("runInjection", () => {
         "message:track-01.mp3",
         "fetch:track-01.mp3",
         "track",
+        "revoke:track-01.mp3",
         "message:main.png",
         "fetch:main.png",
         "cover",
+        "revoke:main.png",
       ],
     ],
     [
@@ -219,14 +233,16 @@ describe("runInjection", () => {
         "message:track-01.mp3",
         "fetch:track-01.mp3",
         "track",
+        "revoke:track-01.mp3",
         "message:main.png",
         "fetch:main.png",
         "cover",
+        "revoke:main.png",
         "finish",
       ],
     ],
   ] as const)(
-    "propagates a %s rejection and performs no later message or side effect",
+    "propagates a %s rejection, revokes fetched assets, and performs no later message or side effect",
     async (failure, expectedEvents) => {
       const events: string[] = [];
       const rejectAt = async (name: string): Promise<void> => {
@@ -243,7 +259,11 @@ describe("runInjection", () => {
           const step = filename === "main.png" ? "coverFetch" : "trackFetch";
           events.push(`fetch:${filename}`);
           if (failure === step) throw new Error(`${failure} failed`);
-          return { filename, blobUrl: `blob:${filename}`, revoke: () => {} };
+          return {
+            filename,
+            blobUrl: `blob:${filename}`,
+            revoke: () => events.push(`revoke:${filename}`),
+          };
         },
         track: async () => rejectAt("track"),
         cover: async () => rejectAt("cover"),

--- a/extensions/distrokid-helper/tests/inject-session.test.ts
+++ b/extensions/distrokid-helper/tests/inject-session.test.ts
@@ -5,7 +5,6 @@
 
 import { describe, it, expect, beforeEach } from "vitest";
 
-import type { SerializedAsset } from "../lib/asset-transfer";
 import {
   InjectSession,
   type Injector,
@@ -49,8 +48,8 @@ function makePayload(trackCount: number): ReleasePayload {
   };
 }
 
-function makeAsset(filename: string): SerializedAsset {
-  return { filename, mimeType: "audio/mpeg", base64: btoa("audio") };
+function makeAsset(filename: string): File {
+  return new File(["audio"], filename, { type: "audio/mpeg" });
 }
 
 interface InjectorCall {

--- a/extensions/distrokid-helper/tests/large-asset-injection.test.ts
+++ b/extensions/distrokid-helper/tests/large-asset-injection.test.ts
@@ -1,0 +1,283 @@
+// 64 MiB 超 asset を注入経路へ通す end-to-end 契約テスト（#4645）。
+//
+// 音源バイト列は 64MiB 上限のある境界を 3 回跨ぐ（background -> overlay の asset 応答、
+// overlay -> background の injectTrack、background -> content の同一タブ relay）。
+// 本テストは local-fetch（chunk 切り出し）-> background-fetch（Blob URL 組み立て）->
+// inject-runner（Blob URL の relay）-> asset-transfer（File 復元）を実物のまま繋ぎ、
+//
+//   1. 送信される全メッセージの JSON 直列化サイズが上限未満であること
+//   2. 往復後のバイト列が元 asset と完全一致すること
+//   3. 生成した Blob URL が漏れなく revoke されること（復元より後に）
+//
+// を大きい素材で固定する。asset 本体を injectTrack へ巻き戻す退行（51.2 MiB の FLAC で
+// 配信が全停止した元インシデント）や ASSET_CHUNK_SIZE の過大化はここで落ちる。
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { blobUrlToFile } from "../lib/asset-transfer";
+import { backgroundFetchAsset } from "../lib/background-fetch";
+import { runInjection, type InjectChannel } from "../lib/inject-runner";
+import { ASSET_CHUNK_SIZE } from "../lib/local-fetch";
+import type { ReleasePayload } from "../lib/types";
+
+// chrome の messaging 上限（"Message exceeded maximum allowed size of 64MiB."）。
+const MESSAGE_LIMIT = 64 * 1024 * 1024;
+// 上限を 1 byte 超える素材。base64 一括経路なら 1 メッセージが必ず上限を超える。
+const HUGE_ASSET_SIZE = MESSAGE_LIMIT + 1;
+// base64 は 3 byte -> 4 文字。1 chunk 応答の理論上限に metadata 分の余白を足す。
+const CHUNK_MESSAGE_LIMIT = Math.ceil(ASSET_CHUNK_SIZE / 3) * 4 + 1024;
+// Blob URL 参照だけを運ぶ注入メッセージの上限（asset 本体が混ざれば即座に超える）。
+const REFERENCE_MESSAGE_LIMIT = 1024;
+// track は chunk 分割され、cover（256 byte）は 1 chunk で収まる。
+const TRACK_CHUNKS = Math.ceil(HUGE_ASSET_SIZE / ASSET_CHUNK_SIZE);
+const EXPECTED_CHUNK_RESPONSES = TRACK_CHUNKS + 1;
+
+const SERVER_URL = "http://localhost:7873";
+const TRACK_PATH = "/distrokid/assets/track-01.flac";
+const COVER_PATH = "/distrokid/assets/main.png";
+
+interface WireMessage {
+  type: string;
+  bytes: number;
+}
+
+interface ChunkRequest {
+  url: string;
+  offset: number;
+}
+
+interface ServedAsset {
+  bytes: Uint8Array;
+  contentType: string;
+}
+
+interface AssetMessage {
+  trackIndex?: number;
+  asset: { filename: string; blobUrl: string };
+}
+
+interface BrowserBoundary {
+  createdUrls: string[];
+  revokedUrls: string[];
+  liveUrls: Map<string, Blob>;
+}
+
+// overlay が跨ぐ全境界のメッセージを JSON 直列化サイズで記録する。
+// vi.mock の factory は module import 時に走るため vi.hoisted に置く。
+const wire = vi.hoisted(() => {
+  const messages: WireMessage[] = [];
+  return {
+    messages,
+    record(type: string, payload: unknown): void {
+      const json = JSON.stringify(payload);
+      messages.push({ type, bytes: new TextEncoder().encode(json).length });
+    },
+  };
+});
+
+// background service worker 境界。overlay の sendMessage を実 handler へ直結し、
+// 往復する chunk メッセージの実サイズを測る。
+vi.mock("../lib/messaging", () => ({
+  sendMessage: async (type: string, request: ChunkRequest) => {
+    const { fetchLocalAssetChunk } = await import("../lib/local-fetch");
+    wire.record(type, request);
+    const chunk = await fetchLocalAssetChunk(request);
+    wire.record(`${type}:response`, chunk);
+    return chunk;
+  },
+}));
+
+// Chrome が提供する 2 つの境界（Blob URL の台帳と loopback fetch）を差し替える。
+// URL は subclass で差し替え、`new URL()` の解釈（loopback 判定）は実物のまま保つ。
+function installBrowserBoundary(
+  assets: Map<string, ServedAsset>
+): BrowserBoundary {
+  const liveUrls = new Map<string, Blob>();
+  const createdUrls: string[] = [];
+  const revokedUrls: string[] = [];
+
+  class StubURL extends URL {
+    static override createObjectURL(object: Blob): string {
+      const url = `blob:${SERVER_URL}/${createdUrls.length + 1}`;
+      liveUrls.set(url, object);
+      createdUrls.push(url);
+      return url;
+    }
+
+    static override revokeObjectURL(url: string): void {
+      liveUrls.delete(url);
+      revokedUrls.push(url);
+    }
+  }
+  vi.stubGlobal("URL", StubURL);
+
+  vi.stubGlobal("fetch", async (input: string | URL | Request) => {
+    const href = resolveHref(input);
+    if (href.startsWith("blob:")) {
+      const blob = liveUrls.get(href);
+      // revoke 済み / 未登録なら content 側の復元失敗として顕在化させる。
+      if (!blob) {
+        throw new TypeError(`blob URL is not live: ${href}`);
+      }
+      return new Response(blob, { headers: { "Content-Type": blob.type } });
+    }
+    const asset = assets.get(new URL(href).pathname);
+    if (!asset) {
+      return new Response("not found", { status: 404 });
+    }
+    return new Response(asset.bytes, {
+      status: 200,
+      headers: { "Content-Type": asset.contentType },
+    });
+  });
+
+  return { createdUrls, revokedUrls, liveUrls };
+}
+
+function resolveHref(input: string | URL | Request): string {
+  if (typeof input === "string") {
+    return input;
+  }
+  return input instanceof Request ? input.url : input.href;
+}
+
+function messagesAtLeast(messages: WireMessage[], limit: number) {
+  return messages.filter((message) => message.bytes >= limit);
+}
+
+function isChunkResponse(message: WireMessage): boolean {
+  return message.type === "fetchLocalAssetChunk:response";
+}
+
+function isAssetReference(message: WireMessage): boolean {
+  return message.type === "injectTrack" || message.type === "injectCover";
+}
+
+// 0..255 全域を巡回させ、chunk 境界での byte 取りこぼし・ずれを検出可能にする。
+function makeSource(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  for (let index = 0; index < size; index += 1) {
+    bytes[index] = index % 256;
+  }
+  return bytes;
+}
+
+// 不一致の先頭 index を返す（一致なら -1）。64 MiB の差分表示を避け index で比べる。
+function firstMismatch(actual: Uint8Array, expected: Uint8Array): number {
+  if (actual.length !== expected.length) {
+    return Math.min(actual.length, expected.length);
+  }
+  for (let index = 0; index < expected.length; index += 1) {
+    if (actual[index] !== expected[index]) {
+      return index;
+    }
+  }
+  return -1;
+}
+
+function makePayload(): ReleasePayload {
+  return {
+    profile: {
+      artist: "Test Artist",
+      language: "ja",
+      main_genre: "Electronic",
+      sub_genre: null,
+      songwriter: null,
+      ai_disclosure: {
+        enabled: true,
+        lyrics: false,
+        music: true,
+        recording_scope: "full",
+        partial_audio_type: null,
+        artist_persona: true,
+        apply_to_all: true,
+      },
+      credits: {
+        performer_role: "Audio",
+        producer_role: "Producer",
+      },
+    },
+    release: {
+      album_title: "Vol.79",
+      tracks: [
+        {
+          title: "Track 1",
+          filename: "track-01.flac",
+          asset_path: TRACK_PATH,
+        },
+      ],
+      cover: { filename: "main.png", asset_path: COVER_PATH },
+      release_date: "2026-07-01",
+    },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  wire.messages.length = 0;
+});
+
+describe("64MiB 超 asset の注入 end-to-end", () => {
+  it("上限未満のメッセージだけで byte 列を往復させ revoke する", async () => {
+    // Given: 上限を超える音源と小さいジャケットを配る loopback サーバー
+    const track = makeSource(HUGE_ASSET_SIZE);
+    const cover = makeSource(256);
+    const assets = new Map<string, ServedAsset>([
+      [TRACK_PATH, { bytes: track, contentType: "audio/flac" }],
+      [COVER_PATH, { bytes: cover, contentType: "image/png" }],
+    ]);
+    const boundary = installBrowserBoundary(assets);
+    const restored: { filename: string; bytes: Uint8Array }[] = [];
+    // content 側の File 復元まで実物を通す。
+    const receive = async (type: string, request: AssetMessage) => {
+      wire.record(type, request);
+      const { blobUrl, filename } = request.asset;
+      const file = await blobUrlToFile(blobUrl, filename);
+      const bytes = new Uint8Array(await file.arrayBuffer());
+      restored.push({ filename: file.name, bytes });
+    };
+    // overlay の実 channel 配線（components/useDistrokidRunner.ts）と同型にする。
+    const channel: InjectChannel = {
+      fetchAsset: (assetPath, filename) =>
+        backgroundFetchAsset(`${SERVER_URL}${assetPath}`, filename),
+      start: async (payload) => {
+        wire.record("injectStart", { payload });
+      },
+      track: (trackIndex, asset) =>
+        receive("injectTrack", { trackIndex, asset }),
+      cover: (asset) => receive("injectCover", { asset }),
+      finish: async () => {
+        wire.record("injectFinish", null);
+      },
+      setMessage: () => {},
+      isStopped: () => false,
+    };
+
+    // When
+    await runInjection(makePayload(), channel);
+
+    // Then: asset は chunk 分割で運ばれ、どのメッセージも上限に届かない
+    const chunkResponses = wire.messages.filter(isChunkResponse);
+    expect(chunkResponses).toHaveLength(EXPECTED_CHUNK_RESPONSES);
+    expect(messagesAtLeast(wire.messages, MESSAGE_LIMIT)).toEqual([]);
+    expect(messagesAtLeast(wire.messages, CHUNK_MESSAGE_LIMIT)).toEqual([]);
+
+    // Then: 注入メッセージは Blob URL 参照だけを運ぶ
+    const references = wire.messages.filter(isAssetReference);
+    expect(references).toHaveLength(2);
+    expect(messagesAtLeast(references, REFERENCE_MESSAGE_LIMIT)).toEqual([]);
+
+    // Then: content 側へ復元された byte 列が元 asset と一致する
+    expect(restored.map((entry) => entry.filename)).toEqual([
+      "track-01.flac",
+      "main.png",
+    ]);
+    expect(firstMismatch(restored[0].bytes, track)).toBe(-1);
+    expect(firstMismatch(restored[1].bytes, cover)).toBe(-1);
+
+    // Then: 生成した Blob URL は復元後に漏れなく revoke される
+    expect(boundary.createdUrls).toHaveLength(2);
+    expect(boundary.revokedUrls).toEqual(boundary.createdUrls);
+    expect(boundary.liveUrls.size).toBe(0);
+  }, 180_000);
+});

--- a/extensions/distrokid-helper/tests/large-asset-injection.test.ts
+++ b/extensions/distrokid-helper/tests/large-asset-injection.test.ts
@@ -47,7 +47,8 @@ interface ChunkRequest {
 }
 
 interface ServedAsset {
-  bytes: Uint8Array;
+  // Response の BodyInit は ArrayBuffer 裏付けの view だけを受ける（SharedArrayBuffer 不可）。
+  bytes: Uint8Array<ArrayBuffer>;
   contentType: string;
 }
 
@@ -154,7 +155,7 @@ function isAssetReference(message: WireMessage): boolean {
 }
 
 // 0..255 全域を巡回させ、chunk 境界での byte 取りこぼし・ずれを検出可能にする。
-function makeSource(size: number): Uint8Array {
+function makeSource(size: number): Uint8Array<ArrayBuffer> {
   const bytes = new Uint8Array(size);
   for (let index = 0; index < size; index += 1) {
     bytes[index] = index % 256;

--- a/extensions/distrokid-helper/tests/local-fetch.test.ts
+++ b/extensions/distrokid-helper/tests/local-fetch.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { fetchLocalAsset, fetchLocalText } from "../lib/local-fetch";
+import {
+  ASSET_CHUNK_SIZE,
+  fetchLocalAssetChunk,
+  fetchLocalText,
+} from "../lib/local-fetch";
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -63,29 +67,40 @@ describe("background local fetch boundary", () => {
     });
   });
 
-  it("asset を1件だけ base64 wire に変換する", async () => {
+  it("asset を固定長 chunk で往復し、境界・端数・全 byte 値を保持する", async () => {
+    const source = Uint8Array.from(
+      { length: ASSET_CHUNK_SIZE + 257 },
+      (_, index) => index % 256
+    );
     vi.stubGlobal(
       "fetch",
       vi.fn(
         async () =>
-          new Response(new Uint8Array([1, 2, 3]), {
+          new Response(source, {
             status: 200,
-            headers: { "Content-Type": "audio/mpeg" },
+            headers: { "Content-Type": "audio/flac" },
           })
       )
     );
 
-    await expect(
-      fetchLocalAsset({
-        url: "http://music.localhost:7873/distrokid/assets/track.mp3",
-        filename: "track.mp3",
-      })
-    ).resolves.toEqual({
-      base64: "AQID",
-      filename: "track.mp3",
-      mimeType: "audio/mpeg",
+    const first = await fetchLocalAssetChunk({
+      url: "http://localhost:7873/distrokid/assets/track.flac",
+      offset: 0,
     });
-  });
+    const last = await fetchLocalAssetChunk({
+      url: "http://localhost:7873/distrokid/assets/track.flac",
+      offset: ASSET_CHUNK_SIZE,
+    });
+    const decode = (value: string) =>
+      Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
+    const restored = new Uint8Array(source.length);
+    restored.set(decode(first.base64));
+    restored.set(decode(last.base64), ASSET_CHUNK_SIZE);
+    expect(restored).toEqual(source);
+    expect(first.base64.length).toBeLessThan(6 * 1024 * 1024);
+    expect(first.totalSize).toBe(source.length);
+    expect(last.contentType).toBe("audio/flac");
+  }, 60_000);
 
   it.each([404, 500])(
     "rejects a non-OK asset response: HTTP %i",
@@ -94,11 +109,10 @@ describe("background local fetch boundary", () => {
         "fetch",
         vi.fn(async () => new Response("failed", { status }))
       );
-
       await expect(
-        fetchLocalAsset({
-          url: "http://localhost:7873/distrokid/assets/track.mp3",
-          filename: "track.mp3",
+        fetchLocalAssetChunk({
+          url: `http://localhost:7873/distrokid/assets/${status}.mp3`,
+          offset: 0,
         })
       ).rejects.toThrow(`asset fetch failed: HTTP ${status}`);
     }

--- a/extensions/distrokid-helper/tests/messaging.test.ts
+++ b/extensions/distrokid-helper/tests/messaging.test.ts
@@ -9,7 +9,6 @@
 
 import { describe, it, expect } from "vitest";
 
-import type { SerializedAsset } from "../lib/asset-transfer";
 import { PHASES, sendMessage, onMessage } from "../lib/messaging";
 import type { InjectTrackRequest } from "../lib/messaging";
 
@@ -17,7 +16,8 @@ import type { InjectTrackRequest } from "../lib/messaging";
 // asset は injectTrack で 1 件ずつ送る。fetchAsset は取得失敗時に throw する（null を返さない）
 // ため asset は常に SerializedAsset で欠落しない。`SerializedAsset | null` へ退行させると
 // 下の代入が型エラーになり `pnpm compile`（tsc --noEmit）で検出される。
-const _trackAssetIsNonNull: SerializedAsset = {} as InjectTrackRequest["asset"];
+const _trackAssetIsNonNull: { filename: string; blobUrl: string } =
+  {} as InjectTrackRequest["asset"];
 void _trackAssetIsNonNull;
 
 describe("PHASES（PROGRESS フェーズ契約）", () => {

--- a/extensions/distrokid-helper/tests/messaging.test.ts
+++ b/extensions/distrokid-helper/tests/messaging.test.ts
@@ -14,8 +14,9 @@ import type { InjectTrackRequest } from "../lib/messaging";
 
 // #871 per-track 分割（コンパイル時契約）:
 // asset は injectTrack で 1 件ずつ送る。fetchAsset は取得失敗時に throw する（null を返さない）
-// ため asset は常に SerializedAsset で欠落しない。`SerializedAsset | null` へ退行させると
-// 下の代入が型エラーになり `pnpm compile`（tsc --noEmit）で検出される。
+// ため asset は常に BlobAssetReference（filename / blobUrl）で欠落しない。
+// `BlobAssetReference | null` へ退行させると下の代入が型エラーになり
+// `pnpm compile`（tsc --noEmit）で検出される。
 const _trackAssetIsNonNull: { filename: string; blobUrl: string } =
   {} as InjectTrackRequest["asset"];
 void _trackAssetIsNonNull;

--- a/extensions/distrokid-helper/tests/popup-compatibility.test.ts
+++ b/extensions/distrokid-helper/tests/popup-compatibility.test.ts
@@ -124,7 +124,6 @@ const discoveryMocks = vi.hoisted(() => ({
 vi.mock("../../shared/server-discovery", () => discoveryMocks);
 
 vi.mock("../lib/background-fetch", async () => {
-  const { encodeAsset } = await import("../lib/asset-transfer");
   return {
     backgroundFetch: (input: string | URL | Request, init?: RequestInit) =>
       init === undefined ? fetch(input) : fetch(input, init),
@@ -132,7 +131,7 @@ vi.mock("../lib/background-fetch", async () => {
       const response = await fetch(url, { method: "GET" });
       if (!response.ok)
         throw new Error(`asset fetch failed: HTTP ${response.status}`);
-      return encodeAsset(filename, await response.blob());
+      return { filename, blobUrl: `blob:${filename}`, revoke: () => {} };
     },
   };
 });

--- a/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
+++ b/extensions/distrokid-helper/tests/use-distrokid-runner.test.ts
@@ -110,7 +110,6 @@ const discoveryMocks = vi.hoisted(() => ({
 vi.mock("../../shared/server-discovery", () => discoveryMocks);
 
 vi.mock("../lib/background-fetch", async () => {
-  const { encodeAsset } = await import("../lib/asset-transfer");
   return {
     backgroundFetch: (input: string | URL | Request, init?: RequestInit) =>
       init === undefined ? fetch(input) : fetch(input, init),
@@ -118,7 +117,7 @@ vi.mock("../lib/background-fetch", async () => {
       const response = await fetch(url, { method: "GET" });
       if (!response.ok)
         throw new Error(`asset fetch failed: HTTP ${response.status}`);
-      return encodeAsset(filename, await response.blob());
+      return { filename, blobUrl: `blob:${filename}`, revoke: () => {} };
     },
   };
 });


### PR DESCRIPTION
## 変更内容
- background から asset を 4 MiB chunk で取得し、overlay で Blob URL に組み立てる
- 注入メッセージは Blob URL のみを relay し、注入後に必ず revoke する
- 不要な一括 base64 asset fetch API を削除し、DistroKid Helper を 0.3.1 へ更新する

## Chrome への反映
1. `pnpm --dir extensions/distrokid-helper build` を実行する
2. `chrome://extensions` で DistroKid Helper の「再読み込み」を押す
3. 開いている DistroKid ページを再読み込みする

Closes #4645