### PR TITLE
fix(ci): .github 配下の変更を対応する契約テストへ漏れなく対応付ける (#4658)

### DIFF
--- a/.github/scripts/select-affected-tests.py
+++ b/.github/scripts/select-affected-tests.py
@@ -33,8 +33,78 @@ CHANGELOG_FRAGMENT_TESTS: Final = (
     "tests/commands/system/test_changelog_compile.py",
     "tests/repo/test_changelog_ci_contract.py",
 )
+# prefix エントリと完全一致エントリは合成される（`_mapped_tests` が全マッチを union する）。
+# prefix 側には配下を横断して検証する test だけを置き、ファイル固有の契約は完全一致側へ分ける。
+# `tests/repo/test_select_affected_tests.py` を `.github/` の両 prefix に含めるのは、
+# 対応表のドリフトを検出する完全性契約テストを、対象ドメインを変更した PR 自身で走らせるため。
 PATH_TEST_MAP: Final = (
-    (".github/workflows/", ("tests/repo/test_actions_parallel_workflows.py",)),
+    (
+        ".github/workflows/",
+        (
+            "tests/repo/test_actions_parallel_workflows.py",
+            "tests/repo/test_github_actions_pinning.py",
+            "tests/repo/test_select_affected_tests.py",
+        ),
+    ),
+    (
+        ".github/workflows/ci.yml",
+        (
+            "tests/repo/test_changelog_ci_contract.py",
+            "tests/repo/test_evals_workflow.py",
+            "tests/repo/test_pyscn_diff_gate_contract.py",
+            "tests/repo/test_pytest_lane_contract.py",
+            "tests/repo/test_release_notes_contract.py",
+            "tests/repo/test_skill_catalog_removal.py",
+        ),
+    ),
+    (".github/workflows/ci-autofix.yml", ("tests/repo/test_ci_autofix_workflow.py",)),
+    (".github/workflows/code-review.yml", ("tests/repo/test_code_review_workflow.py",)),
+    (
+        ".github/workflows/dashboard.yml",
+        ("tests/contracts/architecture/test_repository_reorganization_contract.py",),
+    ),
+    (".github/workflows/evals.yml", ("tests/repo/test_evals_workflow.py",)),
+    (".github/workflows/extensions.yml", ("tests/repo/test_extension_package_manager_contract.py",)),
+    (
+        ".github/workflows/release-extensions.yml",
+        (
+            "tests/repo/test_extension_package_manager_contract.py",
+            "tests/repo/test_release_extensions_workflow.py",
+            "tests/repo/test_verify_extensions_script.py",
+        ),
+    ),
+    (
+        ".github/workflows/site.yml",
+        (
+            "tests/repo/test_site_repository_contract.py",
+            "tests/repo/test_skill_page_generation_contract.py",
+        ),
+    ),
+    (".github/scripts/", ("tests/repo/test_select_affected_tests.py",)),
+    (
+        ".github/scripts/any-usage-gate.sh",
+        (
+            "tests/repo/test_any_usage_gate.py",
+            "tests/repo/test_takt_workflow_contract.py",
+        ),
+    ),
+    # resolver / cleaner は any-usage-gate.sh から subprocess で呼ばれるだけで
+    # 名指しの参照を持たないため、gate 本体の E2E テストへ対応付ける。
+    (".github/scripts/any_usage_python_resolver.py", ("tests/repo/test_any_usage_gate.py",)),
+    (".github/scripts/any_usage_ts_line_cleaner.py", ("tests/repo/test_any_usage_gate.py",)),
+    (".github/scripts/classify-ci-paths.sh", ("tests/repo/test_actions_parallel_workflows.py",)),
+    (".github/scripts/pyscn-diff-gate.py", ("tests/repo/test_pyscn_diff_gate_contract.py",)),
+    (
+        ".github/scripts/run-affected-tests.py",
+        (
+            "tests/repo/test_pytest_lane_contract.py",
+            "tests/repo/test_takt_workflow_contract.py",
+        ),
+    ),
+    (
+        ".github/scripts/validate-changelog-fragments.py",
+        ("tests/repo/test_changelog_ci_contract.py",),
+    ),
     (
         "docs/adr/",
         (
@@ -147,12 +217,18 @@ def _validate_path(repository: Path, changed: str) -> bool:
 
 
 def _mapped_tests(changed: str) -> tuple[str, ...] | None:
+    """マッチした**全**エントリの対象を合成して返す。未マッチなら ``None``。
+
+    最初のマッチで打ち切ると prefix と完全一致のどちらか片方しか効かず、
+    `.github/workflows/ci.yml` の変更が横断 test 1 件にしか対応付かない（#4658）。
+    """
     if changed.startswith(CHANGELOG_FRAGMENT_PREFIX) and changed.endswith(CHANGELOG_FRAGMENT_SUFFIX):
         return CHANGELOG_FRAGMENT_TESTS
+    matched: set[str] = set()
     for pattern, targets in PATH_TEST_MAP:
         if (pattern.endswith("/") and changed.startswith(pattern)) or changed == pattern:
-            return targets
-    return None
+            matched.update(targets)
+    return tuple(sorted(matched)) if matched else None
 
 
 def select_targets(repository: Path, changed_paths: list[str]) -> tuple[str, ...] | None:

--- a/changelog.d/4658-affected-tests-github-asset-mapping.fixed.md
+++ b/changelog.d/4658-affected-tests-github-asset-mapping.fixed.md
@@ -1,0 +1,2 @@
+- CI の影響テスト選定で `.github/workflows/` 配下の変更が横断 test 1 件にしか対応付かず、GitHub Actions の pinning ゲートや `ci.yml` の契約テストが PR CI で走らなかった問題を修正
+- `.github/scripts/` 配下の変更を fail-safe の全件実行から対応する契約テストへ絞り込み

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import functools
 import importlib.util
 import json
 import re
@@ -15,7 +16,6 @@ from tests.helpers.tests_tree import shared_tests_tree_lock
 
 SCRIPT = REPO_ROOT / ".github/scripts/select-affected-tests.py"
 _GITHUB_ASSET_DIRECTORIES: Final = (".github/workflows", ".github/scripts")
-_NON_TEST_PREFIXES: Final = ("tests/helpers/", "tests/fixtures/")
 
 
 def _load_selector():
@@ -379,24 +379,44 @@ def _github_assets() -> list[str]:
     )
 
 
-def _tests_referencing(basename: str) -> set[str]:
-    """basename を path 成分として参照する test module を実ツリーから集める。
+@functools.lru_cache(maxsize=1)
+def _github_asset_reference_index(non_test_prefixes: tuple[str, ...]) -> dict[str, frozenset[str]]:
+    """`.github/` 資産の basename ごとに、参照する test module を実ツリーから集める。
 
-    期待値を PATH_TEST_MAP から導かないのは、対応表が間違っていても通る自己言及
-    テストになるため。直前が path 区切り相当であることを要求し、`extensions.yml`
-    が `release-extensions.yml` の一部へ誤マッチするのを防ぐ。
+    parametrize 1 件ごとに `tests/` を舐め直すと、資産の件数だけツリー全体を再読込
+    することになる。全 basename の突き合わせを 1 回の走査へまとめ、結果だけ持つ。
+    走査は `shared_tests_tree_lock()` の内側で初回だけ動く。
+
+    直前が path 区切り相当であることを要求し、`extensions.yml` が
+    `release-extensions.yml` の一部へ誤マッチするのを防ぐ。
     """
-    pattern = re.compile(r"(?<![A-Za-z0-9_.\-])" + re.escape(basename))
-    referencing: set[str] = set()
+    patterns = {
+        basename: re.compile(r"(?<![A-Za-z0-9_.\-])" + re.escape(basename))
+        for basename in {PurePosixPath(asset).name for asset in _github_assets()}
+    }
+    index: dict[str, set[str]] = {basename: set() for basename in patterns}
     for path in (REPO_ROOT / "tests").rglob("*.py"):
         relative = path.relative_to(REPO_ROOT).as_posix()
         if not (path.name.startswith("test_") or path.name.endswith("_test.py")):
             continue
-        if relative.startswith(_NON_TEST_PREFIXES):
+        if relative.startswith(non_test_prefixes):
             continue
-        if pattern.search(path.read_text(encoding="utf-8")):
-            referencing.add(relative)
-    return referencing
+        text = path.read_text(encoding="utf-8")
+        for basename, pattern in patterns.items():
+            if basename in text and pattern.search(text):
+                index[basename].add(relative)
+    return {basename: frozenset(referencing) for basename, referencing in index.items()}
+
+
+def _tests_referencing(basename: str, non_test_prefixes: tuple[str, ...]) -> frozenset[str]:
+    """basename を path 成分として参照する test module を返す。
+
+    期待値を PATH_TEST_MAP から導かないのは、対応表が間違っていても通る自己言及
+    テストになるため。`non_test_prefixes` は selector の `FAIL_SAFE_PREFIXES` を
+    呼び出し側から渡す。ここで値を複製すると、ドリフトを検出するはずのこの module
+    自身が selector とのドリフトを起こす。
+    """
+    return _github_asset_reference_index(non_test_prefixes)[basename]
 
 
 @pytest.mark.parametrize(
@@ -466,7 +486,7 @@ def test_github_asset_change_selects_every_test_that_references_it(asset: str) -
 
     with shared_tests_tree_lock():
         result = selector.select_targets(REPO_ROOT, [asset])
-        referencing = _tests_referencing(PurePosixPath(asset).name)
+        referencing = _tests_referencing(PurePosixPath(asset).name, selector.FAIL_SAFE_PREFIXES)
 
     if result is None:
         # ALL は全件実行なので契約は満たす。意図せず fail-safe へ落ちる path が

--- a/tests/repo/test_select_affected_tests.py
+++ b/tests/repo/test_select_affected_tests.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import re
 import subprocess
 import sys
-from pathlib import Path
+from pathlib import Path, PurePosixPath
+from typing import Final
 
 import pytest
 
@@ -12,6 +14,8 @@ from tests.helpers.paths import REPO_ROOT
 from tests.helpers.tests_tree import shared_tests_tree_lock
 
 SCRIPT = REPO_ROOT / ".github/scripts/select-affected-tests.py"
+_GITHUB_ASSET_DIRECTORIES: Final = (".github/workflows", ".github/scripts")
+_NON_TEST_PREFIXES: Final = ("tests/helpers/", "tests/fixtures/")
 
 
 def _load_selector():
@@ -66,14 +70,17 @@ def _synthetic_repository(tmp_path: Path) -> Path:
         "tests/test_dynamic_wildcard.py",
         "import importlib\n\n\ndef _load(name):\n    return importlib.import_module(name)\n",
     )
-    _write(repository, "tests/repo/test_actions_parallel_workflows.py")
-    _write(repository, "tests/repo/test_changelog_ci_contract.py")
-    _write(repository, "tests/commands/system/test_changelog_compile.py")
-    _write(repository, "tests/repo/test_b6_integration_contract.py")
-    _write(repository, "tests/repo/test_site_repository_contract.py")
-    _write(repository, ".github/workflows/ci.yml")
+    # 対応表の対象が1件でも実在しないと selector は ALL へ fail-safe する。
+    # ここは期待値ではなく前提条件なので、対応表から機械的に用意する。
+    selector = _load_selector()
+    for pattern, targets in selector.PATH_TEST_MAP:
+        if not pattern.endswith("/"):
+            _write(repository, pattern)
+        for target in targets:
+            _write(repository, target)
+    for target in selector.CHANGELOG_FRAGMENT_TESTS:
+        _write(repository, target)
     _write(repository, "docs/adr/0024-example.md")
-    _write(repository, "CHANGELOG.md")
     _write(repository, "changelog.d/4526-example.fixed.md")
     _write(repository, "changelog.d/notes.txt")
     _write(repository, "some/other/changelog.d/4526-example.fixed.md")
@@ -222,8 +229,17 @@ def test_workflow_adr_changelog_and_direct_test_use_explicit_mapping(tmp_path: P
     selector = _load_selector()
     repository = _synthetic_repository(tmp_path)
 
+    # ci.yml は prefix エントリと完全一致エントリの両方にマッチし、両者が合成される
     assert selector.select_targets(repository, [".github/workflows/ci.yml"]) == (
         "tests/repo/test_actions_parallel_workflows.py",
+        "tests/repo/test_changelog_ci_contract.py",
+        "tests/repo/test_evals_workflow.py",
+        "tests/repo/test_github_actions_pinning.py",
+        "tests/repo/test_pyscn_diff_gate_contract.py",
+        "tests/repo/test_pytest_lane_contract.py",
+        "tests/repo/test_release_notes_contract.py",
+        "tests/repo/test_select_affected_tests.py",
+        "tests/repo/test_skill_catalog_removal.py",
     )
     assert selector.select_targets(repository, ["docs/adr/0024-example.md"]) == (
         "tests/repo/test_b6_integration_contract.py",
@@ -351,3 +367,153 @@ def test_cli_missing_argument_is_usage_error() -> None:
     assert result.returncode == 2
     assert result.stdout == ""
     assert "usage:" in result.stderr
+
+
+def _github_assets() -> list[str]:
+    """`.github/workflows/` と `.github/scripts/` の実在ファイルを repo 相対 path で返す。"""
+    return sorted(
+        path.relative_to(REPO_ROOT).as_posix()
+        for directory in _GITHUB_ASSET_DIRECTORIES
+        for path in (REPO_ROOT / directory).iterdir()
+        if path.is_file()
+    )
+
+
+def _tests_referencing(basename: str) -> set[str]:
+    """basename を path 成分として参照する test module を実ツリーから集める。
+
+    期待値を PATH_TEST_MAP から導かないのは、対応表が間違っていても通る自己言及
+    テストになるため。直前が path 区切り相当であることを要求し、`extensions.yml`
+    が `release-extensions.yml` の一部へ誤マッチするのを防ぐ。
+    """
+    pattern = re.compile(r"(?<![A-Za-z0-9_.\-])" + re.escape(basename))
+    referencing: set[str] = set()
+    for path in (REPO_ROOT / "tests").rglob("*.py"):
+        relative = path.relative_to(REPO_ROOT).as_posix()
+        if not (path.name.startswith("test_") or path.name.endswith("_test.py")):
+            continue
+        if relative.startswith(_NON_TEST_PREFIXES):
+            continue
+        if pattern.search(path.read_text(encoding="utf-8")):
+            referencing.add(relative)
+    return referencing
+
+
+@pytest.mark.parametrize(
+    "entries",
+    [
+        pytest.param(
+            (
+                (".github/workflows/", ("tests/core/test_leaf.py",)),
+                (".github/workflows/ci.yml", ("tests/core/test_middle.py",)),
+            ),
+            id="prefix-first",
+        ),
+        pytest.param(
+            (
+                (".github/workflows/ci.yml", ("tests/core/test_middle.py",)),
+                (".github/workflows/", ("tests/core/test_leaf.py",)),
+            ),
+            id="exact-first",
+        ),
+    ],
+)
+def test_every_matching_entry_contributes_regardless_of_order(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    entries: tuple[tuple[str, tuple[str, ...]], ...],
+) -> None:
+    # #4658: 最初のマッチで打ち切ると prefix と完全一致のどちらか片方しか効かない。
+    # エントリの並び順に依存せず、マッチした全エントリが合成されることを固定する。
+    selector = _load_selector()
+    repository = _synthetic_repository(tmp_path)
+    monkeypatch.setattr(selector, "PATH_TEST_MAP", entries)
+
+    assert selector.select_targets(repository, [".github/workflows/ci.yml"]) == (
+        "tests/core/test_leaf.py",
+        "tests/core/test_middle.py",
+    )
+
+
+@pytest.mark.parametrize("workflow", sorted(path.name for path in (REPO_ROOT / ".github/workflows").glob("*.yml")))
+def test_every_workflow_change_selects_the_actions_pinning_gate(workflow: str) -> None:
+    # test_github_actions_pinning.py は全 workflow を parametrize する supply-chain
+    # ゲート。workflow 固有ではないため prefix 側で必ず選ばれる必要がある。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [f".github/workflows/{workflow}"])
+
+    assert result is not None
+    assert "tests/repo/test_github_actions_pinning.py" in result
+
+
+def test_ci_yml_alone_selects_the_changelog_gate_contract() -> None:
+    # #4658 の再発防止: ci.yml 単独変更で changelog ゲートの契約テストが選ばれること。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [".github/workflows/ci.yml"])
+
+    assert result is not None
+    assert "tests/repo/test_changelog_ci_contract.py" in result
+
+
+@pytest.mark.parametrize("asset", _github_assets())
+def test_github_asset_change_selects_every_test_that_references_it(asset: str) -> None:
+    # 対応表のドリフト検出。実ツリーから参照元を導出し、選定結果が覆うことを要求する。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [asset])
+        referencing = _tests_referencing(PurePosixPath(asset).name)
+
+    if result is None:
+        # ALL は全件実行なので契約は満たす。意図せず fail-safe へ落ちる path が
+        # 増えていないことだけ固定する。
+        assert asset in selector.FAIL_SAFE_EXACT
+        return
+    assert referencing <= set(result), f"{asset}: 対応表に載っていない参照元 test がある"
+
+
+@pytest.mark.parametrize("asset", [".github/workflows/ci.yml", ".github/scripts/pyscn-diff-gate.py"])
+def test_github_asset_change_selects_this_completeness_guard(asset: str) -> None:
+    # ドリフト検出窓を PR 時点へ入れるため、対象ドメインを変更した PR では
+    # 完全性契約テストを持つこの module 自身が選定される必要がある。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [asset])
+
+    assert result is not None
+    assert "tests/repo/test_select_affected_tests.py" in result
+
+
+@pytest.mark.parametrize(
+    ("script", "expected"),
+    [
+        (".github/scripts/pyscn-diff-gate.py", "tests/repo/test_pyscn_diff_gate_contract.py"),
+        (".github/scripts/run-affected-tests.py", "tests/repo/test_pytest_lane_contract.py"),
+        (".github/scripts/any-usage-gate.sh", "tests/repo/test_any_usage_gate.py"),
+        (".github/scripts/validate-changelog-fragments.py", "tests/repo/test_changelog_ci_contract.py"),
+    ],
+)
+def test_github_scripts_change_is_narrowed_from_the_all_fail_safe(script: str, expected: str) -> None:
+    # 未対応 path として ALL へ落ちていた経路を、対応する契約テストへ絞り込む。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [script])
+
+    assert result is not None, f"{script}: ALL へ fail-safe している"
+    assert expected in result
+
+
+def test_selector_script_itself_still_fails_safe_to_all() -> None:
+    # `.github/scripts/` の絞り込みが FAIL_SAFE_EXACT を上書きしないこと。
+    selector = _load_selector()
+
+    with shared_tests_tree_lock():
+        result = selector.select_targets(REPO_ROOT, [".github/scripts/select-affected-tests.py"])
+
+    assert result is None


### PR DESCRIPTION
## 概要

CI の影響テスト選定 `_mapped_tests` が `PATH_TEST_MAP` の**最初にマッチしたエントリで打ち切る**ため、`.github/workflows/` prefix が全 workflow を `tests/repo/test_actions_parallel_workflows.py` 1 件へ潰していた。workflow の契約テストが PR CI で選定されず、壊しても green になりうる。

全マッチの合成へ変更し、workflow / script ごとの完全一致エントリと、ドリフトを検出する完全性契約テストを追加する。

Closes #4658

## 変更内容

- `.github/scripts/select-affected-tests.py` — `_mapped_tests` をマッチした全エントリの union へ変更。prefix エントリと完全一致エントリを併用できるようにする
- `.github/scripts/select-affected-tests.py` — `PATH_TEST_MAP` に workflow 9 件 / script 7 件の完全一致エントリを追加。prefix 側には配下を横断して検証する test だけを残す
- `tests/repo/test_select_affected_tests.py` — union 契約 / pinning ゲートの全 workflow 選定 / `.github/scripts/` の絞り込み / fail-safe 維持を固定し、実ツリー走査による完全性契約テストを追加

## 欠陥の実測

修正前はどの workflow を変更しても選定結果が 1 件だった。

| 変更 path | 修正前 | 修正後 |
|---|---|---|
| `.github/workflows/ci.yml` | 1 件 | 8 件（changelog / pyscn / pytest lane / release notes / evals / pinning ほか） |
| `.github/workflows/site.yml` | 1 件 | 5 件（site repository / skill page generation ほか） |
| `.github/scripts/pyscn-diff-gate.py` | `ALL`（fail-safe） | 2 件 |
| `.github/scripts/select-affected-tests.py` | `ALL` | `ALL`（`FAIL_SAFE_EXACT` 維持） |

最も重いのは `tests/repo/test_github_actions_pinning.py`。全 workflow を parametrize する supply-chain ゲート（third-party action の 40 桁 SHA pinning）だが、**どの workflow を変更しても選定されなかった**。mutable tag の action を追加する PR が green で通りうる状態だった。

## 設計判断

**union 化を選び、完全一致エントリを prefix より前に置く案を採らなかった理由**: 順序で解決すると prefix 側の横断 test が落ちる。エントリ順に依存しないことを `prefix-first` / `exact-first` の両方で固定した。

**完全性契約テストを実ツリー走査で導出する理由**: 期待値を `PATH_TEST_MAP` から引くと、対応表が間違っていても通る自己言及テストになる。`tests/` 配下の test module 本文から basename 参照を検出し、選定結果がそれを覆うことを要求する。`extensions.yml` が `release-extensions.yml` に部分一致しないよう、直前が path 区切り相当であることを要求している。

**両 prefix に `test_select_affected_tests.py` を含める理由**: 完全性テストは、それ自身が選定されないとドリフトを検出できない。`.github/workflows/` / `.github/scripts/` を変更した PR で必ず走らせ、検出窓を PR 時点に入れる。

**`any_usage_python_resolver.py` / `any_usage_ts_line_cleaner.py` の対応先**: どちらも `any-usage-gate.sh` から subprocess で呼ばれるだけで名指しの参照を持たないため、gate 本体を E2E で叩く `tests/repo/test_any_usage_gate.py` へ対応付けた。

## 既知の制限

- 完全性契約テストが検出できるのは「`.github/` 配下の資産を basename で参照する test」まで。workflow を `glob("*.yml")` で横断走査する test（`test_github_actions_pinning.py`）は prefix エントリでの明示列挙が必要で、同種の test が新設された場合は手動追加になる。
- 既存 test が新たに `ci.yml` を読み始めた変更（`tests/` のみの差分）では完全性テストが選定されないため、その PR では検出できず main 側で顕在化する。

## 完全性契約テストが初回 CI で実際にドリフトを検出した

初回 CI（`pull_request` の merge commit）で `test_github_asset_change_selects_every_test_that_references_it[.github/workflows/ci.yml]` が失敗した。原因は本ブランチを切った後に #4655 が main へマージされ、`ci.yml` の契約テスト `tests/repo/test_skill_catalog_removal.py::test_ci_does_not_run_skill_catalog_check`（`yt-skills catalog` step が復活していないことを検証）が増えていたこと。

対応表を手で列挙するだけならこの追加を取りこぼしたまま merge され、`ci.yml` に `yt-skills catalog` を書き戻す PR が green で通る状態に戻っていた。ガードが設計どおり機能したケースなので、`origin/main` へ rebase したうえで当該 test を `ci.yml` エントリへ追加している。

## 検証

- `nix develop --command uv run pytest -n auto`: **10249 passed, 4 skipped, 1 failed**（drift 修正前・rebase 前の実行）
  - 失敗は `tests/commands/collections/test_collection_serve_lifecycle.py::test_distrokid_fallback_console_commands_stop_server_cleanly_without_traceback`。単体実行では pass する既存の並列 flaky で、本 PR の変更対象と無関係
- rebase 後: `pytest tests/repo/test_select_affected_tests.py` 65 passed / `ruff check .` / `ruff format --check .` すべて green
- `.github/scripts/validate-changelog-fragments.py` exit 0

## チェックリスト

- [x] `changelog.d/` に fragment を追加した（`4658-affected-tests-github-asset-mapping.fixed.md`）
- [x] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した
  - 上流の CI 運用のみの変更で、下流チャンネルへの影響はなし
- [x] 必要なテストを追加・更新した
