### PR TITLE
fix(ci): autofix の発火を critical+warning に限定する (#4602)

### DIFF
--- a/.github/workflows/ci-autofix.yml
+++ b/.github/workflows/ci-autofix.yml
@@ -113,8 +113,8 @@ jobs:
             info_count="$(severity_count info)"
             [ -n "$critical_count" ] && [ -n "$warning_count" ] && [ -n "$info_count" ] \
               || skip "code review severity summary could not be parsed"
-            [ "$((critical_count + warning_count + info_count))" -gt 0 ] \
-              || skip "code review reported no findings"
+            [ "$((critical_count + warning_count))" -gt 0 ] \
+              || skip "code review reported no critical or warning findings (info-only is not auto-fixed)"
           fi
 
           # 修正試行は PR あたり 1 回。commit body の [ci-autofix] マーカーで判定し、

--- a/plans/README.md
+++ b/plans/README.md
@@ -14,7 +14,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
 | 034 | Code review を patch-id で重複排除し rebase-only push の sonnet 再レビューを skip | P1 | M | — | [#4601](https://github.com/daiki-beppu/youtube-automation/issues/4601) | — | TODO |
-| 035 | CI autofix の発火しきい値を critical+warning に上げ info-only での Opus 起動を止める | P1 | S | — | [#4602](https://github.com/daiki-beppu/youtube-automation/issues/4602) | — | TODO |
+| 035 | CI autofix の発火しきい値を critical+warning に上げ info-only での Opus 起動を止める | P1 | S | — | [#4602](https://github.com/daiki-beppu/youtube-automation/issues/4602) | — | DONE |
 | 036 | Skill E2E eval の pnpm devShell 不整合を修理し日次 → 週次化 | P2 | S | — | [#4603](https://github.com/daiki-beppu/youtube-automation/issues/4603) | — | TODO |
 
 ### Dependency notes

--- a/tests/repo/test_ci_autofix_workflow.py
+++ b/tests/repo/test_ci_autofix_workflow.py
@@ -74,6 +74,7 @@ def test_gate_processes_ci_failures_and_every_completed_code_review() -> None:
 
 
 def test_review_runs_skip_without_findings_and_supply_the_aggregate_comment() -> None:
+    """info の simplify 提案だけでは自動修正を起動しない。"""
     workflow = _workflow()
     gate = workflow["jobs"]["gate"]
     decide = _decide_step(gate)
@@ -82,12 +83,16 @@ def test_review_runs_skip_without_findings_and_supply_the_aggregate_comment() ->
     assert "<!-- code-review-workflow -->" in decide["run"]
     assert "critical_count" in decide["run"]
     assert "warning_count" in decide["run"]
+    # summary の parse 可能性ガードとして info_count の取得・検証は残す
     assert "info_count" in decide["run"]
     assert "${1}[[:space:][:punct:]]*[0-9]+" in decide["run"]
     assert "][0].body" in decide["run"]
     assert "skip-review" in decide["run"]
     assert "awk '/^---[[:space:]]*$/{exit}" in decide["run"]
-    assert 'skip "code review reported no findings"' in decide["run"]
+    assert 'skip "code review reported no critical or warning findings' in decide["run"]
+    # info-only のレビューでは Opus を起動しない(発火は critical+warning のみ)
+    assert '[ "$((critical_count + warning_count))" -gt 0 ]' in decide["run"]
+    assert "critical_count + warning_count + info_count" not in decide["run"]
 
     prompt = _autofix_step(workflow["jobs"]["autofix"])["with"]["prompt"]
     assert "critical / warning / info" in prompt


### PR DESCRIPTION
## Summary
- CI autofix の発火条件を critical と warning の合計に限定
- info-only のレビューを notice 付きでスキップ
- contract test と Plan 035 の進捗を更新

Closes #4602