### PR TITLE
feat(ci): Code review を patch-id で重複排除する (#4601)

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -44,6 +44,10 @@ jobs:
     needs: auth-check
     if: needs.auth-check.outputs.available == 'true'
     runs-on: ubuntu-latest
+    # 集約コメントの marker は ci-autofix.yml の gate が startswith で探す契約。
+    # 検索側(Look up previous review)と書き込み側(Post review comment)で必ず同一にする
+    env:
+      REVIEW_MARKER: "<!-- code-review-workflow -->"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -66,9 +70,13 @@ jobs:
           PATCH_ID: ${{ steps.fingerprint.outputs.patch_id }}
         run: |
           set -eu
-          marker='<!-- code-review-workflow -->'
-          body="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].body // empty")"
+          # コメント一覧の取得はこの 1 回だけ。id も同時に拾って Post review comment へ渡す
+          # --paginate は page ごとに --jq を適用するため、複数 page 分の出力を 1 件に畳む
+          comment="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"${REVIEW_MARKER}\"))][0] // empty" | head -n 1)"
+          comment_id="$(jq -r '.id // empty' <<<"$comment")"
+          body="$(jq -r '.body // empty' <<<"$comment")"
+          echo "comment_id=${comment_id}" >> "$GITHUB_OUTPUT"
           meta="$(grep -m1 -oE '<!-- code-review-meta patch=[0-9a-f]+ crit=[0-9]+ -->' <<<"$body" || true)"
           prev_patch="$(grep -oE 'patch=[0-9a-f]+' <<<"$meta" | cut -d= -f2 || true)"
           prev_crit="$(grep -oE 'crit=[0-9]+' <<<"$meta" | cut -d= -f2 || true)"
@@ -138,22 +146,20 @@ jobs:
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PATCH_ID: ${{ steps.fingerprint.outputs.patch_id }}
+          COMMENT_ID: ${{ steps.previous.outputs.comment_id }}
         run: |
           set -eu
-          marker='<!-- code-review-workflow -->'
           critical=$(jq -r '.critical_count' <<<"$STRUCTURED_OUTPUT")
           {
-            echo "$marker"
+            echo "$REVIEW_MARKER"
             echo "<!-- code-review-meta patch=${PATCH_ID} crit=${critical} -->"
             echo
             jq -r '.report_markdown' <<<"$STRUCTURED_OUTPUT"
           } > "$RUNNER_TEMP/review-comment.md"
-          comment_id=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].id // empty")
-          if [ -n "$comment_id" ]; then
-            gh api -X PATCH "repos/${REPO}/issues/comments/${comment_id}" \
+          if [ -n "$COMMENT_ID" ]; then
+            gh api -X PATCH "repos/${REPO}/issues/comments/${COMMENT_ID}" \
               -F "body=@$RUNNER_TEMP/review-comment.md" > /dev/null
-            echo "updated comment ${comment_id}"
+            echo "updated comment ${COMMENT_ID}"
           else
             gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
               -F "body=@$RUNNER_TEMP/review-comment.md" > /dev/null

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -69,11 +69,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PATCH_ID: ${{ steps.fingerprint.outputs.patch_id }}
         run: |
-          set -eu
-          # コメント一覧の取得はこの 1 回だけ。id も同時に拾って Post review comment へ渡す
-          # --paginate は page ごとに --jq を適用するため、複数 page 分の出力を 1 件に畳む
-          comment="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
-            --jq "[.[] | select(.body | startswith(\"${REVIEW_MARKER}\"))][0] // empty" | head -n 1)"
+          set -eu -o pipefail
+          # コメント一覧の取得はこの 1 回だけ。id も同時に拾って Post review comment へ渡す。
+          # --slurp は全 page を 1 つの配列へ畳むので page 境界を跨いで先頭 1 件を選べる
+          # （--slurp は --jq と併用できないため jq へパイプする）。jq -c で 1 行に固定し、
+          # 入力を読み切る jq を終端に置くことで --paginate 中の SIGPIPE も起こさない。
+          comment="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate --slurp \
+            | jq -c "[.[][] | select(.body | startswith(\"${REVIEW_MARKER}\"))][0] // empty")"
           comment_id="$(jq -r '.id // empty' <<<"$comment")"
           body="$(jq -r '.body // empty' <<<"$comment")"
           echo "comment_id=${comment_id}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -48,8 +48,41 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+      - name: Compute diff fingerprint
+        id: fingerprint
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -eu
+          patch_id=$(git diff "${BASE_SHA}...${HEAD_SHA}" | git patch-id --stable | cut -d' ' -f1)
+          echo "patch_id=${patch_id}" >> "$GITHUB_OUTPUT"
+      - name: Look up previous review
+        id: previous
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATCH_ID: ${{ steps.fingerprint.outputs.patch_id }}
+        run: |
+          set -eu
+          marker='<!-- code-review-workflow -->'
+          body="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq "[.[] | select(.body | startswith(\"${marker}\"))][0].body // empty")"
+          meta="$(grep -m1 -oE '<!-- code-review-meta patch=[0-9a-f]+ crit=[0-9]+ -->' <<<"$body" || true)"
+          prev_patch="$(grep -oE 'patch=[0-9a-f]+' <<<"$meta" | cut -d= -f2 || true)"
+          prev_crit="$(grep -oE 'crit=[0-9]+' <<<"$meta" | cut -d= -f2 || true)"
+          if [ -n "$PATCH_ID" ] && [ -n "$prev_patch" ] && [ "$PATCH_ID" = "$prev_patch" ]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "prev_crit=${prev_crit:-0}" >> "$GITHUB_OUTPUT"
+            echo "::notice::diff unchanged since last review (patch-id ${PATCH_ID}); skipping paid review"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "prev_crit=" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run Claude code review
         id: review
+        if: steps.previous.outputs.skip != 'true'
         uses: anthropics/claude-code-action@4a3947e8ca609a286ab07d4d048d9ec4016798c1 # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
@@ -98,17 +131,20 @@ jobs:
             --allowedTools "Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh issue view:*),Bash(git log:*),Bash(git diff:*),Bash(git show:*),Bash(git status:*),Bash(git branch:*),Bash(git rev-parse:*),Bash(git merge-base:*)"
             --json-schema '{"type":"object","properties":{"report_markdown":{"type":"string"},"critical_count":{"type":"integer","minimum":0},"warning_count":{"type":"integer","minimum":0},"info_count":{"type":"integer","minimum":0}},"required":["report_markdown","critical_count","warning_count","info_count"]}'
       - name: Post review comment
-        if: steps.review.outputs.structured_output != ''
+        if: steps.previous.outputs.skip != 'true' && steps.review.outputs.structured_output != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
           REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          PATCH_ID: ${{ steps.fingerprint.outputs.patch_id }}
         run: |
           set -eu
           marker='<!-- code-review-workflow -->'
+          critical=$(jq -r '.critical_count' <<<"$STRUCTURED_OUTPUT")
           {
             echo "$marker"
+            echo "<!-- code-review-meta patch=${PATCH_ID} crit=${critical} -->"
             echo
             jq -r '.report_markdown' <<<"$STRUCTURED_OUTPUT"
           } > "$RUNNER_TEMP/review-comment.md"
@@ -126,12 +162,19 @@ jobs:
       - name: Fail on critical findings
         env:
           STRUCTURED_OUTPUT: ${{ steps.review.outputs.structured_output }}
+          SKIPPED: ${{ steps.previous.outputs.skip }}
+          PREV_CRIT: ${{ steps.previous.outputs.prev_crit }}
         run: |
           set -eu
-          critical=$(jq -r '.critical_count' <<<"$STRUCTURED_OUTPUT")
-          warning=$(jq -r '.warning_count' <<<"$STRUCTURED_OUTPUT")
-          info=$(jq -r '.info_count' <<<"$STRUCTURED_OUTPUT")
-          echo "critical=${critical} warning=${warning} info=${info}"
+          if [ "$SKIPPED" = "true" ]; then
+            critical="${PREV_CRIT:-0}"
+            echo "review skipped (unchanged diff); re-applying previous verdict: critical=${critical}"
+          else
+            critical=$(jq -r '.critical_count' <<<"$STRUCTURED_OUTPUT")
+            warning=$(jq -r '.warning_count' <<<"$STRUCTURED_OUTPUT")
+            info=$(jq -r '.info_count' <<<"$STRUCTURED_OUTPUT")
+            echo "critical=${critical} warning=${warning} info=${info}"
+          fi
           if [ "$critical" -gt 0 ]; then
             echo "::error::Code review found ${critical} critical finding(s). See the review comment on the PR."
             exit 1

--- a/plans/README.md
+++ b/plans/README.md
@@ -13,7 +13,7 @@ Status values: TODO | IN PROGRESS | DONE | BLOCKED (with one-line reason) | REJE
 
 | Plan | Title | Priority | Effort | Depends on | Issue | PR | Status |
 |------|-------|----------|--------|------------|-------|-----|--------|
-| 034 | Code review を patch-id で重複排除し rebase-only push の sonnet 再レビューを skip | P1 | M | — | [#4601](https://github.com/daiki-beppu/youtube-automation/issues/4601) | — | TODO |
+| 034 | Code review を patch-id で重複排除し rebase-only push の sonnet 再レビューを skip | P1 | M | — | [#4601](https://github.com/daiki-beppu/youtube-automation/issues/4601) | [#4662](https://github.com/daiki-beppu/youtube-automation/pull/4662) | DONE |
 | 035 | CI autofix の発火しきい値を critical+warning に上げ info-only での Opus 起動を止める | P1 | S | — | [#4602](https://github.com/daiki-beppu/youtube-automation/issues/4602) | — | DONE |
 | 036 | Skill E2E eval の pnpm devShell 不整合を修理し日次 → 週次化 | P2 | S | — | [#4603](https://github.com/daiki-beppu/youtube-automation/issues/4603) | — | TODO |
 

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -143,6 +143,11 @@ def test_unchanged_diff_skips_the_paid_review_but_reapplies_the_verdict() -> Non
     # comment_id も同じ 1 回の取得で拾い、Post review comment 側の再取得を不要にする
     assert "comment_id=" in previous["run"]
     assert previous["run"].count("gh api") == 1
+    # gh api をパイプへ通すため、API 失敗を head/jq の exit 0 で握りつぶさない
+    assert "set -eu -o pipefail" in previous["run"]
+    # page 境界を跨いだ先頭 1 件の選択は --slurp で行う（head での打ち切りは SIGPIPE を招く）
+    assert "--slurp" in previous["run"]
+    assert "head -n 1" not in previous["run"]
 
     assert _review_step(review)["if"] == "steps.previous.outputs.skip != 'true'"
 

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -113,9 +113,15 @@ def test_review_comment_is_upserted_by_a_workflow_step_not_by_claude() -> None:
     assert post["if"] == ("steps.previous.outputs.skip != 'true' && steps.review.outputs.structured_output != ''")
     assert post["env"]["STRUCTURED_OUTPUT"] == "${{ steps.review.outputs.structured_output }}"
     script = post["run"]
-    assert "<!-- code-review-workflow -->" in script
+    # marker は job env の 1 箇所定義（ci-autofix の startswith gate と揃える契約）
+    assert review["env"]["REVIEW_MARKER"] == "<!-- code-review-workflow -->"
+    assert 'echo "$REVIEW_MARKER"' in script
     assert "report_markdown" in script
     assert "PATCH" in script
+
+    # コメント一覧の取得は Look up previous review の 1 回だけ（id を再利用し再取得しない）
+    assert post["env"]["COMMENT_ID"] == "${{ steps.previous.outputs.comment_id }}"
+    assert "--paginate" not in script
 
     # critical 判定で fail する前に、指摘本文が必ず PR へ投稿される
     assert steps.index(post) < steps.index(steps[-1])
@@ -134,6 +140,9 @@ def test_unchanged_diff_skips_the_paid_review_but_reapplies_the_verdict() -> Non
     assert "code-review-meta patch=" in previous["run"]
     assert "crit=" in previous["run"]
     assert "critical" not in previous["run"].split("code-review-meta")[1].splitlines()[0]
+    # comment_id も同じ 1 回の取得で拾い、Post review comment 側の再取得を不要にする
+    assert "comment_id=" in previous["run"]
+    assert previous["run"].count("gh api") == 1
 
     assert _review_step(review)["if"] == "steps.previous.outputs.skip != 'true'"
 

--- a/tests/repo/test_code_review_workflow.py
+++ b/tests/repo/test_code_review_workflow.py
@@ -86,7 +86,11 @@ def test_critical_findings_fail_the_check_via_structured_output() -> None:
     assert "report_markdown" in claude_args
 
     verdict = review["steps"][-1]
-    assert verdict["env"] == {"STRUCTURED_OUTPUT": "${{ steps.review.outputs.structured_output }}"}
+    assert verdict["env"] == {
+        "STRUCTURED_OUTPUT": "${{ steps.review.outputs.structured_output }}",
+        "SKIPPED": "${{ steps.previous.outputs.skip }}",
+        "PREV_CRIT": "${{ steps.previous.outputs.prev_crit }}",
+    }
     assert "critical" in verdict["run"]
     assert "exit 1" in verdict["run"]
 
@@ -106,7 +110,7 @@ def test_review_comment_is_upserted_by_a_workflow_step_not_by_claude() -> None:
     assert not [tool for tool in tools if tool.startswith("Bash(gh api")]
 
     post = next(step for step in steps if step.get("name") == "Post review comment")
-    assert post["if"] == "steps.review.outputs.structured_output != ''"
+    assert post["if"] == ("steps.previous.outputs.skip != 'true' && steps.review.outputs.structured_output != ''")
     assert post["env"]["STRUCTURED_OUTPUT"] == "${{ steps.review.outputs.structured_output }}"
     script = post["run"]
     assert "<!-- code-review-workflow -->" in script
@@ -116,6 +120,42 @@ def test_review_comment_is_upserted_by_a_workflow_step_not_by_claude() -> None:
     # critical 判定で fail する前に、指摘本文が必ず PR へ投稿される
     assert steps.index(post) < steps.index(steps[-1])
     assert steps[-1]["run"].find("exit 1") != -1
+
+
+def test_unchanged_diff_skips_the_paid_review_but_reapplies_the_verdict() -> None:
+    review = _workflow()["jobs"]["review"]
+    steps = review["steps"]
+
+    fingerprint = next(step for step in steps if step.get("id") == "fingerprint")
+    assert "git patch-id --stable" in fingerprint["run"]
+
+    previous = next(step for step in steps if step.get("id") == "previous")
+    # メタ行の語彙は crit= 固定(ci-autofix の severity パーサに "critical" を誤検出させない)
+    assert "code-review-meta patch=" in previous["run"]
+    assert "crit=" in previous["run"]
+    assert "critical" not in previous["run"].split("code-review-meta")[1].splitlines()[0]
+
+    assert _review_step(review)["if"] == "steps.previous.outputs.skip != 'true'"
+
+    verdict = steps[-1]
+    assert verdict["env"]["SKIPPED"] == "${{ steps.previous.outputs.skip }}"
+    assert verdict["env"]["PREV_CRIT"] == "${{ steps.previous.outputs.prev_crit }}"
+    assert "exit 1" in verdict["run"]
+
+
+def test_review_meta_line_never_matches_the_autofix_severity_parser() -> None:
+    """メタ行が ci-autofix の severity_count に数値として拾われないことの回帰ガード。"""
+    import subprocess
+
+    meta_line = "<!-- code-review-meta patch=0123abcd crit=3 -->"
+    result = subprocess.run(
+        ["bash", "-c", "grep -ioE 'critical[[:space:][:punct:]]*[0-9]+' || true"],
+        input=meta_line,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == ""
 
 
 def test_review_cannot_push_to_the_pr_branch() -> None:


### PR DESCRIPTION
## 概要
- PR diff の patch-id と前回レビューコメントの指紋を比較
- diff が同一なら有料レビューを省略し、前回の critical 判定を再適用
- メタ行と autofix severity parser の非干渉を contract test で固定

Closes #4601