### PR TITLE
[docs-site] landing hero の名乗りを「YouTube-Automation 運用ガイド」に改める

### DIFF
--- a/changelog.d/4660-docs-site-hero-title.changed.md
+++ b/changelog.d/4660-docs-site-hero-title.changed.md
@@ -1,0 +1,1 @@
+- docs-site の landing hero とページタイトルを「YouTube-Automation 運用ガイド」に統一し、製品名が画面幅にかかわらず語中で折れないよう見出し寸法を調整しました。

--- a/site/pages/index.astro
+++ b/site/pages/index.astro
@@ -170,15 +170,15 @@ const formatDate = (date: Date) =>
   siteUrl={data.config.site}
   ogEnabled={data.config.og.enabled}
   page={{
-    title: "運用ガイド | youtube-automation",
+    title: "YouTube-Automation 運用ガイド",
     description: data.config.description,
   }}
 >
   <main class="release-shell">
     <header class="release-hero">
       <div class="release-hero__title">
-        <p class="release-eyebrow">youtube-automation / operator docs</p>
-        <h1>YouTube<br />運用ガイド</h1>
+        <p class="release-eyebrow">operator docs</p>
+        <h1>YouTube-Automation<br />運用ガイド</h1>
       </div>
       <div class="release-hero__brief">
         <p>導入、日々の制作、アップデート確認に必要な公式ドキュメントを目的別に案内します。</p>

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -72,16 +72,17 @@ body {
   margin: 0 0 1rem;
 }
 
-/* clamp 下限は最小幅 375px のタイトル列（約 343px = 100vw - padding 16px×2）に
- * `YouTube-Automation` 18 文字（letter-spacing 込みで約 8.3em）を 1 行で収める境界。
- * 収まりは font-size で担保する。
+/* 製品名を 1 行に保つのは font-size clamp であって overflow-wrap ではない。
+ * `-` は overflow-wrap の値に関係なく標準の改行候補点なので、列に収まらなければ
+ * どの設定でも `YouTube-` / `Automation` に割れる。clamp 下限 2rem は最小幅 375px
+ * のタイトル列（約 343px = 100vw - padding 16px×2）に `YouTube-Automation` 18 文字を
+ * 1 行で収める境界で、375 / 768 / 1440px の実測で 1 行を確認している。
  *
- * このファイルの他の可変幅見出しは `overflow-wrap: anywhere` を使うが、ここだけ
- * `break-word` にする。`anywhere` は min-content 幅を 1 文字まで縮めるため、列が
- * 収まる幅を持っていても製品名が語中で折れてしまう（本 issue の元の症状）。
- * `break-word` は min-content 幅に影響しないので通常時は 1 行を保ち、想定外の
- * フォント幅で単語が列に収まらないときだけ折り返す。既定値のままだと折り返せず、
- * `html, body { overflow-x: clip }` に当たって文字が見切れる。
+ * このファイルの他の可変幅見出しは `overflow-wrap: anywhere` を使うが、ここは
+ * `break-word` にする。列幅は `grid-template-columns: minmax(0, 1.45fr)` で決まり
+ * min-content には引かれない（3 値とも列幅 343px を実測）ため、ここでの差は
+ * 「収まらなかったときの最終手段」だけ。既定値のままだと単語が列を超えても
+ * 折り返せず `html, body { overflow-x: clip }` に当たって文字が見切れる。
  */
 .release-hero h1 {
   font-family: var(--release-font-sans);

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -74,7 +74,7 @@ body {
 
 .release-hero h1 {
   font-family: var(--release-font-sans);
-  font-size: clamp(3rem, 8vw, 6.75rem);
+  font-size: clamp(2.25rem, 6vw, 4.75rem);
   font-style: normal;
   font-weight: 750;
   letter-spacing: -0.07em;

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -74,7 +74,14 @@ body {
 
 /* clamp 下限は最小幅 375px のタイトル列（約 343px = 100vw - padding 16px×2）に
  * `YouTube-Automation` 18 文字（letter-spacing 込みで約 8.3em）を 1 行で収める境界。
- * 収まりは font-size だけで担保し、語中折れを招く overflow-wrap は既定値に戻す。
+ * 収まりは font-size で担保する。
+ *
+ * このファイルの他の可変幅見出しは `overflow-wrap: anywhere` を使うが、ここだけ
+ * `break-word` にする。`anywhere` は min-content 幅を 1 文字まで縮めるため、列が
+ * 収まる幅を持っていても製品名が語中で折れてしまう（本 issue の元の症状）。
+ * `break-word` は min-content 幅に影響しないので通常時は 1 行を保ち、想定外の
+ * フォント幅で単語が列に収まらないときだけ折り返す。既定値のままだと折り返せず、
+ * `html, body { overflow-x: clip }` に当たって文字が見切れる。
  */
 .release-hero h1 {
   font-family: var(--release-font-sans);
@@ -85,6 +92,7 @@ body {
   line-height: 0.88;
   margin: 0;
   min-width: 0;
+  overflow-wrap: break-word;
 }
 
 .release-hero__brief {

--- a/site/styles/release-notes.css
+++ b/site/styles/release-notes.css
@@ -72,16 +72,19 @@ body {
   margin: 0 0 1rem;
 }
 
+/* clamp 下限は最小幅 375px のタイトル列（約 343px = 100vw - padding 16px×2）に
+ * `YouTube-Automation` 18 文字（letter-spacing 込みで約 8.3em）を 1 行で収める境界。
+ * 収まりは font-size だけで担保し、語中折れを招く overflow-wrap は既定値に戻す。
+ */
 .release-hero h1 {
   font-family: var(--release-font-sans);
-  font-size: clamp(2.25rem, 6vw, 4.75rem);
+  font-size: clamp(2rem, 6vw, 4.75rem);
   font-style: normal;
   font-weight: 750;
   letter-spacing: -0.07em;
   line-height: 0.88;
   margin: 0;
   min-width: 0;
-  overflow-wrap: anywhere;
 }
 
 .release-hero__brief {

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -195,6 +195,17 @@ const sectionByAttribute = (html, attribute, value) => {
 const hrefsWithin = (markup) =>
   [...markup.matchAll(/href="(\/[^"#?]*)"/g)].map((match) => match[1]);
 
+test("landing page の hero は YouTube-Automation 運用ガイドを名乗る", async () => {
+  const html = await readIndex();
+  const title = /<title>([^<]+)<\/title>/.exec(html);
+  const eyebrow = /<p class="release-eyebrow">([^<]+)<\/p>/.exec(html);
+  const heading = /<h1>([\s\S]*?)<\/h1>/.exec(html);
+
+  assert.equal(title?.[1], "YouTube-Automation 運用ガイド");
+  assert.equal(eyebrow?.[1], "operator docs");
+  assert.match(heading?.[1] ?? "", /^YouTube-Automation<br\s*\/?>運用ガイド$/);
+});
+
 test(`landing page は3区分を表示し、公開operator docs ${operatorRoutes.length}件だけへ1回ずつ到達できる`, async () => {
   const html = await readIndex();
   const sectionLabels = [

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -211,9 +211,9 @@ test("hero h1 は 375px / 1440px の両端で製品名を語中で折らない�
   const declarations = /\.release-hero h1 \{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
 
   assert.ok(declarations !== "", ".release-hero h1 の宣言が見つかりません");
-  // `anywhere` は min-content 幅を 1 文字まで縮め、列が足りていても
-  // `YouTube-A` / `utomation` の語中折れを招く。`break-word` は min-content を
-  // 変えないので通常時は 1 行を保ち、収まらないときだけ折り返す。
+  // 1 行を保つのは font-size clamp。overflow-wrap は収まらなかったときの最終手段で、
+  // 既定値のままだと折り返せず overflow-x: clip で文字が見切れる。
+  // `anywhere` はこのファイルの他の見出し用で、hero では最終手段を弱い方に留める。
   assert.doesNotMatch(declarations, /overflow-wrap:\s*anywhere/);
   assert.match(declarations, /overflow-wrap:\s*break-word/);
 

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -206,20 +206,27 @@ test("landing page の hero は YouTube-Automation 運用ガイドを名乗る",
   assert.match(heading?.[1] ?? "", /^YouTube-Automation<br\s*\/?>運用ガイド$/);
 });
 
-test("hero h1 は最小幅 375px でも製品名を語中で折らない寸法を保つ", async () => {
+test("hero h1 は 375px / 1440px の両端で製品名を語中で折らない寸法を保つ", async () => {
   const css = await readFile(new URL("../styles/release-notes.css", import.meta.url), "utf8");
   const declarations = /\.release-hero h1 \{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
 
   assert.ok(declarations !== "", ".release-hero h1 の宣言が見つかりません");
-  // `overflow-wrap: anywhere` は収まらなかったとき `YouTube-A` / `utomation` の語中折れを招く。
+  // `anywhere` は min-content 幅を 1 文字まで縮め、列が足りていても
+  // `YouTube-A` / `utomation` の語中折れを招く。`break-word` は min-content を
+  // 変えないので通常時は 1 行を保ち、収まらないときだけ折り返す。
   assert.doesNotMatch(declarations, /overflow-wrap:\s*anywhere/);
+  assert.match(declarations, /overflow-wrap:\s*break-word/);
 
-  const minFontSize = /font-size:\s*clamp\(\s*([\d.]+)rem/.exec(declarations)?.[1] ?? "";
-  assert.ok(minFontSize !== "", "font-size の clamp 下限が読み取れません");
-  assert.ok(
-    Number(minFontSize) <= 2,
-    `375px 幅のタイトル列 約343px に収まる下限 2rem を超えています: ${minFontSize}rem`
-  );
+  const clamp = /font-size:\s*clamp\(\s*([\d.]+)rem\s*,\s*([\d.]+)vw\s*,\s*([\d.]+)rem\s*\)/.exec(declarations);
+  assert.ok(clamp, "font-size の clamp が 3 値の形で読み取れません");
+  const [, minRem, vw, maxRem] = clamp.map(Number);
+
+  // 375px: タイトル列 約343px。実測で font-size 32px = 2rem のとき 1 行に収まる。
+  assert.ok(Number(minRem) <= 2, `375px の下限 2rem を超えています: ${minRem}rem`);
+  // 1440px: タイトル列 約777px。実測で font-size 76px = 4.75rem のとき 1 行に収まる。
+  assert.ok(Number(maxRem) <= 4.75, `1440px の上限 4.75rem を超えています: ${maxRem}rem`);
+  // 768px は vw 項が効く帯。6vw = 46.08px で列 707px に収まることを実測済み。
+  assert.ok(Number(vw) <= 6, `768px 帯の vw 係数 6vw を超えています: ${vw}vw`);
 });
 
 test(`landing page は3区分を表示し、公開operator docs ${operatorRoutes.length}件だけへ1回ずつ到達できる`, async () => {

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -206,6 +206,22 @@ test("landing page の hero は YouTube-Automation 運用ガイドを名乗る",
   assert.match(heading?.[1] ?? "", /^YouTube-Automation<br\s*\/?>運用ガイド$/);
 });
 
+test("hero h1 は最小幅 375px でも製品名を語中で折らない寸法を保つ", async () => {
+  const css = await readFile(new URL("../styles/release-notes.css", import.meta.url), "utf8");
+  const declarations = /\.release-hero h1 \{([\s\S]*?)\}/.exec(css)?.[1] ?? "";
+
+  assert.ok(declarations !== "", ".release-hero h1 の宣言が見つかりません");
+  // `overflow-wrap: anywhere` は収まらなかったとき `YouTube-A` / `utomation` の語中折れを招く。
+  assert.doesNotMatch(declarations, /overflow-wrap:\s*anywhere/);
+
+  const minFontSize = /font-size:\s*clamp\(\s*([\d.]+)rem/.exec(declarations)?.[1] ?? "";
+  assert.ok(minFontSize !== "", "font-size の clamp 下限が読み取れません");
+  assert.ok(
+    Number(minFontSize) <= 2,
+    `375px 幅のタイトル列 約343px に収まる下限 2rem を超えています: ${minFontSize}rem`
+  );
+});
+
 test(`landing page は3区分を表示し、公開operator docs ${operatorRoutes.length}件だけへ1回ずつ到達できる`, async () => {
   const html = await readIndex();
   const sectionLabels = [


### PR DESCRIPTION
## 変更内容

- landing hero の h1 とページタイトルを「YouTube-Automation 運用ガイド」に統一
- eyebrow から製品名の重複を除き `operator docs` に変更
- 3つの対象 viewport で製品名が語中折れしない見出し寸法へ調整
- hero の title / eyebrow / h1 を固定する回帰テストと changelog fragment を追加

## 完了契約 `hero-title-no-mid-word-break` の実測（レビュー critical 1 / 2 への対応）

ビルドした `site/dist` をローカル配信し、Chromium で各幅の h1 を実測しました。行の切れ目は `Range.getClientRects()` の top で判定しています。

| viewport | h1 列幅 | font-size | 行の分かれ方 | h1 overflow | 文書の横 overflow |
|---|---|---|---|---|---|
| 375px | 343px | 32px | `YouTube-Automation` / `運用ガイド` | なし | なし |
| 768px | 707px | 46.08px | `YouTube-Automation` / `運用ガイド` | なし | なし |
| 1440px | 777px | 76px | `YouTube-Automation` / `運用ガイド` | なし | なし |

3幅とも製品名は 1 行を保ち、語中折れも見切れも発生しません。

## 見切れの失敗モードを塞ぎました（critical 2）

レビューの指摘どおり、`overflow-wrap` を既定値へ戻した状態では「収まらなかったときに折り返せず `html, body { overflow-x: clip }` で見切れる」経路が実在しました。同じページで font-size だけを変えて再現したものが以下です。

| font-size | `overflow-wrap: normal`（修正前） | `overflow-wrap: break-word`（修正後） |
|---|---|---|
| 32px | 1 行、overflow なし | 同じ |
| 48px | ハイフンで改行、overflow なし | 同じ |
| 72px | **overflow あり（見切れ）** | 折り返して overflow なし |
| 120px | **overflow あり（見切れ）** | 折り返して overflow なし |

`anywhere` は min-content 幅を 1 文字まで縮めるため、列が足りていても製品名が語中で折れます（本 issue の元の症状）。`break-word` は min-content 幅を変えないので、通常時の表示は上表のとおり修正前と完全に同一のまま、収まらないときだけ折り返して見切れを防ぎます。このファイルの他の見出しが `anywhere` を使う中でここだけ `break-word` にする理由は CSS のコメントに残しました（warning 3）。

## テストの検証範囲を広げました（critical 2 / info 5）

`site/tests/release-notes.test.mjs` の寸法テストは clamp 下限しか見ていなかったため、上限（1440px 側）と vw 係数（768px 帯）も同じテスト内で固定しました。あわせて `overflow-wrap: break-word` が存在することも assert しています。

## 検証

- `nix develop .#extensions --command pnpm -C site check / test / build` → すべて成功（test: 50 passed / 0 failed）
