### PR TITLE
fix(config): 移行済み override を旧キーから解決する (#4681)

### DIFF
--- a/changelog.d/4681-legacy-config-override.fixed.md
+++ b/changelog.d/4681-legacy-config-override.fixed.md
@@ -1,0 +1,1 @@
+- 移行済みの統合先設定だけが存在する場合も、旧 skill-config キーから同じ channel override を解決できるようにしました。

--- a/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
+++ b/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
@@ -35,8 +35,6 @@ class MigrationPlan:
     orphans: tuple[Path, ...]
 
 
-# 統合先 skill と名前空間 loader key が成立した段から移行を有効化する。
-# apply は利用者の明示実行だけで行い、旧 loader key は互換入口として維持する。
 _COMPATIBLE_CONFIG_NAMES: Final[frozenset[str]] = frozenset({"postmortem"})
 
 

--- a/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
+++ b/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
@@ -13,15 +13,8 @@ from typing import Final, Mapping
 
 import yaml
 
+from youtube_automation.configuration.skills import SKILL_CONFIG_MIGRATIONS, SkillConfigMigration
 from youtube_automation.core.errors import ConfigError
-
-
-@dataclass(frozen=True, slots=True)
-class SkillConfigMigration:
-    """One old config filename and its consolidated destination."""
-
-    target_skill: str
-    section: str | None
 
 
 @dataclass(frozen=True, slots=True)
@@ -44,23 +37,6 @@ class MigrationPlan:
 
 # 統合先 skill と名前空間 loader key が成立した段から移行を有効化する。
 # apply は利用者の明示実行だけで行い、旧 loader key は互換入口として維持する。
-SKILL_CONFIG_MIGRATIONS: Final[Mapping[str, SkillConfigMigration]] = {
-    "benchmark": SkillConfigMigration("channel-research", "benchmark"),
-    "collection-ideate": SkillConfigMigration("wf-new", None),
-    "community-post": SkillConfigMigration("publish", "community"),
-    "live-clean": SkillConfigMigration("publish", "clean"),
-    "loop-video": SkillConfigMigration("thumbnail", "loop"),
-    "lyria": SkillConfigMigration("music", "generate"),
-    "masterup": SkillConfigMigration("music", "master"),
-    "suno": SkillConfigMigration("music", "prompt"),
-    "suno-lyric": SkillConfigMigration("music", "lyric"),
-    "metadata-audit": SkillConfigMigration("audit", "metadata"),
-    "video-upload": SkillConfigMigration("publish", "upload"),
-    "video-description": SkillConfigMigration("video", "describe"),
-    "videoup": SkillConfigMigration("video", "generate"),
-    "video-analyze": SkillConfigMigration("audit", "video"),
-}
-
 _COMPATIBLE_CONFIG_NAMES: Final[frozenset[str]] = frozenset({"postmortem"})
 
 

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -356,7 +356,12 @@ def _override_candidate_exists(path: Path, *, strict_regular_file: bool) -> bool
     return True
 
 
-def _resolve_channel_override(skill: str, target_channel_dir: Path | None = None) -> Path | None:
+def _resolve_channel_override(
+    skill: str,
+    target_channel_dir: Path | None = None,
+    *,
+    warning_stacklevel: int = 3,
+) -> Path | None:
     candidates = _channel_override_candidates(skill, target_channel_dir)
     selected = next(
         (path for path in candidates if _override_candidate_exists(path, strict_regular_file=skill == "masterup")),
@@ -366,7 +371,7 @@ def _resolve_channel_override(skill: str, target_channel_dir: Path | None = None
         warnings.warn(
             f"旧 skill-config {selected} を読み込みます。{candidates[0]} へリネームしてください。",
             UserWarning,
-            stacklevel=3,
+            stacklevel=warning_stacklevel,
         )
     return selected
 
@@ -455,6 +460,65 @@ def _select_moved_default_section(owner: str, defaults: dict[str, object]) -> di
     return dict(selected)
 
 
+def _resolve_skill_override(
+    skill: str,
+    owner: str,
+    channel_dir: Path | None,
+) -> tuple[Path | None, str | None, str | None]:
+    """override path と互換読込に必要な legacy owner / 移行先 section を返す。"""
+    override_path = _resolve_channel_override(owner, channel_dir, warning_stacklevel=5)
+    if override_path is not None:
+        return override_path, None, None
+
+    migration = SKILL_CONFIG_MIGRATIONS.get(skill)
+    if migration is not None:
+        override_path = _resolve_channel_override(migration.target_skill, channel_dir, warning_stacklevel=5)
+        if override_path is not None:
+            return override_path, None, migration.section
+
+    legacy_owner = _NAMESPACED_LEGACY_OVERRIDE_OWNERS.get(skill)
+    if legacy_owner is None:
+        return None, None, None
+    override_path = _resolve_channel_override(legacy_owner, channel_dir, warning_stacklevel=5)
+    return override_path, legacy_owner if override_path is not None else None, None
+
+
+def _merge_skill_channel_override(
+    skill: str,
+    owner: str,
+    section: str | None,
+    defaults: dict[str, Any],
+    channel_dir: Path | None,
+) -> dict[str, Any]:
+    override_path, legacy_override_owner, migrated_override_section = _resolve_skill_override(
+        skill, owner, channel_dir
+    )
+    if override_path is None:
+        return defaults
+
+    override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
+    if migrated_override_section is not None:
+        migrated = override.get(migrated_override_section)
+        if not isinstance(migrated, dict):
+            raise ConfigError(
+                f"skill-config {override_path} の移行先 {migrated_override_section!r} は "
+                "mapping である必要があります"
+            )
+        override = dict(migrated)
+    if legacy_override_owner is not None and section is not None:
+        override = {section: override}
+
+    merged = _deep_merge(defaults, override)
+    warning_owner = legacy_override_owner or owner
+    warning_override = override[section] if legacy_override_owner is not None and section is not None else override
+    warning_defaults = defaults[section] if legacy_override_owner is not None and section is not None else defaults
+    _warn_deprecated_override_keys(warning_owner, warning_override, override_path, merged)
+    _warn_unknown_top_level_override_keys(
+        warning_owner, warning_override, warning_defaults, override_path, acknowledged
+    )
+    return merged
+
+
 def load_skill_config(
     skill: str,
     *,
@@ -486,37 +550,7 @@ def load_skill_config(
     defaults = _load_yaml(_default_path(owner))
     defaults = _select_moved_default_section(owner, defaults)
 
-    override_path = _resolve_channel_override(owner, channel_dir)
-    migrated_override_section: str | None = None
-    if override_path is None and (migration := SKILL_CONFIG_MIGRATIONS.get(skill)) is not None:
-        override_path = _resolve_channel_override(migration.target_skill, channel_dir)
-        migrated_override_section = migration.section if override_path is not None else None
-    legacy_override_owner: str | None = None
-    if override_path is None and (legacy_owner := _NAMESPACED_LEGACY_OVERRIDE_OWNERS.get(skill)) is not None:
-        override_path = _resolve_channel_override(legacy_owner, channel_dir)
-        legacy_override_owner = legacy_owner if override_path is not None else None
-    if override_path is not None:
-        override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
-        if migrated_override_section is not None:
-            migrated = override.get(migrated_override_section)
-            if not isinstance(migrated, dict):
-                raise ConfigError(
-                    f"skill-config {override_path} の移行先 {migrated_override_section!r} は "
-                    "mapping である必要があります"
-                )
-            override = dict(migrated)
-        if legacy_override_owner is not None and section is not None:
-            override = {section: override}
-        merged = _deep_merge(defaults, override)
-        warning_owner = legacy_override_owner or owner
-        warning_override = override[section] if legacy_override_owner is not None and section is not None else override
-        warning_defaults = defaults[section] if legacy_override_owner is not None and section is not None else defaults
-        _warn_deprecated_override_keys(warning_owner, warning_override, override_path, merged)
-        _warn_unknown_top_level_override_keys(
-            warning_owner, warning_override, warning_defaults, override_path, acknowledged
-        )
-    else:
-        merged = defaults
+    merged = _merge_skill_channel_override(skill, owner, section, defaults, channel_dir)
 
     if section is not None:
         selected = merged.get(section)

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -487,12 +487,10 @@ def _merge_skill_channel_override(
     skill: str,
     owner: str,
     section: str | None,
-    defaults: dict[str, Any],
+    defaults: dict[str, object],
     channel_dir: Path | None,
-) -> dict[str, Any]:
-    override_path, legacy_override_owner, migrated_override_section = _resolve_skill_override(
-        skill, owner, channel_dir
-    )
+) -> dict[str, object]:
+    override_path, legacy_override_owner, migrated_override_section = _resolve_skill_override(skill, owner, channel_dir)
     if override_path is None:
         return defaults
 
@@ -501,8 +499,7 @@ def _merge_skill_channel_override(
         migrated = override.get(migrated_override_section)
         if not isinstance(migrated, dict):
             raise ConfigError(
-                f"skill-config {override_path} の移行先 {migrated_override_section!r} は "
-                "mapping である必要があります"
+                f"skill-config {override_path} の移行先 {migrated_override_section!r} は mapping である必要があります"
             )
         override = dict(migrated)
     if legacy_override_owner is not None and section is not None:

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -24,6 +24,7 @@ import json
 import stat
 import warnings
 from collections.abc import Mapping
+from dataclasses import dataclass
 from importlib.resources import as_file, files
 from pathlib import Path
 from typing import Any, Final
@@ -34,6 +35,32 @@ from youtube_automation.configuration import channel_dir as configured_channel_d
 from youtube_automation.core.errors import ConfigError
 
 _cache: dict[str, dict[str, Any]] = {}
+
+
+@dataclass(frozen=True, slots=True)
+class SkillConfigMigration:
+    """旧 config filename と統合先の対応。"""
+
+    target_skill: str
+    section: str | None
+
+
+SKILL_CONFIG_MIGRATIONS: Final[Mapping[str, SkillConfigMigration]] = {
+    "benchmark": SkillConfigMigration("channel-research", "benchmark"),
+    "collection-ideate": SkillConfigMigration("wf-new", None),
+    "community-post": SkillConfigMigration("publish", "community"),
+    "live-clean": SkillConfigMigration("publish", "clean"),
+    "loop-video": SkillConfigMigration("thumbnail", "loop"),
+    "lyria": SkillConfigMigration("music", "generate"),
+    "masterup": SkillConfigMigration("music", "master"),
+    "suno": SkillConfigMigration("music", "prompt"),
+    "suno-lyric": SkillConfigMigration("music", "lyric"),
+    "metadata-audit": SkillConfigMigration("audit", "metadata"),
+    "video-upload": SkillConfigMigration("publish", "upload"),
+    "video-description": SkillConfigMigration("video", "describe"),
+    "videoup": SkillConfigMigration("video", "generate"),
+    "video-analyze": SkillConfigMigration("audit", "video"),
+}
 
 SKILL_CONFIG_KEYS: Final[frozenset[str]] = frozenset(
     {
@@ -460,12 +487,24 @@ def load_skill_config(
     defaults = _select_moved_default_section(owner, defaults)
 
     override_path = _resolve_channel_override(owner, channel_dir)
+    migrated_override_section: str | None = None
+    if override_path is None and (migration := SKILL_CONFIG_MIGRATIONS.get(skill)) is not None:
+        override_path = _resolve_channel_override(migration.target_skill, channel_dir)
+        migrated_override_section = migration.section if override_path is not None else None
     legacy_override_owner: str | None = None
     if override_path is None and (legacy_owner := _NAMESPACED_LEGACY_OVERRIDE_OWNERS.get(skill)) is not None:
         override_path = _resolve_channel_override(legacy_owner, channel_dir)
         legacy_override_owner = legacy_owner if override_path is not None else None
     if override_path is not None:
         override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
+        if migrated_override_section is not None:
+            migrated = override.get(migrated_override_section)
+            if not isinstance(migrated, dict):
+                raise ConfigError(
+                    f"skill-config {override_path} の移行先 {migrated_override_section!r} は "
+                    "mapping である必要があります"
+                )
+            override = dict(migrated)
         if legacy_override_owner is not None and section is not None:
             override = {section: override}
         merged = _deep_merge(defaults, override)

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -511,7 +511,9 @@ def _merge_skill_channel_override(
 
     override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
     if resolution.migrated_section is not None:
-        migrated = override.get(resolution.migrated_section)
+        if resolution.migrated_section not in override:
+            return defaults
+        migrated = override[resolution.migrated_section]
         if not isinstance(migrated, dict):
             raise ConfigError(
                 f"skill-config {override_path} の移行先 {resolution.migrated_section!r} は mapping である必要があります"

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -27,7 +27,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from importlib.resources import as_file, files
 from pathlib import Path
-from typing import Any, Final
+from typing import Any, Final, NamedTuple
 
 import yaml
 
@@ -45,6 +45,8 @@ class SkillConfigMigration:
     section: str | None
 
 
+# 統合先 skill と名前空間 loader key が成立した段から移行を有効化する。
+# apply は利用者の明示実行だけで行い、旧 loader key は互換入口として維持する。
 SKILL_CONFIG_MIGRATIONS: Final[Mapping[str, SkillConfigMigration]] = {
     "benchmark": SkillConfigMigration("channel-research", "benchmark"),
     "collection-ideate": SkillConfigMigration("wf-new", None),
@@ -209,6 +211,8 @@ def _warn_deprecated_override_keys(
     override: dict[str, object],
     override_path: Path,
     merged: dict[str, object],
+    *,
+    warning_stacklevel: int = 3,
 ) -> None:
     image_generation = merged.get("image_generation")
     codex_provider = isinstance(image_generation, dict) and image_generation.get("provider") == "codex"
@@ -226,7 +230,7 @@ def _warn_deprecated_override_keys(
         "後続リリースで削除予定です（現時点では従来どおり deep-merge されます）。"
         f"意図は {migration_target} へ移行してください (#1702)。",
         DeprecationWarning,
-        stacklevel=3,
+        stacklevel=warning_stacklevel,
     )
 
 
@@ -251,6 +255,8 @@ def _warn_unknown_top_level_override_keys(
     defaults: dict[str, object],
     override_path: Path,
     acknowledged: set[str],
+    *,
+    warning_stacklevel: int = 3,
 ) -> None:
     known_keys = defaults.keys() | _KNOWN_OVERRIDE_ONLY_KEYS.get(skill, frozenset())
     unknown_keys = sorted(override.keys() - known_keys - acknowledged)
@@ -269,7 +275,7 @@ def _warn_unknown_top_level_override_keys(
         "値は互換性のためマージされますが、コードからは参照されない可能性があります。"
         "SKILL.md 経由で AI が読む設計であれば意図どおりです。",
         UserWarning,
-        stacklevel=3,
+        stacklevel=warning_stacklevel,
     )
 
 
@@ -460,27 +466,35 @@ def _select_moved_default_section(owner: str, defaults: dict[str, object]) -> di
     return dict(selected)
 
 
+class _SkillOverrideResolution(NamedTuple):
+    """解決した override path と、互換読込に必要な legacy owner / 移行先 section。"""
+
+    path: Path | None
+    legacy_owner: str | None
+    migrated_section: str | None
+
+
 def _resolve_skill_override(
     skill: str,
     owner: str,
     channel_dir: Path | None,
-) -> tuple[Path | None, str | None, str | None]:
+) -> _SkillOverrideResolution:
     """override path と互換読込に必要な legacy owner / 移行先 section を返す。"""
     override_path = _resolve_channel_override(owner, channel_dir, warning_stacklevel=5)
     if override_path is not None:
-        return override_path, None, None
+        return _SkillOverrideResolution(override_path, None, None)
 
     migration = SKILL_CONFIG_MIGRATIONS.get(skill)
     if migration is not None:
         override_path = _resolve_channel_override(migration.target_skill, channel_dir, warning_stacklevel=5)
         if override_path is not None:
-            return override_path, None, migration.section
+            return _SkillOverrideResolution(override_path, None, migration.section)
 
     legacy_owner = _NAMESPACED_LEGACY_OVERRIDE_OWNERS.get(skill)
     if legacy_owner is None:
-        return None, None, None
+        return _SkillOverrideResolution(None, None, None)
     override_path = _resolve_channel_override(legacy_owner, channel_dir, warning_stacklevel=5)
-    return override_path, legacy_owner if override_path is not None else None, None
+    return _SkillOverrideResolution(override_path, legacy_owner if override_path is not None else None, None)
 
 
 def _merge_skill_channel_override(
@@ -490,28 +504,33 @@ def _merge_skill_channel_override(
     defaults: dict[str, object],
     channel_dir: Path | None,
 ) -> dict[str, object]:
-    override_path, legacy_override_owner, migrated_override_section = _resolve_skill_override(skill, owner, channel_dir)
+    resolution = _resolve_skill_override(skill, owner, channel_dir)
+    override_path = resolution.path
     if override_path is None:
         return defaults
 
     override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
-    if migrated_override_section is not None:
-        migrated = override.get(migrated_override_section)
+    if resolution.migrated_section is not None:
+        migrated = override.get(resolution.migrated_section)
         if not isinstance(migrated, dict):
             raise ConfigError(
-                f"skill-config {override_path} の移行先 {migrated_override_section!r} は mapping である必要があります"
+                f"skill-config {override_path} の移行先 {resolution.migrated_section!r} は mapping である必要があります"
             )
         override = dict(migrated)
-    if legacy_override_owner is not None and section is not None:
-        override = {section: override}
+    # legacy owner の override は節を持たないため、名前空間キー側の節へ包み直す。
+    legacy_section = section if resolution.legacy_owner is not None else None
+    if legacy_section is not None:
+        override = {legacy_section: override}
 
     merged = _deep_merge(defaults, override)
-    warning_owner = legacy_override_owner or owner
-    warning_override = override[section] if legacy_override_owner is not None and section is not None else override
-    warning_defaults = defaults[section] if legacy_override_owner is not None and section is not None else defaults
-    _warn_deprecated_override_keys(warning_owner, warning_override, override_path, merged)
+    warning_owner = resolution.legacy_owner or owner
+    warning_override = override[legacy_section] if legacy_section is not None else override
+    warning_defaults = defaults[legacy_section] if legacy_section is not None else defaults
+    # load_skill_config → _merge_skill_channel_override → 警告関数の 3 段を辿って
+    # 呼び出し元コードを指す。
+    _warn_deprecated_override_keys(warning_owner, warning_override, override_path, merged, warning_stacklevel=4)
     _warn_unknown_top_level_override_keys(
-        warning_owner, warning_override, warning_defaults, override_path, acknowledged
+        warning_owner, warning_override, warning_defaults, override_path, acknowledged, warning_stacklevel=4
     )
     return merged
 

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -291,6 +291,8 @@ def test_unknown_top_level_override_key_warns_but_still_merges(tmp_path, monkeyp
     assert "コードからは参照されない可能性があります" in message
     assert "SKILL.md 経由で AI が読む設計であれば意図どおりです" in message
     assert "利用側に参照されない可能性があります" not in message
+    # 警告の発生位置は loader 内部ではなく呼び出し元コードを指す
+    assert caught[0].filename == __file__
 
 
 def test_acknowledged_unknown_keys_suppress_only_named_warning(tmp_path, monkeypatch):
@@ -419,6 +421,8 @@ def test_thumbnail_deprecated_override_keys_warn_but_still_merge(tmp_path, monke
     assert "image_generation.gemini.composition_rules.environment" in message
     assert "image_generation.gemini.thumbnail_text.copy_position" in message
     assert "#1702" in message
+    # 警告の発生位置は loader 内部ではなく呼び出し元コードを指す
+    assert records[0].filename == __file__
     # override は従来どおり有効（後方互換 no-op を維持）
     gemini = cfg["image_generation"]["gemini"]
     assert gemini["composition_rules"]["environment"] == "cozy tavern"

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -144,6 +144,59 @@ def test_load_namespaced_skill_config_uses_legacy_owner_override(
     assert loaded == {"model": "legacy-custom"}
 
 
+@pytest.mark.parametrize(
+    ("legacy_key", "target_skill", "section"),
+    [
+        (source, migration.target_skill, migration.section)
+        for source, migration in skill_config.SKILL_CONFIG_MIGRATIONS.items()
+    ],
+)
+def test_legacy_skill_config_uses_migrated_override_when_legacy_file_is_absent(
+    tmp_path: Path,
+    legacy_key: str,
+    target_skill: str,
+    section: str | None,
+) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    migrated_override = {"migration_test_marker": legacy_key}
+    target_override = (
+        {**migrated_override, "acknowledged_unknown_keys": ["migration_test_marker"]}
+        if section is None
+        else {section: migrated_override, "acknowledged_unknown_keys": ["migration_test_marker"]}
+    )
+    (overrides / f"{target_skill}.yaml").write_text(yaml.safe_dump(target_override), encoding="utf-8")
+
+    loaded = skill_config.load_skill_config(legacy_key, use_cache=False, channel_dir=tmp_path)
+
+    assert loaded["migration_test_marker"] == legacy_key
+
+
+def test_legacy_and_namespaced_keys_resolve_the_same_migrated_override(tmp_path: Path) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "thumbnail.yaml").write_text(
+        "loop:\n  skip_preview_approval: true\n",
+        encoding="utf-8",
+    )
+
+    legacy = skill_config.load_skill_config("loop-video", use_cache=False, channel_dir=tmp_path)
+    namespaced = skill_config.load_skill_config("thumbnail", use_cache=False, channel_dir=tmp_path)["loop"]
+
+    assert legacy == namespaced
+
+
+def test_legacy_skill_config_file_keeps_priority_over_migrated_override(tmp_path: Path) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "loop-video.yaml").write_text("skip_preview_approval: true\n", encoding="utf-8")
+    (overrides / "thumbnail.yaml").write_text("loop:\n  skip_preview_approval: false\n", encoding="utf-8")
+
+    loaded = skill_config.load_skill_config("loop-video", use_cache=False, channel_dir=tmp_path)
+
+    assert loaded["skip_preview_approval"] is True
+
+
 def test_load_namespaced_skill_config_rejects_missing_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     default_path = tmp_path / "music.default.yaml"
     default_path.write_text("master:\n  target_lufs: -14\n", encoding="utf-8")

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -197,6 +197,33 @@ def test_legacy_skill_config_file_keeps_priority_over_migrated_override(tmp_path
     assert loaded["skip_preview_approval"] is True
 
 
+def test_legacy_skill_config_uses_defaults_when_migrated_override_section_is_absent(tmp_path: Path) -> None:
+    expected = skill_config.load_skill_config(
+        "loop-video",
+        use_cache=False,
+        channel_dir=tmp_path / "without-overrides",
+    )
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "thumbnail.yaml").write_text(
+        "image_generation:\n  provider: gemini\n",
+        encoding="utf-8",
+    )
+
+    loaded = skill_config.load_skill_config("loop-video", use_cache=False, channel_dir=tmp_path)
+
+    assert loaded == expected
+
+
+def test_legacy_skill_config_rejects_non_mapping_migrated_override_section(tmp_path: Path) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "thumbnail.yaml").write_text("loop: null\n", encoding="utf-8")
+
+    with pytest.raises(ConfigError, match="移行先 'loop' は mapping"):
+        skill_config.load_skill_config("loop-video", use_cache=False, channel_dir=tmp_path)
+
+
 def test_load_namespaced_skill_config_rejects_missing_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     default_path = tmp_path / "music.default.yaml"
     default_path.write_text("master:\n  target_lufs: -14\n", encoding="utf-8")


### PR DESCRIPTION
## 概要

- migration table を設定層へ集約
- legacy key から統合先 section の channel override を解決
- 旧ファイル優先順位と全 migration mapping を回帰テストで固定

Closes #4681