### PR TITLE
fix(config): migration の loader 経路を lint する (#4683)

### DIFF
--- a/changelog.d/4683-config-migration-lint.fixed.md
+++ b/changelog.d/4683-config-migration-lint.fixed.md
@@ -1,1 +1,1 @@
-- `yt-skills lint` で config migration と互換 loader 経路の対応を検証し、不整合な移行定義を修正方法付きで報告するようにしました。
+- `yt-skills lint` で config migration の移行先を loader の互換 fallback が解決できるか検証し、登録キー・同梱 default・移行先の節の不整合を修正箇所付きで報告するようにしました。

--- a/changelog.d/4683-config-migration-lint.fixed.md
+++ b/changelog.d/4683-config-migration-lint.fixed.md
@@ -1,0 +1,1 @@
+- `yt-skills lint` で config migration と互換 loader 経路の対応を検証し、不整合な移行定義を修正方法付きで報告するようにしました。

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -142,16 +142,19 @@ def _lint_unmigrated_skill_configs(channel_dir: Path) -> list[str]:
 def _lint_skill_config_migrations(
     migrations: Mapping[str, skill_config.SkillConfigMigration],
 ) -> list[str]:
-    """migration table と公開 loader の互換 fallback が一致するか検証する。"""
+    """移行先 override を loader の互換 fallback が解決できるか検証する。
+
+    判定は loader 側の登録表を単一ソースとする
+    `skill_config.skill_config_migration_loader_gaps` に委ね、ここでは診断文へ整形する。
+    """
     violations: list[str] = []
     for source, migration in sorted(migrations.items()):
-        if skill_config.SKILL_CONFIG_MIGRATIONS.get(source) == migration:
+        gaps = skill_config.skill_config_migration_loader_gaps(source, migration)
+        if not gaps:
             continue
         section_suffix = f"::{migration.section}" if migration.section is not None else ""
-        violations.append(
-            f"{source} -> {migration.target_skill}{section_suffix} に互換 loader 経路がありません: "
-            "youtube_automation.configuration.skills.SKILL_CONFIG_MIGRATIONS に同じ対応を登録してください"
-        )
+        route = f"{source} -> {migration.target_skill}{section_suffix}"
+        violations.append(f"{route} に互換 loader 経路がありません: {' / '.join(gaps)}")
     return violations
 
 

--- a/src/youtube_automation/commands/system/skills_sync/_lint.py
+++ b/src/youtube_automation/commands/system/skills_sync/_lint.py
@@ -21,7 +21,7 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
     11. SKILL.md 本体が 400 行以下である
     12. 成果物ブロックと `書き込む` 宣言行が存在する
     13. skill-config の登録キーと config.default.yaml が双方向に一致する
-    14. 下流に移行対応表の旧 skill-config が残っていない
+    14. config migration に互換 loader 経路があり、下流に旧 skill-config が残っていない
     15. downstream 配布対象の skill が総数上限以下である
     16. 運用成果物 inventory の owner / schema / consumer / JSON+HTML pair が一致する
 """
@@ -29,6 +29,7 @@ skill 編集後の検証を pytest 全体実行 (約 4 分) に律速されず�
 from __future__ import annotations
 
 import argparse
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
 
@@ -138,6 +139,22 @@ def _lint_unmigrated_skill_configs(channel_dir: Path) -> list[str]:
     ]
 
 
+def _lint_skill_config_migrations(
+    migrations: Mapping[str, skill_config.SkillConfigMigration],
+) -> list[str]:
+    """migration table と公開 loader の互換 fallback が一致するか検証する。"""
+    violations: list[str] = []
+    for source, migration in sorted(migrations.items()):
+        if skill_config.SKILL_CONFIG_MIGRATIONS.get(source) == migration:
+            continue
+        section_suffix = f"::{migration.section}" if migration.section is not None else ""
+        violations.append(
+            f"{source} -> {migration.target_skill}{section_suffix} に互換 loader 経路がありません: "
+            "youtube_automation.configuration.skills.SKILL_CONFIG_MIGRATIONS に同じ対応を登録してください"
+        )
+    return violations
+
+
 def _distributed_skill_names(inventory: SkillInventory) -> tuple[str, ...]:
     """Return real sync candidates, excluding dev-only and non-skill residue."""
     return tuple(
@@ -186,7 +203,13 @@ def cmd_lint(args: argparse.Namespace) -> int:
         targets = available
 
     skill_config_violations = (
-        [] if requested else [*_lint_skill_config_contract(inventory), *_lint_unmigrated_skill_configs(Path.cwd())]
+        []
+        if requested
+        else [
+            *_lint_skill_config_contract(inventory),
+            *_lint_skill_config_migrations(_migrate_config.SKILL_CONFIG_MIGRATIONS),
+            *_lint_unmigrated_skill_configs(Path.cwd()),
+        ]
     )
     skill_count_violation = None if requested else _skill_count_violation(inventory)
     artifact_violations = [] if requested else _operational_artifact_violations(root, inventory)

--- a/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
+++ b/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
@@ -13,7 +13,12 @@ from typing import Final, Mapping
 
 import yaml
 
-from youtube_automation.configuration.skills import SKILL_CONFIG_MIGRATIONS, SkillConfigMigration, load_skill_config
+from youtube_automation.configuration.skills import (
+    SKILL_CONFIG_MIGRATIONS,
+    SkillConfigMigration,
+    load_skill_config,
+    skill_config_migration_section_path,
+)
 from youtube_automation.core.errors import ConfigError
 
 
@@ -97,12 +102,27 @@ def build_migration_plan(
             destinations[destination] = source_data
             actions.append(MigrationAction(source, destination, migration.section))
             continue
-        existing = destination_data.get(migration.section)
-        if migration.section in destination_data and existing != source_data:
+        section_path = skill_config_migration_section_path(source_name, migration)
+        destination_section = destination_data
+        for path_part in section_path[:-1]:
+            existing_parent = destination_section.get(path_part)
+            if existing_parent is None:
+                nested: dict[str, object] = {}
+                destination_section[path_part] = nested
+                destination_section = nested
+            elif isinstance(existing_parent, dict):
+                destination_section = existing_parent
+            else:
+                dotted = ".".join(section_path[:-1])
+                raise ConfigError(f"移行先の節が mapping ではありません: {destination}::{dotted}")
+        leaf = section_path[-1]
+        existing = destination_section.get(leaf)
+        if leaf in destination_section and existing != source_data:
+            dotted = ".".join(section_path)
             raise ConfigError(
-                f"移行先の節が既存内容と衝突しています: {destination}::{migration.section} (既存内容を上書きしません)"
+                f"移行先の節が既存内容と衝突しています: {destination}::{dotted} (既存内容を上書きしません)"
             )
-        destination_data[migration.section] = source_data
+        destination_section[leaf] = source_data
         actions.append(MigrationAction(source, destination, migration.section))
 
     return MigrationPlan(

--- a/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
+++ b/src/youtube_automation/commands/system/skills_sync/_migrate_config.py
@@ -73,6 +73,40 @@ def _orphan_configs(
     return tuple(path for path in sorted(config_dir.glob("*.yaml")) if path.is_file() and path.stem not in known)
 
 
+def _merge_source_into_destination(
+    destination: Path,
+    destination_data: dict[str, object],
+    section_path: tuple[str, ...],
+    source_data: dict[str, object],
+) -> dict[str, object]:
+    """source data を section path へ衝突なしで配置する。"""
+    if not section_path:
+        if destination_data and destination_data != source_data:
+            raise ConfigError(f"移行先に既存内容があります: {destination} (既存内容を上書きしません)")
+        return source_data
+
+    destination_section = destination_data
+    for path_part in section_path[:-1]:
+        existing_parent = destination_section.get(path_part)
+        if existing_parent is None:
+            nested: dict[str, object] = {}
+            destination_section[path_part] = nested
+            destination_section = nested
+        elif isinstance(existing_parent, dict):
+            destination_section = existing_parent
+        else:
+            dotted = ".".join(section_path[:-1])
+            raise ConfigError(f"移行先の節が mapping ではありません: {destination}::{dotted}")
+
+    leaf = section_path[-1]
+    existing = destination_section.get(leaf)
+    if leaf in destination_section and existing != source_data:
+        dotted = ".".join(section_path)
+        raise ConfigError(f"移行先の節が既存内容と衝突しています: {destination}::{dotted} (既存内容を上書きしません)")
+    destination_section[leaf] = source_data
+    return destination_data
+
+
 def build_migration_plan(
     channel_dir: Path,
     migrations: Mapping[str, SkillConfigMigration],
@@ -95,34 +129,13 @@ def build_migration_plan(
         source_data = _load_mapping(source)
         if destination not in destinations:
             destinations[destination] = _load_mapping(destination) if destination.is_file() else {}
-        destination_data = destinations[destination]
-        if migration.section is None:
-            if destination_data and destination_data != source_data:
-                raise ConfigError(f"移行先に既存内容があります: {destination} (既存内容を上書きしません)")
-            destinations[destination] = source_data
-            actions.append(MigrationAction(source, destination, migration.section))
-            continue
         section_path = skill_config_migration_section_path(source_name, migration)
-        destination_section = destination_data
-        for path_part in section_path[:-1]:
-            existing_parent = destination_section.get(path_part)
-            if existing_parent is None:
-                nested: dict[str, object] = {}
-                destination_section[path_part] = nested
-                destination_section = nested
-            elif isinstance(existing_parent, dict):
-                destination_section = existing_parent
-            else:
-                dotted = ".".join(section_path[:-1])
-                raise ConfigError(f"移行先の節が mapping ではありません: {destination}::{dotted}")
-        leaf = section_path[-1]
-        existing = destination_section.get(leaf)
-        if leaf in destination_section and existing != source_data:
-            dotted = ".".join(section_path)
-            raise ConfigError(
-                f"移行先の節が既存内容と衝突しています: {destination}::{dotted} (既存内容を上書きしません)"
-            )
-        destination_section[leaf] = source_data
+        destinations[destination] = _merge_source_into_destination(
+            destination,
+            destinations[destination],
+            section_path,
+            source_data,
+        )
         actions.append(MigrationAction(source, destination, migration.section))
 
     return MigrationPlan(

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -327,9 +327,15 @@ def skill_config_migration_loader_gaps(source: str, migration: SkillConfigMigrat
         )
     # migration は移行先ファイル直下の節へ配置し、loader はそこから同梱 default と
     # 同じ full path を辿る。したがって migration の節は full path の入口と一致する必要がある。
-    expected_path = skill_config_migration_section_path(source, migration)
+    configured_path = _MOVED_SKILL_CONFIG_SECTIONS.get(source)
+    if migration.section is not None and configured_path is None:
+        gaps.append(
+            f"移行元 {source} の full section path が未登録です "
+            f"(_MOVED_SKILL_CONFIG_SECTIONS[{source!r}] を登録してください)"
+        )
+    expected_path = configured_path or ()
     expected_section = expected_path[0] if expected_path else None
-    if migration.section != expected_section:
+    if configured_path is not None and migration.section != expected_section:
         dotted = ".".join(expected_path) if expected_path else None
         gaps.append(
             f"移行先の節 {migration.section!r} が同梱 default の節 "

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -296,6 +296,39 @@ def skill_config_default_relative_path(skill: str) -> Path:
     return _MOVED_SKILL_CONFIG_DEFAULTS.get(skill, Path(skill, "config.default.yaml"))
 
 
+def skill_config_migration_loader_gaps(source: str, migration: SkillConfigMigration) -> tuple[str, ...]:
+    """migration の移行先を loader が解決できない理由を返す (空なら互換)。
+
+    旧 config を移行した後、`_resolve_skill_override` は `SKILL_CONFIG_MIGRATIONS`
+    経由で `<target_skill>.yaml` の `section` 節を旧キーの override として読み、
+    同梱 default は `_MOVED_SKILL_CONFIG_DEFAULTS` / `_MOVED_SKILL_CONFIG_SECTIONS`
+    で解決する。この 3 表が食い違うと移行後に設定が失効するため、静的に照合する。
+    """
+    gaps: list[str] = []
+    if source not in SKILL_CONFIG_KEYS | SKILL_ONLY_CONFIG_KEYS | _LEGACY_SKILL_CONFIG_ALIASES:
+        gaps.append(
+            f"移行元 {source} が loader の登録キーではないため load_skill_config から辿れません "
+            "(SKILL_CONFIG_KEYS / SKILL_ONLY_CONFIG_KEYS のいずれかに登録してください)"
+        )
+    default_owner = skill_config_default_relative_path(source).parts[0]
+    if default_owner != migration.target_skill:
+        gaps.append(
+            f"同梱 default が {default_owner}/ 配下のため "
+            f"移行先 {migration.target_skill} の override と噛み合いません "
+            f"(_MOVED_SKILL_CONFIG_DEFAULTS[{source!r}] を確認してください)"
+        )
+    # 移行後の override は移行先ファイル直下の 1 節として読むため、同梱 default 側の
+    # 節パス先頭 (未登録ならファイル全体 = None) と一致していなければ値が拾われない。
+    expected_section = next(iter(_MOVED_SKILL_CONFIG_SECTIONS.get(source, ())), None)
+    if migration.section != expected_section:
+        gaps.append(
+            f"移行先の節 {migration.section!r} が同梱 default の節 "
+            f"{expected_section!r} と一致しません "
+            f"(_MOVED_SKILL_CONFIG_SECTIONS[{source!r}] を確認してください)"
+        )
+    return tuple(gaps)
+
+
 def _default_path(skill: str) -> Path:
     """パッケージ同梱の default.yaml を解決する。
 

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -547,6 +547,31 @@ def _resolve_skill_override(
     return _SkillOverrideResolution(override_path, legacy_owner if override_path is not None else None, ())
 
 
+def _select_migrated_override(
+    override: dict[str, object],
+    section_path: tuple[str, ...],
+    defaults: dict[str, object],
+    override_path: Path,
+) -> dict[str, object] | None:
+    """full path の override を選び、旧 migrate-config の flat 形式も互換読込する。"""
+    migrated: object = override
+    for index, migrated_section in enumerate(section_path):
+        if not isinstance(migrated, dict):
+            dotted = ".".join(section_path[:index])
+            raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
+        if migrated_section not in migrated:
+            # 旧 migrate-config は多階層 path の入口へ source mapping を直接保存した。
+            # 最終 segment だけが無く、legacy default のキーがある場合に限り旧形式と判定する。
+            if index == len(section_path) - 1 and migrated.keys() & defaults.keys():
+                return dict(migrated)
+            return None
+        migrated = migrated[migrated_section]
+    if not isinstance(migrated, dict):
+        dotted = ".".join(section_path)
+        raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
+    return dict(migrated)
+
+
 def _merge_skill_channel_override(
     skill: str,
     owner: str,
@@ -561,18 +586,10 @@ def _merge_skill_channel_override(
 
     override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
     if resolution.migrated_section_path:
-        migrated: object = override
-        for index, migrated_section in enumerate(resolution.migrated_section_path):
-            if not isinstance(migrated, dict):
-                dotted = ".".join(resolution.migrated_section_path[:index])
-                raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
-            if migrated_section not in migrated:
-                return defaults
-            migrated = migrated[migrated_section]
-        if not isinstance(migrated, dict):
-            dotted = ".".join(resolution.migrated_section_path)
-            raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
-        override = dict(migrated)
+        migrated = _select_migrated_override(override, resolution.migrated_section_path, defaults, override_path)
+        if migrated is None:
+            return defaults
+        override = migrated
     # legacy owner の override は節を持たないため、名前空間キー側の節へ包み直す。
     legacy_section = section if resolution.legacy_owner is not None else None
     if legacy_section is not None:

--- a/src/youtube_automation/configuration/skills.py
+++ b/src/youtube_automation/configuration/skills.py
@@ -296,6 +296,14 @@ def skill_config_default_relative_path(skill: str) -> Path:
     return _MOVED_SKILL_CONFIG_DEFAULTS.get(skill, Path(skill, "config.default.yaml"))
 
 
+def skill_config_migration_section_path(source: str, migration: SkillConfigMigration) -> tuple[str, ...]:
+    """移行後の override を旧 loader が読む full section path を返す。"""
+    configured_path = _MOVED_SKILL_CONFIG_SECTIONS.get(source)
+    if configured_path is not None:
+        return configured_path
+    return (migration.section,) if migration.section is not None else ()
+
+
 def skill_config_migration_loader_gaps(source: str, migration: SkillConfigMigration) -> tuple[str, ...]:
     """migration の移行先を loader が解決できない理由を返す (空なら互換)。
 
@@ -317,13 +325,15 @@ def skill_config_migration_loader_gaps(source: str, migration: SkillConfigMigrat
             f"移行先 {migration.target_skill} の override と噛み合いません "
             f"(_MOVED_SKILL_CONFIG_DEFAULTS[{source!r}] を確認してください)"
         )
-    # 移行後の override は移行先ファイル直下の 1 節として読むため、同梱 default 側の
-    # 節パス先頭 (未登録ならファイル全体 = None) と一致していなければ値が拾われない。
-    expected_section = next(iter(_MOVED_SKILL_CONFIG_SECTIONS.get(source, ())), None)
+    # migration は移行先ファイル直下の節へ配置し、loader はそこから同梱 default と
+    # 同じ full path を辿る。したがって migration の節は full path の入口と一致する必要がある。
+    expected_path = skill_config_migration_section_path(source, migration)
+    expected_section = expected_path[0] if expected_path else None
     if migration.section != expected_section:
+        dotted = ".".join(expected_path) if expected_path else None
         gaps.append(
             f"移行先の節 {migration.section!r} が同梱 default の節 "
-            f"{expected_section!r} と一致しません "
+            f"path {dotted!r} の入口 {expected_section!r} と一致しません "
             f"(_MOVED_SKILL_CONFIG_SECTIONS[{source!r}] を確認してください)"
         )
     return tuple(gaps)
@@ -500,11 +510,11 @@ def _select_moved_default_section(owner: str, defaults: dict[str, object]) -> di
 
 
 class _SkillOverrideResolution(NamedTuple):
-    """解決した override path と、互換読込に必要な legacy owner / 移行先 section。"""
+    """解決した override path と、互換読込に必要な legacy owner / 移行先 section path。"""
 
     path: Path | None
     legacy_owner: str | None
-    migrated_section: str | None
+    migrated_section_path: tuple[str, ...]
 
 
 def _resolve_skill_override(
@@ -515,19 +525,20 @@ def _resolve_skill_override(
     """override path と互換読込に必要な legacy owner / 移行先 section を返す。"""
     override_path = _resolve_channel_override(owner, channel_dir, warning_stacklevel=5)
     if override_path is not None:
-        return _SkillOverrideResolution(override_path, None, None)
+        return _SkillOverrideResolution(override_path, None, ())
 
     migration = SKILL_CONFIG_MIGRATIONS.get(skill)
     if migration is not None:
         override_path = _resolve_channel_override(migration.target_skill, channel_dir, warning_stacklevel=5)
         if override_path is not None:
-            return _SkillOverrideResolution(override_path, None, migration.section)
+            section_path = skill_config_migration_section_path(skill, migration)
+            return _SkillOverrideResolution(override_path, None, section_path)
 
     legacy_owner = _NAMESPACED_LEGACY_OVERRIDE_OWNERS.get(skill)
     if legacy_owner is None:
-        return _SkillOverrideResolution(None, None, None)
+        return _SkillOverrideResolution(None, None, ())
     override_path = _resolve_channel_override(legacy_owner, channel_dir, warning_stacklevel=5)
-    return _SkillOverrideResolution(override_path, legacy_owner if override_path is not None else None, None)
+    return _SkillOverrideResolution(override_path, legacy_owner if override_path is not None else None, ())
 
 
 def _merge_skill_channel_override(
@@ -543,14 +554,18 @@ def _merge_skill_channel_override(
         return defaults
 
     override, acknowledged = _split_acknowledged_unknown_keys(_load_override(override_path), override_path)
-    if resolution.migrated_section is not None:
-        if resolution.migrated_section not in override:
-            return defaults
-        migrated = override[resolution.migrated_section]
+    if resolution.migrated_section_path:
+        migrated: object = override
+        for index, migrated_section in enumerate(resolution.migrated_section_path):
+            if not isinstance(migrated, dict):
+                dotted = ".".join(resolution.migrated_section_path[:index])
+                raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
+            if migrated_section not in migrated:
+                return defaults
+            migrated = migrated[migrated_section]
         if not isinstance(migrated, dict):
-            raise ConfigError(
-                f"skill-config {override_path} の移行先 {resolution.migrated_section!r} は mapping である必要があります"
-            )
+            dotted = ".".join(resolution.migrated_section_path)
+            raise ConfigError(f"skill-config {override_path} の移行先 {dotted!r} は mapping である必要があります")
         override = dict(migrated)
     # legacy owner の override は節を持たないため、名前空間キー側の節へ包み直す。
     legacy_section = section if resolution.legacy_owner is not None else None

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -426,7 +426,18 @@ def test_skill_config_migration_lint_rejects_section_outside_bundled_default() -
     )
 
     assert len(violations) == 1
-    assert "移行先の節 'broken-section' が同梱 default の節 'prompt' と一致しません" in violations[0]
+    assert (
+        "移行先の節 'broken-section' が同梱 default の節 path 'prompt' の入口 'prompt' と一致しません" in violations[0]
+    )
+
+
+def test_skill_config_migration_lint_reports_full_bundled_default_section_path() -> None:
+    violations = _lint._lint_skill_config_migrations(
+        {"lyria": _migrate_config.SkillConfigMigration("music", "broken-section")}
+    )
+
+    assert len(violations) == 1
+    assert "同梱 default の節 path 'generate.lyria' の入口 'generate'" in violations[0]
 
 
 def test_skill_config_migration_lint_rejects_source_outside_loader_keys() -> None:

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -403,6 +403,29 @@ def test_cli_lint_guides_unmigrated_downstream_skill_config(
     assert "yt-skills migrate-config" in output
 
 
+def test_skill_config_migration_lint_accepts_loader_compatible_table() -> None:
+    assert _lint._lint_skill_config_migrations(skill_config.SKILL_CONFIG_MIGRATIONS) == []
+
+
+def test_cli_lint_rejects_migration_without_compatible_loader_path(
+    fake_repo: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.setattr(
+        _migrate_config,
+        "SKILL_CONFIG_MIGRATIONS",
+        {"suno": _migrate_config.SkillConfigMigration("broken-owner", "prompt")},
+    )
+
+    assert main(["lint"]) == 1
+
+    output = capsys.readouterr().out
+    assert "suno -> broken-owner::prompt" in output
+    assert "互換 loader 経路がありません" in output
+    assert "SKILL_CONFIG_MIGRATIONS" in output
+
+
 def test_cli_lint_missing_mode_reference_reports_skill_flag_and_path(
     fake_repo: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -440,6 +440,15 @@ def test_skill_config_migration_lint_reports_full_bundled_default_section_path()
     assert "同梱 default の節 path 'generate.lyria' の入口 'generate'" in violations[0]
 
 
+def test_skill_config_migration_lint_rejects_section_without_registered_full_path() -> None:
+    violations = _lint._lint_skill_config_migrations(
+        {"publish": _migrate_config.SkillConfigMigration("publish", "community")}
+    )
+
+    assert len(violations) == 1
+    assert "移行元 publish の full section path が未登録です" in violations[0]
+
+
 def test_skill_config_migration_lint_rejects_source_outside_loader_keys() -> None:
     violations = _lint._lint_skill_config_migrations({"music": _migrate_config.SkillConfigMigration("music", None)})
 

--- a/tests/commands/system/test_skills_lint.py
+++ b/tests/commands/system/test_skills_lint.py
@@ -66,6 +66,9 @@ def fake_repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     monkeypatch.setattr(skills_sync, "_editable_root", lambda: tmp_path)
     monkeypatch.setattr(skill_config, "SKILL_CONFIG_KEYS", frozenset())
     monkeypatch.setattr(skill_config, "SKILL_ONLY_CONFIG_KEYS", frozenset())
+    # 登録キーを空にした偽ツリーでは実表の migration を検証できないため、
+    # migration lint を使うテストだけが自前の表を設定する。
+    monkeypatch.setattr(_migrate_config, "SKILL_CONFIG_MIGRATIONS", {})
     return tmp_path
 
 
@@ -407,11 +410,41 @@ def test_skill_config_migration_lint_accepts_loader_compatible_table() -> None:
     assert _lint._lint_skill_config_migrations(skill_config.SKILL_CONFIG_MIGRATIONS) == []
 
 
+def test_skill_config_migration_lint_rejects_target_without_bundled_default() -> None:
+    violations = _lint._lint_skill_config_migrations(
+        {"suno": _migrate_config.SkillConfigMigration("broken-owner", "prompt")}
+    )
+
+    assert len(violations) == 1
+    assert violations[0].startswith("suno -> broken-owner::prompt に互換 loader 経路がありません")
+    assert "同梱 default が music/ 配下" in violations[0]
+
+
+def test_skill_config_migration_lint_rejects_section_outside_bundled_default() -> None:
+    violations = _lint._lint_skill_config_migrations(
+        {"suno": _migrate_config.SkillConfigMigration("music", "broken-section")}
+    )
+
+    assert len(violations) == 1
+    assert "移行先の節 'broken-section' が同梱 default の節 'prompt' と一致しません" in violations[0]
+
+
+def test_skill_config_migration_lint_rejects_source_outside_loader_keys() -> None:
+    violations = _lint._lint_skill_config_migrations({"music": _migrate_config.SkillConfigMigration("music", None)})
+
+    assert len(violations) == 1
+    assert "移行元 music が loader の登録キーではない" in violations[0]
+
+
 def test_cli_lint_rejects_migration_without_compatible_loader_path(
     fake_repo: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
+    skills_dir = fake_repo / ".claude" / "skills"
+    _write_skill(skills_dir, "music", _VALID_SKILL_MD.replace("good-skill", "music"))
+    (skills_dir / "music" / "config.default.yaml").write_text("prompt: {}\n", encoding="utf-8")
+    monkeypatch.setattr(skill_config, "SKILL_CONFIG_KEYS", frozenset({"suno"}))
     monkeypatch.setattr(
         _migrate_config,
         "SKILL_CONFIG_MIGRATIONS",
@@ -423,7 +456,7 @@ def test_cli_lint_rejects_migration_without_compatible_loader_path(
     output = capsys.readouterr().out
     assert "suno -> broken-owner::prompt" in output
     assert "互換 loader 経路がありません" in output
-    assert "SKILL_CONFIG_MIGRATIONS" in output
+    assert "_MOVED_SKILL_CONFIG_DEFAULTS['suno']" in output
 
 
 def test_cli_lint_missing_mode_reference_reports_skill_flag_and_path(

--- a/tests/commands/system/test_skills_migrate_config.py
+++ b/tests/commands/system/test_skills_migrate_config.py
@@ -239,7 +239,7 @@ def test_production_cli_migrates_consolidated_skill_configs_without_orphans(
     assert _read_config(channel_dir, "wf-new") == sources["collection-ideate"]
     assert _read_config(channel_dir, "thumbnail")["loop"] == sources["loop-video"]
     assert _read_config(channel_dir, "music")["master"] == sources["masterup"]
-    assert _read_config(channel_dir, "music")["generate"] == sources["lyria"]
+    assert _read_config(channel_dir, "music")["generate"]["lyria"] == sources["lyria"]
     assert _read_config(channel_dir, "channel-research")["benchmark"] == sources["benchmark"]
     assert all(not (channel_dir / "config" / "skills" / f"{name}.yaml").exists() for name in sources)
     assert "孤児 skill-config" not in capsys.readouterr().out

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -160,16 +160,30 @@ def test_legacy_skill_config_uses_migrated_override_when_legacy_file_is_absent(
     overrides = tmp_path / "config" / "skills"
     overrides.mkdir(parents=True)
     migrated_override = {"migration_test_marker": legacy_key}
-    target_override = (
-        {**migrated_override, "acknowledged_unknown_keys": ["migration_test_marker"]}
-        if section is None
-        else {section: migrated_override, "acknowledged_unknown_keys": ["migration_test_marker"]}
-    )
+    section_path = skill_config._MOVED_SKILL_CONFIG_SECTIONS.get(legacy_key, ())
+    nested_override: dict[str, object] = migrated_override
+    for path_part in reversed(section_path):
+        nested_override = {path_part: nested_override}
+    target_override = {**nested_override, "acknowledged_unknown_keys": ["migration_test_marker"]}
     (overrides / f"{target_skill}.yaml").write_text(yaml.safe_dump(target_override), encoding="utf-8")
 
     loaded = skill_config.load_skill_config(legacy_key, use_cache=False, channel_dir=tmp_path)
 
     assert loaded["migration_test_marker"] == legacy_key
+
+
+def test_legacy_skill_config_narrows_migrated_override_through_full_section_path(tmp_path: Path) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "music.yaml").write_text(
+        "generate:\n  provider: sibling\n  lyria:\n    model: lyria-002\n",
+        encoding="utf-8",
+    )
+
+    loaded = skill_config.load_skill_config("lyria", use_cache=False, channel_dir=tmp_path)
+
+    assert loaded["model"] == "lyria-002"
+    assert "provider" not in loaded
 
 
 def test_legacy_and_namespaced_keys_resolve_the_same_migrated_override(tmp_path: Path) -> None:

--- a/tests/configuration/test_skill_config.py
+++ b/tests/configuration/test_skill_config.py
@@ -186,6 +186,37 @@ def test_legacy_skill_config_narrows_migrated_override_through_full_section_path
     assert "provider" not in loaded
 
 
+def test_legacy_skill_config_reads_flat_override_written_by_old_migrate_config(tmp_path: Path) -> None:
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "music.yaml").write_text(
+        "generate:\n  model: lyria-002\n",
+        encoding="utf-8",
+    )
+
+    loaded = skill_config.load_skill_config("lyria", use_cache=False, channel_dir=tmp_path)
+
+    assert loaded["model"] == "lyria-002"
+
+
+def test_legacy_skill_config_ignores_sibling_only_migrated_override(tmp_path: Path) -> None:
+    expected = skill_config.load_skill_config(
+        "lyria",
+        use_cache=False,
+        channel_dir=tmp_path / "without-overrides",
+    )
+    overrides = tmp_path / "config" / "skills"
+    overrides.mkdir(parents=True)
+    (overrides / "music.yaml").write_text(
+        "generate:\n  minimax:\n    model: speech-2.6-hd\n",
+        encoding="utf-8",
+    )
+
+    loaded = skill_config.load_skill_config("lyria", use_cache=False, channel_dir=tmp_path)
+
+    assert loaded == expected
+
+
 def test_legacy_and_namespaced_keys_resolve_the_same_migrated_override(tmp_path: Path) -> None:
     overrides = tmp_path / "config" / "skills"
     overrides.mkdir(parents=True)


### PR DESCRIPTION
## 概要

- config migration table と互換 fallback 対応を lint で照合
- 不整合時に source・移行先・修正対象を診断
- 正常表と壊れた表の回帰テストを追加

Closes #4683