### PR TITLE
fix(ci): evals の pnpm shell を修正し週次化する (#4603)

### DIFF
--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -3,7 +3,7 @@ name: Skill E2E eval
 on:
   workflow_dispatch:
   schedule:
-    - cron: "17 18 * * *"
+    - cron: "17 18 * * 1"
 
 permissions:
   contents: read
@@ -49,14 +49,14 @@ jobs:
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
       - name: Install Claude Code
         run: |
-          nix develop --command npm install --global --prefix "$RUNNER_TEMP/claude-code" @anthropic-ai/claude-code@2.1.226
+          nix develop .#extensions --command npm install --global --prefix "$RUNNER_TEMP/claude-code" @anthropic-ai/claude-code@2.1.226
           echo "$RUNNER_TEMP/claude-code/bin" >> "$GITHUB_PATH"
       - name: Run skill E2E eval
         id: promptfoo
         continue-on-error: true
         run: |
           mkdir -p evals/results
-          nix develop --command pnpm dlx promptfoo@0.122.0 eval \
+          nix develop .#extensions --command pnpm dlx promptfoo@0.122.0 eval \
             -c evals/promptfooconfig.yaml \
             --output evals/results/ci.json
       - name: Summarize assertions

--- a/tests/repo/test_evals_workflow.py
+++ b/tests/repo/test_evals_workflow.py
@@ -21,12 +21,13 @@ def _triggers(workflow: dict[str, object]) -> dict[str, object]:
     return triggers
 
 
-def test_evals_workflow_is_manual_and_nightly_but_not_a_pr_gate() -> None:
+def test_evals_workflow_is_manual_and_weekly_but_not_a_pr_gate() -> None:
     triggers = _triggers(_workflow())
 
     assert set(triggers) == {"workflow_dispatch", "schedule"}
     assert triggers["workflow_dispatch"] is None
-    assert triggers["schedule"] == [{"cron": "17 18 * * *"}]
+    # 日次は対象 skill の変更頻度に対して過剰だったため週次にする（2026-08 監査）。
+    assert triggers["schedule"] == [{"cron": "17 18 * * 1"}]
 
 
 def test_missing_auth_explicitly_skips_the_paid_eval() -> None:
@@ -60,7 +61,9 @@ def test_authenticated_eval_uses_pinned_tools_and_reports_assertion_failures() -
 
     promptfoo = next(step for step in steps if step.get("id") == "promptfoo")
     assert promptfoo["continue-on-error"] is True
-    assert "pnpm dlx promptfoo@0.122.0 eval" in promptfoo["run"]
+    # pnpm / npm は .#extensions shell にしか無い（既定 shell では即死する）。
+    assert "nix develop .#extensions --command pnpm dlx promptfoo@0.122.0 eval" in promptfoo["run"]
+    assert "nix develop .#extensions --command npm install" in steps[2]["run"]
     assert "-c evals/promptfooconfig.yaml" in promptfoo["run"]
     assert "--output evals/results/ci.json" in promptfoo["run"]
 


### PR DESCRIPTION
## Summary
- Claude Code と promptfoo を `.#extensions` devShell で実行する
- Skill E2E eval の schedule を月曜 18:17 UTC の週次実行へ変更する
- workflow contract test で cadence と devShell を固定する

Closes #4603