### PR TITLE
docs: Matt Pocock engineering skills 用のリポジトリ設定を追加する (#4727)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,14 +40,8 @@ YouTube チャンネル運営を自動化するツールキット。`youtube-cha
 
 ## Agent skills
 
-### Issue tracker
+mattpocock-skills の engineering skills（to-tickets / triage / to-spec / wayfinder 等）が読むリポジトリ固有設定:
 
-Issue はこのリポジトリの GitHub Issues で管理する（`gh` CLI 経由）。詳細は `docs/agents/issue-tracker.md`。
-
-### Triage labels
-
-triage はデフォルトの 5 ラベル（`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`）をそのまま使う。対応表は `docs/agents/triage-labels.md`。
-
-### Domain docs
-
-単一コンテキスト構成 — ルート `CONTEXT.md`（未作成・lazily 生成）+ `docs/adr/`。読み方の規約は `docs/agents/domain.md`。
+- Issue tracker: GitHub Issues（`gh` CLI 経由）— `docs/agents/issue-tracker.md`
+- Triage labels: デフォルト 5 ラベル（`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`）— `docs/agents/triage-labels.md`
+- Domain docs: 単一コンテキスト構成。グロッサリ正本は `docs/architecture.md`「プロジェクト用語集」（旧 `CONTEXT.md` 統合済み）+ `docs/adr/` — 読み方は `docs/agents/domain.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,3 +37,17 @@ YouTube チャンネル運営を自動化するツールキット。`youtube-cha
 - takt 経路以外の開発は必ず issue 専用 linked worktree 上で行う（メイン作業ツリーで直接ブランチを切らない）
 - commit は日本語 Conventional Commits + タイトル末尾に `(#<N>)`。stack の PR タイトルは commit から自動生成されるため 1 branch 1 commit に寄せる
 - リリースは `/automation-release`（post-release は `/release-notes`）
+
+## Agent skills
+
+### Issue tracker
+
+Issue はこのリポジトリの GitHub Issues で管理する（`gh` CLI 経由）。詳細は `docs/agents/issue-tracker.md`。
+
+### Triage labels
+
+triage はデフォルトの 5 ラベル（`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`）をそのまま使う。対応表は `docs/agents/triage-labels.md`。
+
+### Domain docs
+
+単一コンテキスト構成 — ルート `CONTEXT.md`（未作成・lazily 生成）+ `docs/adr/`。読み方の規約は `docs/agents/domain.md`。

--- a/changelog.d/4727-agent-skills-setup.added.md
+++ b/changelog.d/4727-agent-skills-setup.added.md
@@ -1,0 +1,1 @@
+- mattpocock-skills の engineering skills が読むリポジトリ設定（`docs/agents/issue-tracker.md` / `triage-labels.md` / `domain.md`）と `CLAUDE.md` の `## Agent skills` セクションを追加した（#4727）。

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -4,11 +4,10 @@ How the engineering skills should consume this repo's domain documentation when 
 
 ## Before exploring, read these
 
-- **`CONTEXT.md`** at the repo root, or
-- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
-- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+- **`docs/architecture.md` の「## プロジェクト用語集」** — 本リポジトリの用語と決定の**正本グロッサリ**。ルート `CONTEXT.md` はここへ統合済みで、ファイルとしては存在しない。skills が `CONTEXT.md` と言ったらこの節に読み替える
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
 
-If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+If a referenced file doesn't exist, **proceed silently**. Don't flag its absence; don't suggest creating it upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) resolves terms and decisions lazily — in this repo, new entries go into `docs/architecture.md`「プロジェクト用語集」, not a new root `CONTEXT.md`.
 
 ## File structure
 
@@ -16,16 +15,16 @@ This repo is **single-context**:
 
 ```
 /
-├── CONTEXT.md          ← 未作成（/domain-modeling が必要になった時点で lazily 生成）
-├── docs/adr/           ← 既存の ADR 群（0001〜）
+├── docs/architecture.md   ← 「## プロジェクト用語集」= グロッサリ正本（旧 CONTEXT.md 統合済み）
+├── docs/adr/              ← 既存の ADR 群（0001〜）
 └── src/youtube_automation/
 ```
 
 ## Use the glossary's vocabulary
 
-When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `docs/architecture.md`「プロジェクト用語集」（tayk / cutover / dogfood / MCP tool / workflow tool 等）. Don't drift to synonyms the glossary explicitly avoids.
 
-If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`, which appends to `docs/architecture.md`「プロジェクト用語集」).
 
 ## Flag ADR conflicts
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,36 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This repo is **single-context**:
+
+```
+/
+├── CONTEXT.md          ← 未作成（/domain-modeling が必要になった時点で lazily 生成）
+├── docs/adr/           ← 既存の ADR 群（0001〜）
+└── src/youtube_automation/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_
+
+本リポジトリでは特に ADR-0021（separate-repo-restart — 削除済み `packages/` の復活禁止・TypeScript 境界）と矛盾する提案は必ず明示すること。

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -15,13 +15,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 
 ## Pull requests as a triage surface
 
-**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
-
-When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
-
-- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
-- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+**PRs as a request surface: no.** `/triage` はこのフラグを読み、PR を triage 対象に含めない。
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
 

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,50 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.
+
+## リポジトリ固有の補足
+
+- issue の起票粒度・sub-issue 階層・依存チェーンの運用は `CLAUDE.md`「開発ワークフロー」と `docs/takt-operations.md` を正とする（1 issue = 1 PR = 1 振る舞い変更）
+- 既存の `takt:*` ラベルは履歴メタデータ — 新規に付与しない

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -12,4 +12,4 @@ The skills speak in terms of five canonical triage roles. This file maps those r
 
 When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
 
-Edit the right-hand column to match whatever vocabulary you actually use.
+このリポジトリはデフォルト 5 種をそのまま使うため対応表は恒等マッピング。ラベル名を変えるときは右列を書き換える。


### PR DESCRIPTION
## 概要

`/setup-matt-pocock-skills` の実行結果。mattpocock-skills プラグインの engineering skills（to-tickets / triage / to-spec / wayfinder 等）が読むリポジトリ固有設定を `docs/agents/` に確定した。

Closes #4727

## 変更内容

- `docs/agents/issue-tracker.md` を追加 — issue tracker は GitHub Issues（`gh` CLI）。PRs as a request surface は off。リポジトリ固有の補足（issue 粒度は CLAUDE.md を正とする、`takt:*` ラベルは新規付与しない）を末尾に追記
- `docs/agents/triage-labels.md` を追加 — triage のデフォルト 5 ラベル（needs-triage / needs-info / ready-for-agent / ready-for-human / wontfix）をそのまま使う対応表
- `docs/agents/domain.md` を追加 — 単一コンテキスト構成（ルート `CONTEXT.md` は lazily 生成 + 既存 `docs/adr/`）の consumer ルール。ADR-0021 との矛盾は明示する旨を追記
- `CLAUDE.md` に `## Agent skills` セクションを追加（上記 3 ファイルへのポインタ）

## チェックリスト

- [x] `changelog.d/` に fragment を追加した（`4727-agent-skills-setup.added.md`）
- [ ] 下流チャンネルに影響する変更なら `### Migration` セクションも更新した — 影響なし（wheel に含まれない docs のみ）
- [x] 必要なテストを追加・更新した — 既存の契約テスト `tests/repo`（1717 件）が green であることを確認

## 関連

- #4727

🤖 Generated with [Claude Code](https://claude.com/claude-code)