### PR TITLE
fix(suno-helper): モーダル検出を dialog role に統一する (#4747)

### DIFF
--- a/changelog.d/4747-suno-modal-role.fixed.md
+++ b/changelog.d/4747-suno-modal-role.fixed.md
@@ -1,0 +1,1 @@
+- suno-helper の形式選択モーダル検出を変動する CSS class ではなく `dialog` role に統一し、現行 Suno UI で playlist 追加後の ZIP ダウンロードがタイムアウトする問題を修正。

--- a/extensions/suno-helper/lib/download.ts
+++ b/extensions/suno-helper/lib/download.ts
@@ -9,8 +9,9 @@ const CLIP_ROW_SELECTOR =
   '[data-testid="clip-row"], .clip-row, article, [role="group"]';
 const CONTEXT_MENU_SELECTOR = 'div[data-context-menu="true"]';
 const DOWNLOAD_MENU_ITEM_TEXT = /download\s*all/i;
-const FORMAT_MODAL_CANDIDATE_SELECTOR =
-  '[role="dialog"], div.modal-class.modal-overlay';
+// Suno の Tailwind class はリリースごとに変わるため、形式選択モーダルは
+// WAI-ARIA の dialog role だけを安定した探索契約として使う (#4747)。
+const FORMAT_MODAL_CANDIDATE_SELECTOR = '[role="dialog"]';
 const BUTTON_SELECTOR = "button";
 const DOWNLOAD_CONFIRM_LABEL = "Download";
 const FORMAT_OPTION_LABELS = ["M4A", "MP3", "WAV"] as const;

--- a/extensions/suno-helper/tests/download.test.ts
+++ b/extensions/suno-helper/tests/download.test.ts
@@ -16,7 +16,6 @@ interface FormatModalFixtureOptions {
   confirm?: boolean;
   formats?: readonly string[];
   hidden?: boolean;
-  legacy?: boolean;
   mp3Disabled?: boolean;
   testId?: string;
 }
@@ -35,9 +34,8 @@ function formatModalFixture(options: FormatModalFixtureOptions = {}): string {
     options.confirm === false
       ? ""
       : '<button class="hxc-btn-variant-primary">Download</button>';
-  const modalContract = options.legacy
-    ? 'class="modal-class modal-overlay"'
-    : 'role="dialog" data-open data-base-ui-focusable';
+  const modalContract =
+    'role="dialog" class="fixed top-1/2 left-1/2 animate-modal-cont" data-open data-base-ui-focusable';
   return `<div ${modalContract} data-testid="${
     options.testId ?? "format-modal"
   }"${options.hidden ? " hidden" : ""}>${formatButtons}${confirm}</div>`;
@@ -286,45 +284,6 @@ describe("triggerDownloadAll", () => {
     await triggerDownloadAll("mp3");
 
     expect(clicked).toEqual(["more", "download-all", "mp3", "confirm"]);
-  });
-
-  it("DOM fixture: 旧 class 形式モーダルでも MP3 → Download を操作する", async () => {
-    vi.useFakeTimers();
-    const clicked: string[] = [];
-    vi.stubGlobal("PointerEvent", MouseEvent);
-    document.body.innerHTML = `
-      <div class="clip-browser-list-scroller">
-        <article>
-          <img src="clip.jpg" alt="" />
-          <div class="multi-select-button"><button aria-label="Deselect clip">Selected</button></div>
-          <button aria-label="More options">...</button>
-        </article>
-      </div>
-      <div data-context-menu="true">
-        <button aria-label="Download all">Download all</button>
-      </div>
-      ${formatModalFixture({ legacy: true })}
-    `;
-    const formatModal = document.querySelector<HTMLElement>(
-      '[data-testid="format-modal"]'
-    )!;
-    const mp3 = Array.from(
-      formatModal.querySelectorAll<HTMLButtonElement>("button.flex.w-full")
-    ).find((button) => button.textContent?.trim() === "MP3")!;
-    const confirm = formatModal.querySelector<HTMLButtonElement>(
-      "button.hxc-btn-variant-primary"
-    )!;
-    mp3.addEventListener("click", () => clicked.push("mp3"));
-    confirm.addEventListener("click", () => {
-      clicked.push("confirm");
-      formatModal.remove();
-    });
-
-    const result = triggerDownloadAll("mp3");
-    await vi.advanceTimersByTimeAsync(20_000);
-
-    await expect(result).resolves.toBeUndefined();
-    expect(clicked).toEqual(["mp3", "confirm"]);
   });
 
   it("DOM fixture: Download 確定後に 10 秒超で閉じる形式選択モーダルを待てる", async () => {


### PR DESCRIPTION
## Summary
- Suno の形式選択モーダルを WAI-ARIA の `dialog` role で検出
- 現行 Tailwind ベース DOM fixture で Download all フローを回帰検証
- 旧 CSS class セレクタへの依存を削除

Closes #4747