### PR TITLE
feat(documents): 文書 pair の一括再発行を追加する (#4725)

### DIFF
--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -504,6 +504,10 @@ uv sync
 ```
 
 `channel_config` 以外の `yt-doctor` check が `warn` / `fail` / `unknown` の場合は、安全化して表示された `message` / `next_action` を省略せず利用者へ示し、`/setup` を起動して再診断するよう案内。`channel_config` 自体が `ok` 以外、check の重複・欠落・型不正、JSON 破損、またはコマンドを起動できない場合は `yt-channel-status` へ進まず停止する。
+
+### Step 3-4. 既発行文書 pair のテンプレート整合確認
+
+追従に文書テンプレート変更が含まれる可能性があるため、下流リポジトリの root で `uv run yt-document-render --check --all` を実行する。stale が 1 件以上なら列挙結果を利用者へ示し、HTML の一括上書きについて `[HUMAN STEP]` で同意を得た場合だけ `uv run yt-document-render --fix --all` を実行する。JSON の再生成や `/analytics --analyze` の再実行は不要。修復後は同じ `--check --all` を再実行し、stale 0 件を確認する。
 ただし `branding/icon.png` / `branding/banner.png` の「未生成」が報告された場合は、新規生成の前に必ず `branding/` 配下の既存ファイルを確認する。同名 stem の別拡張子（例: `icon.jpg` / `banner.webp`）と別サフィックス（例: `banner-v2.jpg` / `banner-v3.png`）も候補に含め、複数候補がある場合はどれが最終版か人間に確認してからリネーム/変換する。
 
 sync 直後に、次の 2 点を Phase 4 へ進む前に判定する。手順は [post-apply-checks.md](post-apply-checks.md) を読む:

--- a/changelog.d/4725-document-pair-refresh.added.md
+++ b/changelog.d/4725-document-pair-refresh.added.md
@@ -1,0 +1,2 @@
+- `yt-document-render --check --all` と `--fix --all` を追加し、全登録 schema の stale HTML pair を横断検知・一括再発行できるようにした（#4725）。
+- analytics report の JSON が正常で HTML のみ stale な場合は、再分析ではなく再 render を案内するようにした（#4725）。

--- a/src/youtube_automation/application/channel_readiness/checks.py
+++ b/src/youtube_automation/application/channel_readiness/checks.py
@@ -34,7 +34,13 @@ from youtube_automation.configuration import (
     workspace_channels,
 )
 from youtube_automation.configuration.skills import load_skill_config
-from youtube_automation.core.errors import AutomationError, ConfigError, YouTubeAPIError
+from youtube_automation.core.errors import (
+    AutomationError,
+    ConfigError,
+    DocumentRenderError,
+    DocumentValidationError,
+    YouTubeAPIError,
+)
 from youtube_automation.domains.channel_readiness import (
     ReadinessResult,
     approved_ttp_exceptions,
@@ -42,6 +48,7 @@ from youtube_automation.domains.channel_readiness import (
     evaluate_ttp_wf_new_readiness,
 )
 from youtube_automation.domains.documents.operational_artifacts import resolve_artifacts
+from youtube_automation.domains.documents.schema_registry import RepositorySchema, validate_repository_document
 from youtube_automation.infrastructure.auth import (
     UPLOAD_REQUIRED_SCOPES,
     OAuthCredentialState,
@@ -59,6 +66,7 @@ from youtube_automation.infrastructure.collections.numbered_duplicates import (
     format_scan_error_reason,
     scan_numbered_duplicates,
 )
+from youtube_automation.infrastructure.documents.publishing import read_published_json_document
 from youtube_automation.infrastructure.retry import QUOTA_REASONS
 from youtube_automation.infrastructure.youtube.reporting_api import ReportingAPIClient
 from youtube_automation.infrastructure.youtube.streaming.state_reconciliation import reconcile_streaming_vps
@@ -1632,12 +1640,19 @@ def _temporary_channel_dir(channel_dir: Path) -> Iterator[None]:
 def check_analytics_report(channel_dir: Path) -> CheckResult:
     input_mode = _resolve_wf_new_input_mode(channel_dir)
     if input_mode.invalid_report:
+        stale_html = _analysis_report_with_stale_html(channel_dir)
+        instructions = (
+            f"`uv run yt-document-render {stale_html} --schema analysis-report.schema.json` で "
+            "HTML を再発行してください"
+            if stale_html is not None
+            else "/analytics --analyze を再実行してください"
+        )
         return CheckResult(
             id="analytics_report",
             status="fail",
             category=DATA_CATEGORY,
             message="reports/analysis_*.json が schema 不正、HTML 欠損、または JSON と不一致",
-            next_action={"kind": "human", "instructions": "/analytics --analyze を再実行してください"},
+            next_action={"kind": "human", "instructions": instructions},
         )
     if input_mode.stale_report:
         if input_mode.stale_reason == "absolute":
@@ -1677,6 +1692,20 @@ def check_analytics_report(channel_dir: Path) -> CheckResult:
         category=DATA_CATEGORY,
         message=f"reports/analysis_*.json 未生成。/wf-new は {input_mode.mode} で開始可能",
     )
+
+
+def _analysis_report_with_stale_html(channel_dir: Path) -> Path | None:
+    for source in sorted((channel_dir / "reports").glob("analysis_*.json"), reverse=True):
+        try:
+            document = json.loads(source.read_text(encoding="utf-8"))
+            validate_repository_document(RepositorySchema.ANALYSIS_REPORT, document)
+        except (OSError, UnicodeError, json.JSONDecodeError, DocumentValidationError):
+            continue
+        try:
+            read_published_json_document(source, RepositorySchema.ANALYSIS_REPORT)
+        except DocumentRenderError:
+            return source.relative_to(channel_dir)
+    return None
 
 
 def _resolve_wf_new_input_mode(channel_dir: Path) -> _WfNewInputMode:

--- a/src/youtube_automation/commands/documents/render.py
+++ b/src/youtube_automation/commands/documents/render.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 import argparse
+import json
 from pathlib import Path
 
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import DocumentRenderError, DocumentValidationError
-from youtube_automation.domains.documents.schema_registry import RepositorySchema, repository_schema_names
+from youtube_automation.domains.documents.schema_registry import (
+    RepositorySchema,
+    repository_schema_names,
+    validate_repository_document,
+)
 from youtube_automation.infrastructure.documents import publish_json_document
 from youtube_automation.infrastructure.documents.publishing import read_published_json_document
 
@@ -17,13 +22,32 @@ def build_parser() -> argparse.ArgumentParser:
         prog="yt-document-render",
         description="検証済み JSON と同 basename の HTML を生成",
     )
-    parser.add_argument("json_path", type=Path, help="registry 所有 schema に対応する JSON file")
-    parser.add_argument("--schema", required=True, choices=repository_schema_names(), help="固定 registry の schema 名")
+    parser.add_argument("json_path", type=Path, nargs="?", help="registry 所有 schema に対応する JSON file")
+    parser.add_argument("--schema", choices=repository_schema_names(), help="固定 registry の schema 名")
     parser.add_argument("--check", action="store_true", help="JSON+HTML pair を変更せず検証")
+    parser.add_argument(
+        "--all",
+        dest="scan_root",
+        type=Path,
+        nargs="?",
+        const=Path("."),
+        help="directory 以下の registry 所有 JSON を全 schema 横断で走査",
+    )
+    parser.add_argument("--fix", action="store_true", help="--all で検出した stale / 欠損 HTML を一括再発行")
     return parser
 
 
 def run(args: argparse.Namespace) -> int:
+    if args.scan_root is not None:
+        if args.json_path is not None or args.schema is not None:
+            raise DocumentRenderError("--all は json_path / --schema と同時に指定できません")
+        if args.check == args.fix:
+            raise DocumentRenderError("--all には --check または --fix のどちらか一方を指定してください")
+        return _scan_all_pairs(args.scan_root, fix=args.fix)
+    if args.json_path is None or args.schema is None:
+        raise DocumentRenderError("単一文書には json_path と --schema が必要です")
+    if args.fix:
+        raise DocumentRenderError("--fix は --all と一緒に指定してください")
     schema = RepositorySchema(args.schema)
     if args.check:
         read_published_json_document(args.json_path, schema)
@@ -32,6 +56,47 @@ def run(args: argparse.Namespace) -> int:
         destination = publish_json_document(args.json_path, schema)
     print(destination.resolve())
     return 0
+
+
+def _scan_all_pairs(root: Path, *, fix: bool) -> int:
+    stale: list[tuple[Path, RepositorySchema]] = []
+    for source in sorted(root.rglob("*.json")):
+        schema = _infer_registered_schema(source)
+        if schema is None:
+            continue
+        try:
+            read_published_json_document(source, schema)
+        except DocumentRenderError:
+            stale.append((source, schema))
+
+    if fix:
+        for source, schema in stale:
+            publish_json_document(source, schema)
+            print(f"refreshed: {source.resolve()} ({schema.value})")
+        print(f"refreshed {len(stale)} document pair(s)")
+        return 0
+
+    for source, schema in stale:
+        print(f"stale: {source.resolve()} ({schema.value})")
+    print(f"stale {len(stale)} document pair(s)")
+    return 1 if stale else 0
+
+
+def _infer_registered_schema(source: Path) -> RepositorySchema | None:
+    try:
+        document = json.loads(source.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError):
+        return None
+    matches: list[RepositorySchema] = []
+    for schema in RepositorySchema:
+        try:
+            validate_repository_document(schema, document)
+        except DocumentValidationError:
+            continue
+        matches.append(schema)
+    if len(matches) == 1:
+        return matches[0]
+    return None
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/tests/commands/documents/test_render.py
+++ b/tests/commands/documents/test_render.py
@@ -29,3 +29,40 @@ def test_cli_returns_nonzero_and_preserves_existing_html_for_invalid_document(tm
     assert result == 1
     assert "pointer=/" in capsys.readouterr().err
     assert output.read_bytes() == b"previous"
+
+
+def test_cli_checks_all_registered_pairs_and_ignores_unregistered_json(tmp_path: Path, capsys) -> None:
+    current = tmp_path / "current.json"
+    stale = tmp_path / "nested" / "stale.json"
+    stale.parent.mkdir()
+    payload = json.dumps({"schema_version": 1, "entries": []})
+    current.write_text(payload, encoding="utf-8")
+    stale.write_text(payload, encoding="utf-8")
+    (tmp_path / "config.json").write_text('{"unrelated": true}', encoding="utf-8")
+    assert render.main([str(current), "--schema", "weekly_vote_log.schema.json"]) == 0
+    stale.with_suffix(".html").write_text("old template", encoding="utf-8")
+    capsys.readouterr()
+
+    result = render.main(["--check", "--all", str(tmp_path)])
+
+    output = capsys.readouterr().out
+    assert result == 1
+    assert "stale" in output
+    assert str(stale.resolve()) in output
+    assert str(current.resolve()) not in output
+    assert "config.json" not in output
+
+
+def test_cli_fixes_all_stale_or_missing_registered_pairs(tmp_path: Path, capsys) -> None:
+    stale = tmp_path / "stale.json"
+    missing = tmp_path / "missing.json"
+    payload = json.dumps({"schema_version": 1, "entries": []})
+    stale.write_text(payload, encoding="utf-8")
+    missing.write_text(payload, encoding="utf-8")
+    stale.with_suffix(".html").write_text("old template", encoding="utf-8")
+
+    result = render.main(["--fix", "--all", str(tmp_path)])
+
+    assert result == 0
+    assert "refreshed 2" in capsys.readouterr().out
+    assert render.main(["--check", "--all", str(tmp_path)]) == 0

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -2640,6 +2640,17 @@ class TestCheckAnalyticsReport:
         assert result.status == "fail"
         assert "HTML 欠損" in result.message
 
+    def test_stale_analysis_html_routes_to_render_without_reanalysis(self, tmp_path):
+        _write_analysis_pair(tmp_path, "20240101")
+        report = tmp_path / "reports" / "analysis_20240101.json"
+        report.with_suffix(".html").write_text("old template", encoding="utf-8")
+
+        result = doctor.check_analytics_report(tmp_path)
+
+        assert result.status == "fail"
+        assert "yt-document-render" in result.next_action["instructions"]
+        assert "/analytics --analyze" not in result.next_action["instructions"]
+
     def test_multiple_analysis_files_is_ok(self, tmp_path):
         """analysis_*.md が複数存在しても ok."""
         reports_dir = tmp_path / "reports"


### PR DESCRIPTION
## Summary
- 全登録 schema の structured document pair を一括走査できる `--all` を追加
- stale pair を `--fix --all` で再発行できる導線を追加
- doctor と automation 更新手順を stale HTML の再 render に対応

Closes #4725