### PR TITLE
fix(publish): 自動予約 INFO の公開設定表示を正す (#4752)

### DIFF
--- a/changelog.d/4752-upload-plan-privacy.fixed.md
+++ b/changelog.d/4752-upload-plan-privacy.fixed.md
@@ -1,0 +1,1 @@
+- `yt-upload-collection --plan` の自動予約 INFO が実効公開範囲を誤って即時公開と表示しないよう修正

--- a/src/youtube_automation/domains/uploads/_published_dates.py
+++ b/src/youtube_automation/domains/uploads/_published_dates.py
@@ -155,13 +155,13 @@ class PublishedDatesScheduler:
         """
         if not self.config.scheduling_enabled:
             if self.config.scheduling_explicitly_disabled:
-                logger.info("📅 公開設定: 即時公開（schedule.auto_schedule_enabled=false）")
+                logger.info("📅 自動予約: 無効（schedule.auto_schedule_enabled=false）")
                 return None
             default_publish_at = resolve_default_publish_at(load_config())
             if default_publish_at:
                 logger.info(f"📅 channel youtube.default_publish_time から公開予定を適用: {default_publish_at}")
                 return default_publish_at
-            logger.info("📅 公開設定: 即時公開（schedule_config.json で auto_schedule_enabled 未設定）")
+            logger.info("📅 自動予約: 無効（schedule_config.json で auto_schedule_enabled 未設定）")
             return None
 
         publish_time = self.config.publish_time

--- a/tests/domains/uploads/test_collection_uploader.py
+++ b/tests/domains/uploads/test_collection_uploader.py
@@ -776,17 +776,42 @@ class TestDefaultPublishTimeFallback:
         assert result == "2099-01-01T20:00:00+09:00"
         assert mock_resolve.called
 
-    def test_auto_schedule_false_suppresses_channel_default(self, tmp_path):
+    def test_auto_schedule_false_suppresses_channel_default(self, tmp_path, caplog):
         uploader, _ = _make_uploader_with_schedule_config(
             tmp_path,
             {"schedule": {"auto_schedule_enabled": False, "timezone": "Asia/Tokyo"}},
         )
 
-        with patch("youtube_automation.domains.uploads._published_dates.resolve_default_publish_at") as mock_resolve:
+        with (
+            caplog.at_level(logging.INFO, logger="youtube_automation.domains.uploads._published_dates"),
+            patch("youtube_automation.domains.uploads._published_dates.resolve_default_publish_at") as mock_resolve,
+        ):
             result = uploader.published_dates.calculate_publish_at()
 
         assert result is None
         assert not mock_resolve.called
+        assert "📅 自動予約: 無効（schedule.auto_schedule_enabled=false）" in caplog.text
+        assert "公開設定:" not in caplog.text
+
+    def test_missing_auto_schedule_reports_only_automatic_scheduling_state(self, tmp_path, caplog):
+        uploader, _ = _make_uploader_with_schedule_config(
+            tmp_path,
+            {"schedule": {"timezone": "Asia/Tokyo"}},
+        )
+
+        with (
+            caplog.at_level(logging.INFO, logger="youtube_automation.domains.uploads._published_dates"),
+            patch("youtube_automation.domains.uploads._published_dates.load_config", return_value=MagicMock()),
+            patch(
+                "youtube_automation.domains.uploads._published_dates.resolve_default_publish_at",
+                return_value=None,
+            ),
+        ):
+            result = uploader.published_dates.calculate_publish_at()
+
+        assert result is None
+        assert "📅 自動予約: 無効（schedule_config.json で auto_schedule_enabled 未設定）" in caplog.text
+        assert "公開設定:" not in caplog.text
 
 
 class TestScheduleConfigPathResolution:


### PR DESCRIPTION
## Summary
- 自動予約無効時の INFO 行を「自動予約: 無効」へ変更
- 実効公開範囲との矛盾を解消
- 明示的無効化と設定未指定を回帰テストで固定

Closes #4752