### PR TITLE
fix(wf-new): 初期化前に企画 draft を公開する (#4754)

### DIFF
--- a/.claude/skills/wf-new/references/collection-plan-documents.md
+++ b/.claude/skills/wf-new/references/collection-plan-documents.md
@@ -22,9 +22,11 @@ browserのないterminal環境だけは `--transport terminal` を明示し、�
 ```bash
 uv run yt-document-migrate <candidate.json> \
   --target <collection>/20-documentation/plan_proposals.json \
-  --schema collection-plan.schema.json \
-  --workflow-state <collection>/workflow-state.json
+  --schema collection-plan.schema.json
 ```
+
+draft pair は collection 初期化前でも公開できるため `--workflow-state` を指定しない。選択時は
+`yt-collection-plan-select` が `workflow-state.json` へ確定企画を投影する。
 
 既存 `plan_proposals.md` だけがある場合は移行可否を明示確認し、Yes だけ `--migration-decision yes`、No は `--migration-decision no` を付ける。No では Markdown と workflow state を変更しない。JSON+HTML pair の更新では移行 flag を付けない。
 

--- a/changelog.d/4754-collection-plan-draft.fixed.md
+++ b/changelog.d/4754-collection-plan-draft.fixed.md
@@ -1,0 +1,1 @@
+- collection 初期化前でも collection plan の draft JSON/HTML pair を公開できるように修正

--- a/changelog.d/4754-collection-plan-draft.fixed.md
+++ b/changelog.d/4754-collection-plan-draft.fixed.md
@@ -1,1 +1,2 @@
 - collection 初期化前でも collection plan の draft JSON/HTML pair を公開できるように修正
+- `yt-init-collection` が企画 draft 公開済みディレクトリを既存扱いで停止せず、投影済みの `planning.generated` / `final_title` / `target_persona` を残して初期化するよう修正

--- a/src/youtube_automation/application/documents/collection_plan.py
+++ b/src/youtube_automation/application/documents/collection_plan.py
@@ -27,7 +27,7 @@ SelectionSource = Literal["web", "terminal", "automatic"]
 
 def write_collection_plan_document(
     json_path: Path,
-    workflow_state_path: Path,
+    workflow_state_path: Path | None,
     build_document: Callable[[], object],
     migration_decision: MarkdownMigrationDecision,
 ) -> DocumentWriteResult:
@@ -82,6 +82,8 @@ def _write_collection_plan_document(
         _result, selected = published
         if selected is None:
             return
+        if workflow_state_path is None:
+            raise DocumentMigrationError("collection plan の確定には workflow-state.json が必要です")
 
         def transition(state):
             state.record_collection_plan(

--- a/src/youtube_automation/application/documents/collection_plan.py
+++ b/src/youtube_automation/application/documents/collection_plan.py
@@ -43,7 +43,7 @@ def write_collection_plan_document(
 
 def _write_collection_plan_document(
     json_path: Path,
-    workflow_state_path: Path,
+    workflow_state_path: Path | None,
     build_document: Callable[[], object],
     migration_decision: MarkdownMigrationDecision,
     *,
@@ -83,6 +83,10 @@ def _write_collection_plan_document(
         if selected is None:
             return
         if workflow_state_path is None:
+            # `selected` が非 None になるのは selection_finalized=True の確定経路だけで、そこは
+            # 常に state path を渡すため現在のコールグラフでは到達しない。将来 draft 公開側
+            # （workflow_state_path=None）へ確定 candidate が流れ込んだときに、投影を黙って
+            # 飛ばさず fail-closed で止めるための防御。
             raise DocumentMigrationError("collection plan の確定には workflow-state.json が必要です")
 
         def transition(state):

--- a/src/youtube_automation/commands/collections/init_collection.py
+++ b/src/youtube_automation/commands/collections/init_collection.py
@@ -21,8 +21,9 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-from youtube_automation.core.errors import ValidationError
+from youtube_automation.core.errors import ValidationError, WorkflowStateError
 from youtube_automation.domains.collections.workflow_state import WorkflowState
+from youtube_automation.domains.collections.workflow_state import read_or_none as read_workflow_state_or_none
 from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.domains.uploads.playlist_resolution import (
     categorizing_playlist_keys,
@@ -32,6 +33,11 @@ from youtube_automation.infrastructure.media.collection_paths import CollectionP
 
 # --- パス解決 ---
 SCRIPT_DIR = Path(__file__).resolve().parent
+
+# 初期化済みコレクションだけが持つ workflow-state のキー（企画 draft 投影では書かれない）。
+_INITIALIZED_STATE_KEYS = frozenset(
+    {"collection_name", "theme", "created_at", "stage", "phase", "selected_plan", "track_count", "assets", "upload"}
+)
 
 
 def build_state(
@@ -76,6 +82,23 @@ def build_state(
             "publish_at": None,
         },
     }
+
+
+def _is_plan_draft_directory(base_path: Path) -> bool:
+    """企画 draft 公開だけが作った未初期化ディレクトリかを判定する (#4754).
+
+    `/wf-new` Phase 1 は初期化前に `20-documentation/plan_proposals.json` pair を公開し、
+    `yt-collection-plan-select` が `planning.*` だけの `workflow-state.json` を作る。この
+    状態のディレクトリで Phase 2a を止めると、本来の workflow-state を書ける入口が無くなる。
+    初期化済みコレクションと破損 state は従来どおり fail-loud で拒否する。
+    """
+    if not (base_path / "20-documentation" / "plan_proposals.json").is_file():
+        return False
+    try:
+        state = read_workflow_state_or_none(base_path / "workflow-state.json")
+    except WorkflowStateError:
+        return False
+    return state is None or not (_INITIALIZED_STATE_KEYS & state.keys())
 
 
 def _resolve_playlist_argument(config, args) -> list[str] | None:
@@ -166,7 +189,8 @@ def main():
     dir_name = f"{date_prefix}-{short}-{args.theme}-collection"
     base_path = ch_dir / "collections" / "planning" / dir_name
 
-    if base_path.exists():
+    plan_draft = base_path.exists() and _is_plan_draft_directory(base_path)
+    if base_path.exists() and not plan_draft:
         print(f"[ERROR] ディレクトリが既に存在します: {base_path}", file=sys.stderr)
         print(
             "        骨格の欠落を補完する場合は手動 mkdir ではなく "
@@ -174,6 +198,9 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
+
+    if plan_draft:
+        print(f"[INFO] 企画 draft 公開済みディレクトリを初期化します: {base_path}")
 
     # ディレクトリ作成（REQUIRED_SUBDIRS を CollectionPaths と共有、#1494）
     base_path.mkdir(parents=True, exist_ok=True)
@@ -189,7 +216,15 @@ def main():
         playlists=playlists,
     )
     state_path = base_path / "workflow-state.json"
-    update_workflow_state(state_path, lambda _current: WorkflowState(state))
+
+    def initialize(current: WorkflowState) -> WorkflowState:
+        """企画確定で投影済みの planning 値を初期化で消さない (#4754)。"""
+        published = current.get("planning")
+        if isinstance(published, dict):
+            state["planning"] = {**published, **state["planning"]}
+        return WorkflowState(state)
+
+    update_workflow_state(state_path, initialize)
 
     print(f"[OK] コレクション作成完了: {base_path}")
     print(f"  テーマ: {args.theme}")

--- a/src/youtube_automation/commands/documents/migrate.py
+++ b/src/youtube_automation/commands/documents/migrate.py
@@ -55,8 +55,6 @@ def run(args: argparse.Namespace) -> int:
     if schema is RepositorySchema.CHANNEL_STRATEGY:
         result = write_channel_strategy_document(args.target, load_candidate, decision)
     elif schema is RepositorySchema.COLLECTION_PLAN:
-        if args.workflow_state is None:
-            raise ValidationError("collection plan の公開には --workflow-state が必要です")
         result = write_collection_plan_document(args.target, args.workflow_state, load_candidate, decision)
     elif schema is RepositorySchema.MUSIC_PROMPT:
         if args.workflow_state is None:

--- a/tests/application/documents/test_collection_plan.py
+++ b/tests/application/documents/test_collection_plan.py
@@ -182,6 +182,34 @@ def test_proposed_plan_pair_is_published_for_review_without_state_projection(tmp
     assert state.read_bytes() == before
 
 
+def test_draft_without_state_is_projected_when_selection_is_finalized(tmp_path: Path) -> None:
+    target = tmp_path / "20-documentation/plan_proposals.json"
+    state = tmp_path / "workflow-state.json"
+    target.parent.mkdir()
+    preview = tmp_path / "10-assets" / "planning-preview.png"
+    preview.parent.mkdir()
+    preview.write_bytes(b"preview")
+    draft = _document()
+    draft["candidates"] = [_candidate(status="proposed")]
+
+    write_collection_plan_document(target, None, lambda: draft, MarkdownMigrationDecision.NOT_REQUIRED)
+
+    assert not state.exists()
+    finalize_collection_plan_selection(
+        target,
+        state,
+        proposal_id="plan-a",
+        source="terminal",
+        expected_artifact_digest=collection_plan_artifact_digest(target),
+    )
+
+    assert json.loads(state.read_text(encoding="utf-8"))["planning"] == {
+        "generated": True,
+        "final_title": "Rain Focus",
+        "target_persona": "persona-primary",
+    }
+
+
 def test_web_selection_revalidates_digest_and_projects_existing_owner_order(tmp_path: Path) -> None:
     target = tmp_path / "20-documentation/plan_proposals.json"
     state = tmp_path / "workflow-state.json"

--- a/tests/commands/collections/test_init_collection.py
+++ b/tests/commands/collections/test_init_collection.py
@@ -7,6 +7,7 @@ conftest.py が CHANNEL_DIR を tmp コピーへ向けるため fixture を汚�
 
 import json
 import sys
+from datetime import datetime
 from pathlib import Path
 
 from tests.helpers.paths import REPO_ROOT
@@ -17,6 +18,7 @@ import pytest
 
 from youtube_automation.commands.collections.init_collection import main
 from youtube_automation.configuration import channel_dir, load_config, reset
+from youtube_automation.domains.collections.workflow_state import update as update_workflow_state
 from youtube_automation.infrastructure.media.collection_paths import REQUIRED_SUBDIRS
 
 
@@ -46,6 +48,32 @@ def categorizing_playlists():
     yield
     path.write_text(original, encoding="utf-8")
     reset()
+
+
+def _collection_path(theme: str) -> Path:
+    """init_collection と同じ規則で collection path を組み立てる。"""
+    short = load_config().meta.channel_short.lower()
+    dir_name = f"{datetime.now().strftime('%Y%m%d')}-{short}-{theme}-collection"
+    return Path(channel_dir()) / "collections" / "planning" / dir_name
+
+
+def _publish_plan_draft(theme: str, *, project_selection: bool = True) -> Path:
+    """Phase 1 の draft 公開と企画確定投影が作る状態を再現する (#4754)."""
+    base = _collection_path(theme)
+    documentation = base / "20-documentation"
+    documentation.mkdir(parents=True)
+    (documentation / "plan_proposals.json").write_text(
+        json.dumps({"schema_version": 1, "candidates": []}, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    if project_selection:
+
+        def project(state):
+            state.record_collection_plan(final_title="Rain Focus", target_persona="persona-primary")
+            return state
+
+        update_workflow_state(base / "workflow-state.json", project)
+    return base
 
 
 def _created_collection() -> Path:
@@ -170,6 +198,80 @@ class TestScaffold:
             state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
             assert state["planning"]["music"]["engine"] == "minimax"
             assert "music_engine" not in state
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+
+class TestPlanDraftDirectory:
+    """#4754: Phase 1 の企画 draft 公開が先に作ったディレクトリで 2a を止めない。
+
+    draft pair は初期化前に `20-documentation/` へ公開され、`yt-collection-plan-select`
+    が `planning.*` だけの workflow-state を作る。ここで「既に存在します」と落ちると、
+    完全な workflow-state を書ける入口が無くなって制作フローが詰む。
+    """
+
+    def test_init_continues_and_keeps_projected_planning(self, monkeypatch, capsys):
+        collection = _publish_plan_draft("draft-scaffold")
+        try:
+            _run(monkeypatch, ["Draft Scaffold", "draft-scaffold", "--track-count", "9"])
+            assert "企画 draft 公開済み" in capsys.readouterr().out
+            for sub in REQUIRED_SUBDIRS:
+                assert (collection / sub).is_dir(), f"{sub} が作成されていません"
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["collection_name"] == "Draft Scaffold"
+            assert state["stage"] == "planning"
+            assert state["phase"] == "planning"
+            assert state["track_count"] == 9
+            assert state["planning"]["generated"] is True
+            assert state["planning"]["final_title"] == "Rain Focus"
+            assert state["planning"]["target_persona"] == "persona-primary"
+            assert state["planning"]["music"]["engine"] == load_config().youtube.music_engine
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_init_continues_when_selection_is_not_finalized_yet(self, monkeypatch):
+        """draft 公開だけで state が無い段階でも初期化できる。"""
+        collection = _publish_plan_draft("draft-only-scaffold", project_selection=False)
+        try:
+            _run(monkeypatch, ["Draft Only", "draft-only-scaffold"])
+            state = json.loads((collection / "workflow-state.json").read_text(encoding="utf-8"))
+            assert state["collection_name"] == "Draft Only"
+            assert "generated" not in state["planning"]
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_initialized_collection_still_fails_loud(self, monkeypatch, capsys):
+        """企画 pair があっても初期化済み collection の再初期化は拒否する。"""
+        _run(monkeypatch, ["Init Scaffold", "init-scaffold"])
+        collection = _created_collection()
+        try:
+            (collection / "20-documentation" / "plan_proposals.json").write_text("{}", encoding="utf-8")
+            with pytest.raises(SystemExit) as exc:
+                _run(monkeypatch, ["Init Scaffold", "init-scaffold"])
+            assert exc.value.code == 1
+            assert "既に存在します" in capsys.readouterr().err
+        finally:
+            import shutil
+
+            shutil.rmtree(collection)
+
+    def test_directory_without_plan_pair_still_fails_loud(self, monkeypatch, capsys):
+        """企画 draft 由来でないディレクトリは従来どおり fail-loud で止める。"""
+        collection = _collection_path("bare-scaffold")
+        collection.mkdir(parents=True)
+        try:
+            with pytest.raises(SystemExit) as exc:
+                _run(monkeypatch, ["Bare Scaffold", "bare-scaffold"])
+            assert exc.value.code == 1
+            err = capsys.readouterr().err
+            assert "既に存在します" in err
+            assert "uv run yt-collection-preflight" in err
         finally:
             import shutil
 

--- a/tests/commands/documents/test_migrate.py
+++ b/tests/commands/documents/test_migrate.py
@@ -73,16 +73,62 @@ def test_cli_no_decision_stops_markdown_update_successfully(tmp_path: Path, caps
     assert markdown.read_bytes() == b"legacy"
 
 
-def test_collection_plan_requires_workflow_state_gate(tmp_path: Path, capsys) -> None:
+def test_collection_plan_draft_can_be_published_before_workflow_state_exists(tmp_path: Path, capsys) -> None:
     candidate = tmp_path / "candidate.json"
     target = tmp_path / "20-documentation/plan_proposals.json"
     target.parent.mkdir()
-    candidate.write_text("{}", encoding="utf-8")
+    preview = tmp_path / "10-assets/planning-preview.png"
+    preview.parent.mkdir()
+    preview.write_bytes(b"preview")
+    candidate.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "generated_at": "2026-08-16T00:00:00Z",
+                "mode": "normal",
+                "collection_id": "20260816-rain-focus",
+                "provenance": {"producer": "wf-new", "batch_id": None},
+                "candidates": [
+                    {
+                        "plan_id": "plan-a",
+                        "collection_name": "Rain Focus",
+                        "theme_slug": "rain-focus",
+                        "track_count": 12,
+                        "music_engine": "suno",
+                        "music_direction": "soft ambient",
+                        "video_direction": "rainy window",
+                        "thumbnail_direction": "blue window",
+                        "final_title": "Rain Focus",
+                        "target_persona": "persona-primary",
+                        "viewing_scene": "scene-night",
+                        "constraint_compliance": [
+                            {"constraint_id": "audio-001", "status": "pass", "evidence_ids": ["ev-1"]}
+                        ],
+                        "evidence": [
+                            {
+                                "id": "ev-1",
+                                "source_path": "reports/analysis.json",
+                                "observation": "retention",
+                            }
+                        ],
+                        "insight_ids": [],
+                        "preview_assets": ["10-assets/planning-preview.png"],
+                        "selection_status": "proposed",
+                        "selection_reason": "推奨順1位",
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
 
     result = migrate.main([str(candidate), "--target", str(target), "--schema", "collection-plan.schema.json"])
 
-    assert result == 1
-    assert "--workflow-state" in capsys.readouterr().err
+    assert result == 0
+    assert "created:" in capsys.readouterr().out
+    assert target.is_file()
+    assert target.with_suffix(".html").is_file()
+    assert not (tmp_path / "workflow-state.json").exists()
 
 
 def test_music_prompt_cli_publishes_reviewed_candidate_without_approving_state(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- collection 初期化前は workflow-state なしで draft pair を公開
- 企画選択確定時に state を新規作成して投影
- Phase 1 の手順と integration tests を更新

Closes #4754