### PR TITLE
fix(streaming): 動画削除後も destroy を許可する (#4771)

### DIFF
--- a/changelog.d/4771-streaming-destroy-missing-video.fixed.md
+++ b/changelog.d/4771-streaming-destroy-missing-video.fixed.md
@@ -1,0 +1,1 @@
+- 配信元動画を削除した後でも Terraform が video hash の評価で停止せず、配信 VPS を destroy して課金を止められるようにした（#4771）。

--- a/infra/terraform/streaming/main.tf
+++ b/infra/terraform/streaming/main.tf
@@ -83,7 +83,7 @@ resource "vultr_instance" "this" {
 resource "null_resource" "deploy" {
   triggers = {
     instance_id           = vultr_instance.this.id
-    video_hash            = filemd5(var.video_path)
+    video_hash            = fileexists(var.video_path) ? filemd5(var.video_path) : ""
     ssh_host_key          = local.ssh_host_public_key_sha
     stream_hours          = tostring(var.stream_hours)
     break_hours           = tostring(var.break_hours)

--- a/tests/repo/streaming/test_main_tf.py
+++ b/tests/repo/streaming/test_main_tf.py
@@ -465,7 +465,7 @@ class TestMainTfNullResource:
         Then deploy 再実行に必要なキーが宣言されている。
 
         - instance_id = vultr_instance.this.id（VPS 再作成時の再 deploy）
-        - video_hash = filemd5(var.video_path)（動画差分での再 deploy）
+        - video_hash = fileexists(...) ? filemd5(...) : ""（動画差分での再 deploy。destroy は不在を許容）
         - stream_hours / break_hours / crash_restart_seconds（配信サイクル差分での再 deploy）
         - stream_key（sha256 ハッシュ。stream key 差分での再 deploy）
         """
@@ -477,9 +477,11 @@ class TestMainTfNullResource:
         assert re.search(r"instance_id\s*=\s*vultr_instance\.this\.id", triggers), (
             "triggers.instance_id が vultr_instance.this.id でない"
         )
-        assert re.search(r"video_hash\s*=\s*filemd5\(\s*var\.video_path\s*\)", triggers), (
-            "triggers.video_hash が filemd5(var.video_path) でない"
-        )
+        assert re.search(
+            r"video_hash\s*=\s*fileexists\(\s*var\.video_path\s*\)\s*\?\s*"
+            r'filemd5\(\s*var\.video_path\s*\)\s*:\s*""',
+            triggers,
+        ), "triggers.video_hash が動画不在時を空 hash に退避せず、実在時の filemd5(var.video_path) を維持していない"
         assert re.search(r"stream_hours\s*=\s*tostring\(\s*var\.stream_hours\s*\)", triggers), (
             "triggers.stream_hours が tostring(var.stream_hours) でない"
         )


### PR DESCRIPTION
## Summary
- video_hash の算出を動画存在確認でガード
- 動画削除後も terraform destroy を実行可能に変更
- apply 時の preflight と動画存在時の hash 算出を回帰テストで維持

Closes #4771