### PR TITLE
fix(wf-new): postmortem 許可範囲をチャンネル基準にする (#4809)

### DIFF
--- a/changelog.d/4809-cloud-planning-postmortem.fixed.md
+++ b/changelog.d/4809-cloud-planning-postmortem.fixed.md
@@ -1,0 +1,1 @@
+- multi-channel workspace でも cloud planning が対象チャンネル配下の postmortem を正しく許可するよう修正

--- a/changelog.d/4809-cloud-planning-postmortem.fixed.md
+++ b/changelog.d/4809-cloud-planning-postmortem.fixed.md
@@ -1,1 +1,1 @@
-- multi-channel workspace でも cloud planning が対象チャンネル配下の postmortem を正しく許可するよう修正
+- multi-channel workspace でも cloud planning が対象チャンネル配下の postmortem と監査出力（`.automation-run/history.json` / `data/insights.jsonl`）を正しく許可するよう修正

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -103,11 +103,14 @@ def verify_planning_completion(root: Path, collection: Path | None) -> Path:
 def validate_planning_changes(repository: Path, collection: Path, changed: set[str]) -> None:
     """Restrict the planning agent to its selected collection and audit outputs."""
 
-    relative_collection = collection.resolve().relative_to(repository.resolve()).as_posix()
-    collection_prefix = f"{relative_collection}/"
+    relative_collection = collection.resolve().relative_to(repository.resolve())
+    collection_prefix = f"{relative_collection.as_posix()}/"
+    collection_parts = relative_collection.parts
+    collections_index = collection_parts.index("collections")
+    live_prefix = Path(*collection_parts[:collections_index], "collections", "live").as_posix() + "/"
     for path in changed:
         allowed_audit = path in {".automation-run/history.json", "data/insights.jsonl"}
-        allowed_postmortem = path.startswith("collections/live/") and path.endswith("/20-documentation/postmortem.md")
+        allowed_postmortem = path.startswith(live_prefix) and path.endswith("/20-documentation/postmortem.md")
         if not path.startswith(collection_prefix) and not allowed_audit and not allowed_postmortem:
             raise StateSyncError(f"cloud planning changed an unowned path: {path}")
 

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -100,16 +100,18 @@ def verify_planning_completion(root: Path, collection: Path | None) -> Path:
     return collection
 
 
-def validate_planning_changes(repository: Path, collection: Path, changed: set[str]) -> None:
+def validate_planning_changes(repository: Path, channel_dir: Path, collection: Path, changed: set[str]) -> None:
     """Restrict the planning agent to its selected collection and audit outputs."""
 
-    relative_collection = collection.resolve().relative_to(repository.resolve())
-    collection_prefix = f"{relative_collection.as_posix()}/"
-    collection_parts = relative_collection.parts
-    collections_index = collection_parts.index("collections")
-    live_prefix = Path(*collection_parts[:collections_index], "collections", "live").as_posix() + "/"
+    root = repository.resolve()
+    relative_channel = channel_dir.resolve().relative_to(root)
+    # repository == channel_dir の single-channel では relative_to が "." を返すため前置を空にする。
+    channel_prefix = "" if relative_channel == Path(".") else f"{relative_channel.as_posix()}/"
+    collection_prefix = f"{collection.resolve().relative_to(root).as_posix()}/"
+    live_prefix = f"{channel_prefix}collections/live/"
+    audit_paths = {f"{channel_prefix}.automation-run/history.json", f"{channel_prefix}data/insights.jsonl"}
     for path in changed:
-        allowed_audit = path in {".automation-run/history.json", "data/insights.jsonl"}
+        allowed_audit = path in audit_paths
         allowed_postmortem = path.startswith(live_prefix) and path.endswith("/20-documentation/postmortem.md")
         if not path.startswith(collection_prefix) and not allowed_audit and not allowed_postmortem:
             raise StateSyncError(f"cloud planning changed an unowned path: {path}")
@@ -136,4 +138,5 @@ class PlanningStagePolicy(ReadinessStagePolicy):
     def allows(self, repository: Path, changed: set[str]) -> None:
         if self._completed is None:
             raise StateSyncError("cloud planning completion target is missing")
-        validate_planning_changes(repository, self._completed, changed)
+        # hybrid_runner から渡される self.root が対象チャンネルの channel_dir そのもの。
+        validate_planning_changes(repository, self.root, self._completed, changed)

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -131,10 +131,12 @@ def test_planning_stage_policy_rejects_media_handoff_before_any_side_effect(tmp_
 
 
 def test_change_allowlist_scopes_postmortem_to_channel_directory(tmp_path: Path) -> None:
-    collection = tmp_path / "channels" / "focus" / "collections" / "planning" / "demo"
+    channel_dir = tmp_path / "channels" / "focus"
+    collection = channel_dir / "collections" / "planning" / "demo"
 
     validate_planning_changes(
         tmp_path,
+        channel_dir,
         collection,
         {"channels/focus/collections/live/older/20-documentation/postmortem.md"},
     )
@@ -142,6 +144,45 @@ def test_change_allowlist_scopes_postmortem_to_channel_directory(tmp_path: Path)
     with pytest.raises(StateSyncError, match="unowned path"):
         validate_planning_changes(
             tmp_path,
+            channel_dir,
             collection,
             {"collections/live/older/20-documentation/postmortem.md"},
+        )
+
+
+def test_change_allowlist_scopes_audit_outputs_to_channel_directory(tmp_path: Path) -> None:
+    channel_dir = tmp_path / "channels" / "focus"
+    collection = channel_dir / "collections" / "planning" / "demo"
+
+    validate_planning_changes(
+        tmp_path,
+        channel_dir,
+        collection,
+        {"channels/focus/.automation-run/history.json", "channels/focus/data/insights.jsonl"},
+    )
+
+    with pytest.raises(StateSyncError, match="unowned path"):
+        validate_planning_changes(tmp_path, channel_dir, collection, {"data/insights.jsonl"})
+
+
+def test_change_allowlist_keeps_repository_root_scope_for_single_channel(tmp_path: Path) -> None:
+    collection = tmp_path / "collections" / "planning" / "demo"
+
+    validate_planning_changes(
+        tmp_path,
+        tmp_path,
+        collection,
+        {
+            "collections/live/older/20-documentation/postmortem.md",
+            ".automation-run/history.json",
+            "data/insights.jsonl",
+        },
+    )
+
+    with pytest.raises(StateSyncError, match="unowned path"):
+        validate_planning_changes(
+            tmp_path,
+            tmp_path,
+            collection,
+            {"channels/focus/collections/live/older/20-documentation/postmortem.md"},
         )

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -11,6 +11,7 @@ from youtube_automation.domains.cloud_planning import (
     PlanningStagePolicy,
     _planning_states,
     resolve_planning_readiness,
+    validate_planning_changes,
     verify_planning_completion,
 )
 from youtube_automation.domains.collections.inventory import CollectionRecord
@@ -127,3 +128,20 @@ def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_pat
 def test_planning_stage_policy_rejects_media_handoff_before_any_side_effect(tmp_path: Path) -> None:
     with pytest.raises(ValidationError, match="media handoff を受け付けません"):
         PlanningStagePolicy(tmp_path, "/wf-new --auto", object())
+
+
+def test_change_allowlist_scopes_postmortem_to_channel_directory(tmp_path: Path) -> None:
+    collection = tmp_path / "channels" / "focus" / "collections" / "planning" / "demo"
+
+    validate_planning_changes(
+        tmp_path,
+        collection,
+        {"channels/focus/collections/live/older/20-documentation/postmortem.md"},
+    )
+
+    with pytest.raises(StateSyncError, match="unowned path"):
+        validate_planning_changes(
+            tmp_path,
+            collection,
+            {"collections/live/older/20-documentation/postmortem.md"},
+        )


### PR DESCRIPTION
## Summary
- cloud planning の postmortem allowlist を repository 直下固定から対象 channel_dir 基準へ変更
- multi-channel workspace と別チャンネル誤許可の回帰テストを追加

Closes #4809