### PR TITLE
fix(wf-new): cloud runner の channel dir を解決する (#4808)

### DIFF
--- a/.claude/skills/wf-new/references/run-sandwich.sh
+++ b/.claude/skills/wf-new/references/run-sandwich.sh
@@ -26,6 +26,20 @@ checkout=$workspace/channel
 git clone --quiet --branch "$repository_ref" --single-branch "$repository_url" "$checkout"
 cd "$checkout"
 
+channel_slug=
+expect_channel_slug=false
+for argument in "$@"; do
+  if [ "$expect_channel_slug" = true ]; then
+    channel_slug=$argument
+    break
+  fi
+  case "$argument" in
+    --channel-slug) expect_channel_slug=true ;;
+    --channel-slug=*) channel_slug=${argument#*=}; break ;;
+  esac
+done
+[ -n "$channel_slug" ] || usage
+
 # Cloud and local use the same uv-direct path. Provider-specific workflow syntax belongs outside this script.
 uv run --frozen yt-hybrid-runner --channel-dir . "$@"
-uv run --frozen yt-human-tasks
+uv run --frozen yt-human-tasks --channel "$channel_slug"

--- a/changelog.d/4808-cloud-runner-channel-dir.fixed.md
+++ b/changelog.d/4808-cloud-runner-channel-dir.fixed.md
@@ -1,0 +1,1 @@
+- cloud sandwich runner が multi-channel workspace で `--channel-slug` に対応する channel directory を使用し、planning 前に `collections/` 欠落を検出するよう修正

--- a/src/youtube_automation/commands/system/hybrid_runner.py
+++ b/src/youtube_automation/commands/system/hybrid_runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from youtube_automation.application.hybrid_runner import MediaHandoffRequest, SandwichRequest, run_sandwich
 from youtube_automation.commands._shared.cli_harness import run_cli
+from youtube_automation.configuration import workspace_channels
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.hybrid_resources import SystemHybridResourceProbe
 from youtube_automation.infrastructure.media_store.local import LocalMediaStore
@@ -54,6 +55,20 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _resolve_channel_dir(repository: Path, channel_slug: str) -> Path:
+    root = repository.resolve()
+    channels = workspace_channels(root)
+    if not channels:
+        return root
+    try:
+        return channels[channel_slug].resolve()
+    except KeyError as exc:
+        available = ", ".join(channels)
+        raise ConfigError(
+            f"--channel-slug={channel_slug!r} に対応するチャンネルがありません。候補: {available}"
+        ) from exc
+
+
 def run(args: argparse.Namespace) -> int:
     if args.media_store == "local":
         if args.local_store_root is None:
@@ -80,8 +95,9 @@ def run(args: argparse.Namespace) -> int:
         if any(handoff_values)
         else None
     )
+    resolved_channel_dir = _resolve_channel_dir(args.channel_dir, args.channel_slug)
     request = SandwichRequest(
-        channel_dir=args.channel_dir.resolve(),
+        channel_dir=resolved_channel_dir,
         channel=args.channel_slug,
         collection=args.collection,
         agent=args.agent,

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -55,8 +55,12 @@ def _sort_key(item: tuple[Path, WorkflowState]) -> tuple[str, str]:
 def resolve_planning_readiness(root: Path) -> PlanningReadiness:
     """Select the oldest active collection without mutating repository state."""
 
+    resolved_root = root.resolve()
+    collections_root = resolved_root / "collections"
+    if not collections_root.exists() and not collections_root.is_symlink():
+        raise StateSyncError(f"cloud planning collections directory is missing: {collections_root}")
     try:
-        active = _planning_states(iter_collections(root.resolve(), ("planning",)))
+        active = _planning_states(iter_collections(resolved_root, ("planning",)))
     except WorkflowStateError as exc:
         raise StateSyncError("cloud planning inventory is invalid") from exc
     if not active:

--- a/tests/application/test_hybrid_runner.py
+++ b/tests/application/test_hybrid_runner.py
@@ -652,7 +652,10 @@ def test_posix_script_completes_local_pull_run_push(tmp_path: Path) -> None:
         """#!/bin/sh
 set -eu
 [ "$1" = run ] && [ "$2" = --frozen ]
-if [ "$3" = yt-human-tasks ]; then exit 0; fi
+if [ "$3" = yt-human-tasks ]; then
+  printf "%s\\n" "$*" > "$YTA_HUMAN_TASKS_ARGS"
+  exit 0
+fi
 [ "$3" = yt-hybrid-runner ]
 shift 3
 git config user.name Test
@@ -691,6 +694,7 @@ exec "$YTA_TEST_PYTHON" "$YTA_AGENT_SCRIPT"
             "PATH": f"{bin_dir}:{env['PATH']}",
             "YTA_TEST_PYTHON": sys.executable,
             "YTA_AGENT_SCRIPT": str(agent_script),
+            "YTA_HUMAN_TASKS_ARGS": str(tmp_path / "human-tasks-args"),
         }
     )
 
@@ -742,6 +746,9 @@ exec "$YTA_TEST_PYTHON" "$YTA_AGENT_SCRIPT"
     assert "disk_free=" in result.stderr
     assert "r2_retained=" in result.stderr
     assert "projected_actions_minutes=" in result.stderr
+    assert (tmp_path / "human-tasks-args").read_text(encoding="utf-8").strip() == (
+        "run --frozen yt-human-tasks --channel 003ch"
+    )
     verify = tmp_path / "script-verify"
     subprocess.run(["git", "clone", "--branch", "main", str(remote), str(verify)], check=True, capture_output=True)
     state = json.loads((verify / "collections/planning/demo/workflow-state.json").read_text(encoding="utf-8"))

--- a/tests/commands/test_pipeline_notification_wiring.py
+++ b/tests/commands/test_pipeline_notification_wiring.py
@@ -136,6 +136,84 @@ def test_handoff_free_hybrid_stage_does_not_require_media_store(monkeypatch, tmp
     assert result == 0
 
 
+def test_hybrid_command_resolves_workspace_channel_from_slug(monkeypatch, tmp_path: Path) -> None:
+    channel_dir = tmp_path / "channels" / "ambient-lab"
+    (channel_dir / "config" / "channel").mkdir(parents=True)
+
+    def fake_run_sandwich(
+        request,
+        store,
+        *,
+        resource_probe,
+        on_resource_event,
+        on_resource_diagnostics,
+        on_state_sync_event,
+    ):
+        assert store is None
+        assert request.channel_dir == channel_dir.resolve()
+        assert resource_probe.channel_dir == channel_dir.resolve()
+        return SandwichResult("completed", request.collection)
+
+    monkeypatch.setattr(hybrid_runner, "create_discord_notification_sink", RecordingSink)
+    monkeypatch.setattr(hybrid_runner, "run_sandwich", fake_run_sandwich)
+
+    result = hybrid_runner.run(
+        Namespace(
+            media_store="r2",
+            local_store_root=None,
+            channel_dir=tmp_path,
+            collection_dir="collections/planning/night-rain",
+            channel_slug="ambient-lab",
+            collection="night-rain",
+            agent="claude",
+            stage="planning",
+            prompt="/wf-new --auto",
+            commit_message="chore: state",
+            input_handoff=None,
+            input_destination=None,
+            output_handoff=None,
+            output_root=None,
+            output_file=[],
+            generation_cost_usd=0,
+            monthly_run_count=0,
+            estimated_run_minutes=60,
+        )
+    )
+
+    assert result == 0
+
+
+def test_hybrid_command_rejects_unknown_workspace_channel_before_execution(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    (tmp_path / "channels" / "ambient-lab" / "config" / "channel").mkdir(parents=True)
+    runner = MagicMock(side_effect=AssertionError("runner must not execute"))
+    monkeypatch.setattr(hybrid_runner, "run_sandwich", runner)
+
+    result = hybrid_runner.main(
+        [
+            "--channel-dir",
+            str(tmp_path),
+            "--channel-slug",
+            "missing",
+            "--collection",
+            "night-rain",
+            "--collection-dir",
+            "collections/planning/night-rain",
+            "--stage",
+            "planning",
+            "--prompt",
+            "/wf-new --auto",
+        ]
+    )
+
+    assert result == 1
+    assert "--channel-slug='missing' に対応するチャンネルがありません" in capsys.readouterr().err
+    runner.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("action", "expected_kind", "expected_stage"),
     [

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -38,7 +38,13 @@ def _state(root: Path, name: str, *, phase: str, created_at: str, engine: str = 
 
 
 def test_readiness_selects_new_planning_when_no_unfinished_collection_exists(tmp_path: Path) -> None:
+    (tmp_path / "collections").mkdir()
     assert resolve_planning_readiness(tmp_path) == PlanningReadiness("ready", None)
+
+
+def test_readiness_rejects_missing_collections_directory(tmp_path: Path) -> None:
+    with pytest.raises(StateSyncError, match="collections directory"):
+        resolve_planning_readiness(tmp_path)
 
 
 def test_planning_policy_projects_inventory_records_without_reading_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- multi-channel workspace で channel slug から実 channel directory を解決
- 選択した channel directory を後段 human-tasks へ伝搬
- collections/ 欠落を agent 起動前に fail-loud 化し回帰テストを追加

Closes #4808