### PR TITLE
fix(wf-new): headless agent の未着手を診断する (#4813)

### DIFF
--- a/changelog.d/4813-headless-agent-blocked-detection.fixed.md
+++ b/changelog.d/4813-headless-agent-blocked-detection.fixed.md
@@ -1,0 +1,1 @@
+- cloud planning の headless agent が前提不足を人間へ問い返さず失敗として報告し、collection 未作成時に未着手の可能性を示すよう修正した（#4813）。

--- a/src/youtube_automation/domains/cloud_planning.py
+++ b/src/youtube_automation/domains/cloud_planning.py
@@ -21,7 +21,9 @@ _CLOUD_PLANNING_SCOPE = (
     "Cloud planning scope ends after planning.generated and assets.music_prompts are true, "
     "and the planning and music prompt JSON/HTML pairs are finalized. "
     "Do not generate thumbnail or loop-video assets, and do not set phase prepared; "
-    "leave phase planning for local continuation."
+    "leave phase planning for local continuation. "
+    "No human can respond to this headless run. If a prerequisite is unavailable, "
+    "report the blocker and exit non-zero instead of asking a question or offering choices."
 )
 
 
@@ -88,6 +90,11 @@ def verify_planning_completion(root: Path, collection: Path | None) -> Path:
             active = _planning_states(iter_collections(root.resolve(), ("planning",)))
         except WorkflowStateError as exc:
             raise StateSyncError("cloud planning inventory is invalid") from exc
+        if not active:
+            raise StateSyncError(
+                "cloud planning created no active collection; the agent may not have started "
+                "because a prerequisite was unavailable or it tried to ask a human"
+            )
         if len(active) != 1:
             raise StateSyncError("cloud planning must create exactly one active collection")
         collection, state = active[0]

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -126,6 +126,13 @@ def test_completion_resolves_exactly_one_new_collection(tmp_path: Path) -> None:
         verify_planning_completion(tmp_path, None)
 
 
+def test_completion_reports_when_agent_created_no_active_collection(tmp_path: Path) -> None:
+    (tmp_path / "collections").mkdir()
+
+    with pytest.raises(StateSyncError, match="agent may not have started"):
+        verify_planning_completion(tmp_path, None)
+
+
 def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_path: Path) -> None:
     collection = _state(tmp_path, "demo", phase="planning", created_at="2026-01-01T00:00:00Z")
     policy = PlanningStagePolicy(tmp_path, "/wf-new --auto")
@@ -134,6 +141,8 @@ def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_pat
     assert policy.waiting is False
     assert policy.prompt_for().startswith("/wf-new --auto\nCloud planning scope ends after")
     assert "leave phase planning" in policy.prompt_for()
+    assert "No human can respond to this headless run" in policy.prompt_for()
+    assert "exit non-zero instead of asking a question or offering choices" in policy.prompt_for()
 
     state_path = collection / "workflow-state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))

--- a/tests/domains/test_cloud_planning.py
+++ b/tests/domains/test_cloud_planning.py
@@ -141,8 +141,10 @@ def test_planning_stage_policy_adapts_readiness_completion_and_allowlist(tmp_pat
     assert policy.waiting is False
     assert policy.prompt_for().startswith("/wf-new --auto\nCloud planning scope ends after")
     assert "leave phase planning" in policy.prompt_for()
-    assert "No human can respond to this headless run" in policy.prompt_for()
-    assert "exit non-zero instead of asking a question or offering choices" in policy.prompt_for()
+    assert (
+        "No human can respond to this headless run. If a prerequisite is unavailable, "
+        "report the blocker and exit non-zero instead of asking a question or offering choices." in policy.prompt_for()
+    )
 
     state_path = collection / "workflow-state.json"
     state = json.loads(state_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- headless 実行では人間へ質問せず前提不足を非ゼロ終了する prompt に強化
- active collection が 0 件なら agent 未着手の可能性を直接診断
- 診断契約をテストで固定

Closes #4813