### PR TITLE
fix(site): サイドバーのリリース節を release-notes から生成する (#4726)

### DIFF
--- a/site/blume.config.ts
+++ b/site/blume.config.ts
@@ -1,7 +1,7 @@
 import dadsTokens from "@digital-go-jp/design-tokens";
 import { defineConfig } from "blume";
-import { releaseScaleLabels } from "./release-scale";
 import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import { z } from "zod";
 import {
   createOperatorDocSource,
@@ -9,6 +9,7 @@ import {
   operatorDocReleaseField,
 } from "./operator-doc-source";
 import { releaseFrontmatter } from "./release-schema";
+import { releaseSidebarGroups } from "./release-sidebar";
 import { createSkillPageSource } from "./skill-page-source";
 
 const lightAccent = dadsTokens.Color.Key["800"].$value;
@@ -81,22 +82,7 @@ export default defineConfig({
           },
         ],
       },
-      {
-        label: `本体｜${releaseScaleLabels.major}`,
-        items: ["/v5.6.0"],
-      },
-      {
-        label: `本体｜${releaseScaleLabels.minor}`,
-        items: ["/v5.5.17"],
-      },
-      {
-        label: `Chrome 拡張｜${releaseScaleLabels.major}`,
-        items: ["/ext-v0.3.0"],
-      },
-      {
-        label: `Chrome 拡張｜${releaseScaleLabels.minor}`,
-        items: ["/ext-v0.2.5"],
-      },
+      ...releaseSidebarGroups(join(repositoryRoot, "docs/release-notes")),
     ],
     // Operator routes are intentionally flat; root-scoped tabs keep the same
     // three-section sidebar visible instead of treating one route as a prefix.

--- a/site/release-sidebar.ts
+++ b/site/release-sidebar.ts
@@ -1,0 +1,73 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { z } from "zod";
+import { groupReleasesByScale, releaseScaleLabels } from "./release-scale.ts";
+import { releaseFrontmatter } from "./release-schema.ts";
+
+export interface ReleaseSidebarGroup {
+  readonly items: readonly string[];
+  readonly label: string;
+}
+
+const releaseSchema = z.object(releaseFrontmatter);
+
+type ReleaseKind = z.infer<typeof releaseSchema>["kind"];
+
+const releaseKindLabels: Record<ReleaseKind, string> = {
+  main: "本体",
+  extension: "Chrome 拡張",
+};
+const releaseKinds: readonly ReleaseKind[] = ["main", "extension"];
+const frontmatterBlock = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u;
+const topLevelScalar = /^(?<key>[A-Za-z_][\w-]*):[^\S\r\n]+(?<value>\S.*)$/u;
+
+/**
+ * ネストしたキー（`sidebar.order`）を持たない frontmatter 前提で、
+ * 依存を増やさずに release 判定へ必要なスカラーだけを取り出す。
+ */
+const parseFrontmatter = (source: string, path: string): Record<string, string> => {
+  const block = frontmatterBlock.exec(source);
+  if (block === null) {
+    throw new Error(`Release note has no frontmatter: ${path}`);
+  }
+
+  return Object.fromEntries(
+    block[1]
+      .split(/\r?\n/u)
+      .map((line) => topLevelScalar.exec(line))
+      .filter((match) => match !== null)
+      .map((match) => [match.groups.key, match.groups.value.replace(/^"(.*)"$/u, "$1")])
+  );
+};
+
+const readRelease = (directory: string, file: string) => {
+  const path = join(directory, file);
+  const release = releaseSchema.parse(parseFrontmatter(readFileSync(path, "utf8"), path));
+  const expectedVersion = file.replace(/\.md$/u, "");
+  if (release.version !== expectedVersion) {
+    throw new Error(
+      `Release note version does not match its filename: ${path} declares ${release.version}`
+    );
+  }
+
+  return release;
+};
+
+/**
+ * `docs/release-notes/` の実ファイルから blume の sidebar 節を導出する。
+ * リリースごとに config を手で足す運用は追加漏れで drift するため（#4726）。
+ */
+export function releaseSidebarGroups(directory: string): ReleaseSidebarGroup[] {
+  const releases = readdirSync(directory)
+    .filter((file) => file.endsWith(".md"))
+    .map((file) => readRelease(directory, file));
+
+  return releaseKinds.flatMap((kind) =>
+    groupReleasesByScale(releases.filter((release) => release.kind === kind)).map(
+      (group) => ({
+        items: group.releases.map((release) => `/${release.version}`),
+        label: `${releaseKindLabels[kind]}｜${releaseScaleLabels[group.scale]}`,
+      })
+    )
+  );
+}

--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -1,13 +1,17 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { readdir, readFile } from "node:fs/promises";
+import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import { promisify } from "node:util";
 import {
   groupReleasesByScale,
   releaseScaleLabels,
   scaleFromVersion,
 } from "../release-scale.ts";
+import { releaseSidebarGroups } from "../release-sidebar.ts";
 
 const readIndex = () => readFile(new URL("../dist/index.html", import.meta.url), "utf8");
 const readRelease = (version) =>
@@ -656,34 +660,87 @@ const sidebarGroups = (html) => {
     }));
 };
 
-test("全詳細ページのサイドバーを kind × 更新規模の4 flat groupで表示する", async () => {
-  const expectedGroups = [
-    { label: "本体｜大きいアップデート", hrefs: ["/v5.6.0"] },
-    { label: "本体｜小さいアップデート", hrefs: ["/v5.5.17"] },
-    { label: "Chrome 拡張｜大きいアップデート", hrefs: ["/ext-v0.3.0"] },
-    { label: "Chrome 拡張｜小さいアップデート", hrefs: ["/ext-v0.2.5"] },
-  ];
-  const details = [
-    { version: "v5.6.0", title: "youtube-automation v5.6.0" },
-    { version: "v5.5.17", title: "youtube-automation v5.5.17" },
-    { version: "ext-v0.3.0", title: "Chrome 拡張 ext-v0.3.0" },
-    { version: "ext-v0.2.5", title: "Chrome 拡張 ext-v0.2.5" },
-  ];
+const releaseNotesDirectory = fileURLToPath(
+  new URL("../../docs/release-notes", import.meta.url)
+);
 
-  for (const detail of details) {
-    const html = await readRelease(detail.version);
+const releaseNotes = async () => {
+  const files = (await readdir(releaseNotesDirectory)).filter((file) =>
+    file.endsWith(".md")
+  );
+  return Promise.all(
+    files.map(async (file) => {
+      const source = await readFile(join(releaseNotesDirectory, file), "utf8");
+      const title = source.match(/^title:\s*"?(?<title>.+?)"?$/mu)?.groups.title;
+      assert.ok(title, `release note has no title: ${file}`);
+      return { title, version: file.replace(/\.md$/u, "") };
+    })
+  );
+};
+
+const writeReleaseNotes = async (directory, releases) =>
+  Promise.all(
+    releases.map(({ file, kind, released_at, version }) =>
+      writeFile(
+        join(directory, file ?? `${version}.md`),
+        [
+          "---",
+          `title: "${version}"`,
+          `version: ${version}`,
+          `released_at: ${released_at}`,
+          `kind: ${kind}`,
+          'summary: "テスト用のリリース"',
+          "sidebar:",
+          "  order: -1",
+          "---",
+          "",
+        ].join("\n")
+      )
+    )
+  );
+
+test("sidebar の release 節を実ファイル群から導出し、節内を公開日の降順にする", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "release-sidebar-"));
+  await writeReleaseNotes(directory, [
+    { kind: "main", released_at: "2026-07-31", version: "v5.6.0" },
+    { kind: "main", released_at: "2026-08-29", version: "v5.7.0" },
+    { kind: "main", released_at: "2026-07-10", version: "v5.5.17" },
+    { kind: "extension", released_at: "2026-07-31", version: "ext-v0.3.0" },
+  ]);
+
+  assert.deepEqual(releaseSidebarGroups(directory), [
+    { items: ["/v5.7.0", "/v5.6.0"], label: `本体｜${releaseScaleLabels.major}` },
+    { items: ["/v5.5.17"], label: `本体｜${releaseScaleLabels.minor}` },
+    { items: ["/ext-v0.3.0"], label: `Chrome 拡張｜${releaseScaleLabels.major}` },
+  ]);
+});
+
+test("ファイル名と version が食い違う release note を path 付きで拒否する", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "release-sidebar-"));
+  await writeReleaseNotes(directory, [
+    { file: "v5.6.1.md", kind: "main", released_at: "2026-07-31", version: "v5.6.0" },
+  ]);
+
+  assert.throws(() => releaseSidebarGroups(directory), /v5\.6\.1\.md/u);
+});
+
+test("全詳細ページのサイドバーへ release 節を実ファイル群から反映する", async () => {
+  const expectedGroups = releaseSidebarGroups(releaseNotesDirectory).map((group) => ({
+    hrefs: [...group.items],
+    label: group.label,
+  }));
+  const notes = await releaseNotes();
+
+  assert.ok(notes.length > 0);
+  for (const note of notes) {
+    const html = await readRelease(note.version);
     const titles = [...html.matchAll(/<h1(?:\s[^>]*)?>([^<]+)<\/h1>/g)].map(
       (match) => match[1]
     );
-    const groups = sidebarGroups(html);
 
-    assert.equal(titles.filter((title) => title === detail.title).length, 1);
+    assert.equal(titles.filter((title) => title === note.title).length, 1);
     assert.match(html, /youtube-automation ドキュメント/);
-    assert.deepEqual(groups, expectedGroups);
-    assert.deepEqual(
-      groups.flatMap((group) => group.hrefs),
-      expectedGroups.flatMap((group) => group.hrefs)
-    );
+    assert.deepEqual(sidebarGroups(html), expectedGroups);
   }
 });
 


### PR DESCRIPTION
サイドバーのリリース節を `docs/release-notes/` の実ファイルから導出し、リリースごとの手動更新を廃止する。

## 直った不具合

`site/blume.config.ts` のリリース節は version がハードコードされており、v5.7.0 公開（#4709）で追加が漏れて全ページのサイドバーから欠落していた。トップページの一覧は動的生成のため v5.7.0 が出ており、サイドバーとの間で drift していた。

ビルド後のサイドバーで `本体｜大きいアップデート` が `/v5.7.0` → `/v5.6.0` の順に並ぶことを確認済み。

## 変更

- `site/release-sidebar.ts`（新規）: `docs/release-notes/` を走査し、`release-schema.ts` の zod schema で frontmatter を検証したうえで、`release-scale.ts` の `groupReleasesByScale` で kind × 規模の節を生成する。トップページと同一の分類・並び規則を再利用しており、0 件の規模節は出力しない。ファイル名と frontmatter の `version` が食い違う場合は path を名指しして停止する。
- `site/blume.config.ts`: 4 節のハードコード items をヘルパーの導出結果へ置換。`navigation.sidebar` は blume の既存契約（`label` + `items`）のまま。
- `site/tests/release-notes.test.mjs`: サイドバー検証を実ファイル群からの導出へ追従。

## テストの複製をやめた理由

既存のサイドバーテストは config と同じ version リストを期待値へ複製していたため、config の追加漏れを検出できず v5.7.0 の欠落を通していた。導出結果との突き合わせに変えたことで、ノート追加では落ちず、config だけが古いままなら落ちる。

- unit: 一時ディレクトリの release note 群から、節内の公開日降順と 0 件節の省略を検証
- unit: ファイル名と version の不一致を path 付きで拒否することを検証
- integration: ビルド後の全詳細ページのサイドバーが、実ファイルからの導出結果と一致することを検証

## 検証

- `pnpm -C site check` / `build` / `test` がいずれも exit 0（52 tests pass）

docs-site のみの変更のため `skip-changelog` を付与する。

Closes #4726

🤖 Generated with [Claude Code](https://claude.com/claude-code)
