### PR TITLE
fix(analytics): validator を uv run 経由で実行する (#4827)

### DIFF
--- a/.claude/skills/analytics/references/analysis-json-validator.md
+++ b/.claude/skills/analytics/references/analysis-json-validator.md
@@ -470,7 +470,7 @@ jq -e --slurpfile targets "$analysis_target" '
          end)
 ' "$analysis_json" >/dev/null
 
-yt-document-render "$analysis_json" --schema analysis-report.schema.json --check >/dev/null
+uv run yt-document-render "$analysis_json" --schema analysis-report.schema.json --check >/dev/null
 ```
 
 ## 検証する evidence 契約

--- a/changelog.d/4827-analytics-validator-uv-run.fixed.md
+++ b/changelog.d/4827-analytics-validator-uv-run.fixed.md
@@ -1,0 +1,1 @@
+- analytics の analysis JSON validator が `yt-document-render` を `uv run` 経由で実行し、仮想環境を activate していない標準運用でも完走するようにした（#4827）。

--- a/tests/repo/test_analytics_analyze_validator.py
+++ b/tests/repo/test_analytics_analyze_validator.py
@@ -22,7 +22,7 @@ def _validator_script() -> str:
 def test_validator_uses_cwd_independent_canonical_cli_boundary() -> None:
     script = _validator_script()
 
-    assert "yt-document-render" in script
+    assert 'uv run yt-document-render "$analysis_json"' in script
     assert "--check" in script
     assert "uv run python" not in script
     assert "from youtube_automation" not in script


### PR DESCRIPTION
analysis JSON validator の yt-document-render を uv run 経由で起動し、標準環境で Hard Gate が完走するようにします。

Closes #4827