### PR TITLE
test(release-notes): 期待値を実ファイルから導出する (#4834)

### DIFF
--- a/site/tests/release-notes.test.mjs
+++ b/site/tests/release-notes.test.mjs
@@ -18,6 +18,9 @@ const readRelease = (version) =>
   readFile(new URL(`../dist/${version}/index.html`, import.meta.url), "utf8");
 const readOperatorDoc = (route) =>
   readFile(new URL(`../dist${route}/index.html`, import.meta.url), "utf8");
+const releaseNotesDirectory = fileURLToPath(
+  new URL("../../docs/release-notes", import.meta.url)
+);
 const execFileAsync = promisify(execFile);
 const operatorSections = [
   {
@@ -538,59 +541,43 @@ test("release がない規模の group は返さない", () => {
 
 test("top page は kind の下に非空の更新規模 section を見出し階層付きで描画する", async () => {
   const html = await readIndex();
+  const releases = await releaseNotes();
 
   for (const [kind, kindLabel] of [
     ["main", "本体"],
     ["extension", "Chrome 拡張"],
   ]) {
     const kindSection = sectionByAttribute(html, "data-release-kind", kind);
-    const majorSection = sectionByAttribute(kindSection, "data-release-scale", "major");
-    const minorSection = sectionByAttribute(kindSection, "data-release-scale", "minor");
+    const expectedGroups = groupReleasesByScale(
+      releases.filter((release) => release.kind === kind)
+    );
 
     assert.match(kindSection, new RegExp(`<h3>${kindLabel}</h3>`));
-    assert.equal([...kindSection.matchAll(/<section[^>]*data-release-scale=/g)].length, 2);
-    assert.match(majorSection, /<h4>大きいアップデート<\/h4>/);
-    assert.match(minorSection, /<h4>小さいアップデート<\/h4>/);
-    assert.match(majorSection, /<ol[^>]*class="release-list"[^>]*>\s*<li>/);
-    assert.match(minorSection, /<ol[^>]*class="release-list"[^>]*>\s*<li>/);
+    assert.equal(
+      [...kindSection.matchAll(/<section[^>]*data-release-scale=/g)].length,
+      expectedGroups.length
+    );
+    for (const group of expectedGroups) {
+      const scaleSection = sectionByAttribute(
+        kindSection,
+        "data-release-scale",
+        group.scale
+      );
+      assert.match(scaleSection, new RegExp(`<h4>${group.label}<\\/h4>`));
+      assert.match(scaleSection, /<ol[^>]*class="release-list"[^>]*>\s*<li>/);
+    }
     assert.doesNotMatch(kindSection, /<section[^>]*data-release-scale[^>]*>\s*<h4>[^<]+<\/h4>\s*<ol[^>]*>\s*<\/ol>/);
   }
 });
 
-test("top page の kind × 更新規模 group は6 releaseの所属・日付・リンクを維持する", async () => {
+test("top page の kind × 更新規模 group は実ファイルの所属・日付・リンクを維持する", async () => {
   const html = await readIndex();
-  const expectedGroups = [
-    {
-      kind: "main",
-      scale: "major",
-      entries: [
-        { version: "v5.7.0", date: "2026-08-29T00:00:00.000Z", href: "/v5.7.0" },
-        { version: "v5.6.0", date: "2026-07-31T00:00:00.000Z", href: "/v5.6.0" },
-      ],
-    },
-    {
-      kind: "main",
-      scale: "minor",
-      entries: [
-        { version: "v5.7.1", date: "2026-09-02T00:00:00.000Z", href: "/v5.7.1" },
-        { version: "v5.5.17", date: "2026-07-10T00:00:00.000Z", href: "/v5.5.17" },
-      ],
-    },
-    {
-      kind: "extension",
-      scale: "major",
-      entries: [
-        { version: "ext-v0.3.0", date: "2026-07-31T00:00:00.000Z", href: "/ext-v0.3.0" },
-      ],
-    },
-    {
-      kind: "extension",
-      scale: "minor",
-      entries: [
-        { version: "ext-v0.2.5", date: "2026-07-10T00:00:00.000Z", href: "/ext-v0.2.5" },
-      ],
-    },
-  ];
+  const releases = await releaseNotes();
+  const expectedGroups = ["main", "extension"].flatMap((kind) =>
+    groupReleasesByScale(releases.filter((release) => release.kind === kind)).map(
+      (group) => ({ entries: group.releases, kind, scale: group.scale })
+    )
+  );
 
   for (const expected of expectedGroups) {
     const kindSection = sectionByAttribute(html, "data-release-kind", expected.kind);
@@ -605,11 +592,14 @@ test("top page の kind × 更新規模 group は6 releaseの所属・日付・�
 
     assert.deepEqual(
       hrefs,
-      expected.entries.map((entry) => entry.href)
+      expected.entries.map((entry) => `/${entry.version}`)
     );
     for (const entry of expected.entries) {
       assert.match(scaleSection, new RegExp(`<h5>${entry.version}</h5>`));
-      assert.match(scaleSection, new RegExp(`<time datetime="${entry.date}">[^<]+</time>`));
+      assert.match(
+        scaleSection,
+        new RegExp(`<time datetime="${entry.released_at.toISOString()}">[^<]+</time>`)
+      );
     }
     assert.match(
       scaleSection,
@@ -636,8 +626,13 @@ test("一覧は本体とChrome拡張に分かれ、それぞれ公開日の新�
 
   assert.match(main, /<h3>本体<\/h3>/);
   assert.match(extension, /<h3>Chrome 拡張<\/h3>/);
-  assert.deepEqual(hrefs(main), ["/v5.7.0", "/v5.6.0", "/v5.7.1", "/v5.5.17"]);
-  assert.deepEqual(hrefs(extension), ["/ext-v0.3.0", "/ext-v0.2.5"]);
+  const releases = await releaseNotes();
+  const expectedHrefs = (kind) =>
+    groupReleasesByScale(releases.filter((release) => release.kind === kind)).flatMap(
+      (group) => group.releases.map((release) => `/${release.version}`)
+    );
+  assert.deepEqual(hrefs(main), expectedHrefs("main"));
+  assert.deepEqual(hrefs(extension), expectedHrefs("extension"));
 });
 
 test("本体とChrome拡張を区別し、詳細ページへリンクする", async () => {
@@ -660,10 +655,6 @@ const sidebarGroups = (html) => {
     }));
 };
 
-const releaseNotesDirectory = fileURLToPath(
-  new URL("../../docs/release-notes", import.meta.url)
-);
-
 const releaseNotes = async () => {
   const files = (await readdir(releaseNotesDirectory)).filter((file) =>
     file.endsWith(".md")
@@ -672,8 +663,18 @@ const releaseNotes = async () => {
     files.map(async (file) => {
       const source = await readFile(join(releaseNotesDirectory, file), "utf8");
       const title = source.match(/^title:\s*"?(?<title>.+?)"?$/mu)?.groups.title;
+      const kind = source.match(/^kind:\s*(?<kind>main|extension)$/mu)?.groups.kind;
+      const releasedAt = source.match(/^released_at:\s*(?<date>\d{4}-\d{2}-\d{2})$/mu)
+        ?.groups.date;
       assert.ok(title, `release note has no title: ${file}`);
-      return { title, version: file.replace(/\.md$/u, "") };
+      assert.ok(kind, `release note has no kind: ${file}`);
+      assert.ok(releasedAt, `release note has no released_at: ${file}`);
+      return {
+        kind,
+        released_at: new Date(`${releasedAt}T00:00:00.000Z`),
+        title,
+        version: file.replace(/\.md$/u, ""),
+      };
     })
   );
 };

--- a/tests/repo/test_release_notes_content.py
+++ b/tests/repo/test_release_notes_content.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import date
+from itertools import pairwise
 from pathlib import Path
 
 import pytest
@@ -11,56 +12,7 @@ from tests.helpers.paths import REPO_ROOT
 
 ROOT = REPO_ROOT
 NOTES_DIR = ROOT / "docs" / "release-notes"
-EXPECTED_NOTES = {
-    "v5.5.17.md": (
-        "v5.5.17",
-        date(2026, 7, 10),
-        "main",
-        "youtube-automation v5.5.17",
-        -2026071002,
-        "/automation --update",
-    ),
-    "v5.6.0.md": (
-        "v5.6.0",
-        date(2026, 7, 31),
-        "main",
-        "youtube-automation v5.6.0",
-        -2026073102,
-        "/automation --update",
-    ),
-    "v5.7.0.md": (
-        "v5.7.0",
-        date(2026, 8, 29),
-        "main",
-        "youtube-automation v5.7.0",
-        -2026082902,
-        "/automation --update",
-    ),
-    "v5.7.1.md": (
-        "v5.7.1",
-        date(2026, 9, 2),
-        "main",
-        "youtube-automation v5.7.1",
-        -2026090202,
-        "/automation --update",
-    ),
-    "ext-v0.2.5.md": (
-        "ext-v0.2.5",
-        date(2026, 7, 10),
-        "extension",
-        "Chrome 拡張 ext-v0.2.5",
-        -2026071001,
-        "/ext-install",
-    ),
-    "ext-v0.3.0.md": (
-        "ext-v0.3.0",
-        date(2026, 7, 31),
-        "extension",
-        "Chrome 拡張 ext-v0.3.0",
-        -2026073101,
-        "/ext-install",
-    ),
-}
+NOTE_PATHS = tuple(sorted(NOTES_DIR.glob("*.md")))
 REQUIRED_HEADINGS = (
     "## 30 秒サマリー",
     "## アップデート方法",
@@ -91,34 +43,64 @@ def test_release_notes_define_the_public_content_contract() -> None:
     assert "`extension`" in contract
 
 
-def test_release_notes_have_the_expected_initial_entries() -> None:
-    assert {path.name for path in NOTES_DIR.glob("*.md")} == set(EXPECTED_NOTES)
+def test_release_notes_directory_is_non_empty_and_uses_release_tag_filenames() -> None:
+    assert NOTE_PATHS
+    for path in NOTE_PATHS:
+        assert re.fullmatch(r"(?:ext-)?v\d+\.\d+\.\d+", path.stem), path
 
 
-@pytest.mark.parametrize("filename", EXPECTED_NOTES)
-def test_release_note_matches_frontmatter_and_body_contract(filename: str) -> None:
-    expected_version, expected_date, expected_kind, expected_title, expected_order, command = EXPECTED_NOTES[filename]
-    metadata, body = _read_note(NOTES_DIR / filename)
+@pytest.mark.parametrize("path", NOTE_PATHS, ids=lambda path: path.name)
+def test_release_note_matches_frontmatter_and_body_contract(path: Path) -> None:
+    _assert_frontmatter_and_body_contract(path)
+
+
+def _assert_frontmatter_and_body_contract(path: Path) -> None:
+    metadata, body = _read_note(path)
 
     assert set(metadata) == {"title", "version", "released_at", "kind", "summary", "sidebar"}
-    assert metadata["title"] == expected_title
-    assert metadata["version"] == expected_version
-    assert metadata["released_at"] == expected_date
-    assert metadata["kind"] == expected_kind
+    assert isinstance(metadata["title"], str) and metadata["title"].strip()
+    assert metadata["version"] == path.stem
+    assert isinstance(metadata["released_at"], date)
+    assert metadata["kind"] in {"main", "extension"}
     assert isinstance(metadata["summary"], str) and metadata["summary"].strip()
-    assert metadata["sidebar"] == {"order": expected_order}
-    assert Path(filename).stem == expected_version
+    assert isinstance(metadata["sidebar"], dict)
+    assert set(metadata["sidebar"]) == {"order"}
+    assert isinstance(metadata["sidebar"]["order"], int)
+    assert metadata["sidebar"]["order"] < 0
     assert not body.lstrip().startswith("# "), "ページタイトルは Blume に一度だけ描画させる"
+    command = "/automation --update" if metadata["kind"] == "main" else "/ext-install"
     assert f"```text\n{command}\n```" in body
 
     for heading in REQUIRED_HEADINGS:
         assert heading in body
-    assert f"https://github.com/daiki-beppu/youtube-automation/releases/tag/{expected_version}" in body
+    assert f"https://github.com/daiki-beppu/youtube-automation/releases/tag/{path.stem}" in body
 
 
-@pytest.mark.parametrize("filename", EXPECTED_NOTES)
-def test_release_note_uses_public_web_markdown(filename: str) -> None:
-    _, body = _read_note(NOTES_DIR / filename)
+def _assert_sidebar_order(paths: tuple[Path, ...]) -> None:
+    metadatas = [_read_note(path)[0] for path in paths]
+    contract_order = sorted(
+        metadatas,
+        key=lambda metadata: (
+            -metadata["released_at"].toordinal(),
+            0 if metadata["kind"] == "main" else 1,
+        ),
+    )
+    sidebar_orders = [metadata["sidebar"]["order"] for metadata in contract_order]
+
+    assert all(left < right for left, right in pairwise(sidebar_orders))
+
+
+def test_release_note_sidebar_order_follows_the_public_contract() -> None:
+    _assert_sidebar_order(NOTE_PATHS)
+
+
+@pytest.mark.parametrize("path", NOTE_PATHS, ids=lambda path: path.name)
+def test_release_note_uses_public_web_markdown(path: Path) -> None:
+    _assert_public_web_markdown(path)
+
+
+def _assert_public_web_markdown(path: Path) -> None:
+    _, body = _read_note(path)
 
     assert not {"■", "★", "・"}.intersection(body)
     assert body.count("```text") == 1
@@ -126,3 +108,122 @@ def test_release_note_uses_public_web_markdown(filename: str) -> None:
     assert not re.search(r"(?<!\w)#\d+", body), "issue・PR 番号を本文へ出さない"
     assert "/pull/" not in body
     assert "libecity.com" not in body
+
+
+def _write_fixture_note(
+    path: Path,
+    *,
+    body: str = "",
+    order: int = -1,
+    released_at: str = "2026-09-01",
+    kind: str = "main",
+    version: str | None = None,
+) -> Path:
+    """契約を満たす fixture ノートを書き出す。違反は引数で 1 項目だけ差し替える。"""
+    path.write_text(
+        "\n".join(
+            (
+                "---",
+                'title: "Fixture"',
+                f"version: {version if version is not None else path.stem}",
+                f"released_at: {released_at}",
+                f"kind: {kind}",
+                'summary: "Fixture"',
+                "sidebar:",
+                f"  order: {order}",
+                "---",
+                body,
+            )
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _fixture_body(version: str, *, kind: str = "main", omit_heading: str | None = None) -> str:
+    command = "/automation --update" if kind == "main" else "/ext-install"
+    sections: list[str] = []
+    for heading in REQUIRED_HEADINGS:
+        if heading == omit_heading:
+            continue
+        sections.append(heading)
+        sections.append(f"```text\n{command}\n```" if heading == "## アップデート方法" else "本文")
+    sections.append(f"https://github.com/daiki-beppu/youtube-automation/releases/tag/{version}")
+    return "\n\n".join(sections) + "\n"
+
+
+def test_release_note_fixture_baseline_satisfies_the_contract(tmp_path: Path) -> None:
+    """違反 fixture の対照群。ここが緑でないと「1 項目の違反で落ちた」と言えない。"""
+    baseline = _write_fixture_note(tmp_path / "v1.0.0.md", body=_fixture_body("v1.0.0"))
+
+    _assert_frontmatter_and_body_contract(baseline)
+    _assert_public_web_markdown(baseline)
+
+    extension = _write_fixture_note(
+        tmp_path / "ext-v1.0.0.md",
+        body=_fixture_body("ext-v1.0.0", kind="extension"),
+        kind="extension",
+    )
+    _assert_frontmatter_and_body_contract(extension)
+    _assert_public_web_markdown(extension)
+
+
+def test_release_note_contract_rejects_version_mismatch(tmp_path: Path) -> None:
+    note = _write_fixture_note(tmp_path / "v1.0.0.md", body=_fixture_body("v1.0.0"), version="v1.0.1")
+
+    with pytest.raises(AssertionError):
+        _assert_frontmatter_and_body_contract(note)
+
+
+def test_release_note_contract_rejects_non_date_released_at(tmp_path: Path) -> None:
+    note = _write_fixture_note(tmp_path / "v1.0.0.md", body=_fixture_body("v1.0.0"), released_at='"invalid"')
+
+    with pytest.raises(AssertionError):
+        _assert_frontmatter_and_body_contract(note)
+
+
+def test_release_note_contract_rejects_missing_heading(tmp_path: Path) -> None:
+    note = _write_fixture_note(tmp_path / "v1.0.0.md", body=_fixture_body("v1.0.0", omit_heading="## 改善"))
+
+    with pytest.raises(AssertionError):
+        _assert_frontmatter_and_body_contract(note)
+
+
+def test_release_note_contract_rejects_internal_notation(tmp_path: Path) -> None:
+    note = _write_fixture_note(tmp_path / "v1.0.0.md", body=_fixture_body("v1.0.0") + "\n・内部表記\n")
+
+    with pytest.raises(AssertionError):
+        _assert_public_web_markdown(note)
+
+
+def test_release_note_sidebar_order_accepts_contract_conforming_fixtures(tmp_path: Path) -> None:
+    newer = _write_fixture_note(tmp_path / "v1.1.0.md", released_at="2026-09-02", order=-3)
+    same_day_main = _write_fixture_note(tmp_path / "v1.0.0.md", released_at="2026-09-01", order=-2)
+    same_day_extension = _write_fixture_note(
+        tmp_path / "ext-v1.0.0.md", released_at="2026-09-01", kind="extension", order=-1
+    )
+
+    _assert_sidebar_order((same_day_extension, newer, same_day_main))
+
+
+def test_release_note_contract_rejects_reversed_released_at_order(tmp_path: Path) -> None:
+    """公開日が新しいノートに大きい order を与えると落ちる（日付方向の逆転）。"""
+    newer = _write_fixture_note(tmp_path / "v1.1.0.md", released_at="2026-09-02", order=-1)
+    older = _write_fixture_note(tmp_path / "v1.0.0.md", released_at="2026-09-01", order=-2)
+
+    # 日付キーを落とした退行では入力順のまま昇順になり、この raises が失敗して退行を検出する
+    with pytest.raises(AssertionError):
+        _assert_sidebar_order((older, newer))
+
+
+def test_release_note_contract_rejects_reversed_same_day_kind_order(tmp_path: Path) -> None:
+    """同じ公開日で拡張が本体より小さい order を持つと落ちる（kind タイブレークの逆転）。"""
+    newer = _write_fixture_note(tmp_path / "v1.1.0.md", released_at="2026-09-02", order=-3)
+    same_day_main = _write_fixture_note(tmp_path / "v1.0.0.md", released_at="2026-09-01", order=-1)
+    same_day_extension = _write_fixture_note(
+        tmp_path / "ext-v1.0.0.md", released_at="2026-09-01", kind="extension", order=-2
+    )
+
+    # kind キーを落とした退行では入力順のまま昇順になり、この raises が失敗して退行を検出する
+    with pytest.raises(AssertionError):
+        _assert_sidebar_order((newer, same_day_extension, same_day_main))


### PR DESCRIPTION
## Summary
- site の top page 描画期待値を `docs/release-notes/` の frontmatter から導出
- Python の content contract を実ファイル走査と順序関係の検証へ変更
- 契約違反 fixture とリリースノート追加時の回帰を検証

Closes #4834