### PR TITLE
docs: 立ち上げ・メンテスキルの解説を追加 (#4796)

### DIFF
--- a/changelog.d/4796-setup-maintenance-skill-docs.added.md
+++ b/changelog.d/4796-setup-maintenance-skill-docs.added.md
@@ -1,0 +1,1 @@
+- setup・extension・automation・skill-feedback のサイト向け手書き解説を追加

--- a/site/skill-docs/automation.md
+++ b/site/skill-docs/automation.md
@@ -2,7 +2,7 @@
 
 下流のチャンネルリポジトリを youtube-automation の最新 release へ追従させたり、導入中の version に即してツールキットの使い方を調べたりするスキルです。更新は差分確認と人間の承認を挟む wizard、質問はローカル資料を優先する読み取り専用処理として分離されています。upstream 本体ではなく、automation package を依存に持つ下流リポジトリで使います。
 
-| mode | すること | 主な結果 |
+| mode | すること | 主な成果物 |
 |---|---|---|
 | `--update` | package、lock、skill を最新 release へ追従 | 更新済みファイルとローカル commit |
 | `--question` | 仕様、skill、CLI の質問に根拠つきで回答 | version と参照元を示した回答 |

--- a/site/skill-docs/automation.md
+++ b/site/skill-docs/automation.md
@@ -1,0 +1,33 @@
+## 何ができるか
+
+下流のチャンネルリポジトリを youtube-automation の最新 release へ追従させたり、導入中の version に即してツールキットの使い方を調べたりするスキルです。更新は差分確認と人間の承認を挟む wizard、質問はローカル資料を優先する読み取り専用処理として分離されています。upstream 本体ではなく、automation package を依存に持つ下流リポジトリで使います。
+
+| mode | すること | 主な結果 |
+|---|---|---|
+| `--update` | package、lock、skill を最新 release へ追従 | 更新済みファイルとローカル commit |
+| `--question` | 仕様、skill、CLI の質問に根拠つきで回答 | version と参照元を示した回答 |
+
+## 最新 release へ追従したいとき
+
+```
+/automation --update
+```
+
+現在の依存と local fix を調べ、更新 plan の確認後に package と配布 skill を同期し、機械チェックと commit まで進めます。手書き skill の上書き、sha pin の更新先決定、`--force-sync` や `--prune` による破壊的変更は、人間が明示的に同意するまで実行しません。push は利用者が行います。
+
+## ツールキットについて質問したいとき
+
+```
+/automation --question "thumbnail の入力は何ですか？"
+/automation yt-automation-update の使い方を教えて
+```
+
+明示的な `--question` の後ろ、または mode flag のない自然文を質問として扱います。導入済みの skill、ドキュメント、CHANGELOG の順に根拠を探し、必要な場合だけ GitHub を参照します。この mode はファイル、git、upstream を変更しません。
+
+## つまずいたら
+
+- **mode 未指定で止まる** — 引数が空だと処理を選べません。更新なら `/automation --update`、質問なら質問文を添えて実行してください
+- **`--question` が空だと言われる** — flag の後ろに具体的な質問を記述してください
+- **実行場所が違うと言われる** — youtube-automation upstream では実行できません。`youtube-channels-automation` を依存に持つ下流チャンネルリポジトリへ移動してください
+- **更新が承認待ちで止まる** — local fix の破棄や旧 skill の削除など、取り消しにくい変更の確認です。差分を読み、実行するかを明示してください
+- **質問の答えが見つからない** — `/skill-feedback` で不足している仕様や資料を記録してください

--- a/site/skill-docs/extension.md
+++ b/site/skill-docs/extension.md
@@ -1,0 +1,61 @@
+## 何ができるか
+
+automation と一緒に使う Chrome 拡張の導入・更新と、拡張が collection を読むためのローカル server を管理するスキルです。suno-helper、distrokid-helper、community-helper の 3 種を扱い、対象だけを modifier で絞れます。フラグなしでは各拡張の状態を調べ、未導入なら install、旧版なら update、最新版なら skip します。
+
+| mode | すること | 主な結果 |
+|---|---|---|
+| `--install` | GitHub Release から拡張を新規導入 | `~/chrome-extensions/<name>/` |
+| `--update` | 導入済み拡張を最新 release に置換 | release と一致した manifest version |
+| `--serve` | 対象拡張用 collection server を起動・確認 | ローカル server URL |
+| `--stop` | 対象拡張用 server を停止 | 対象 process の停止確認 |
+
+対象は `--suno`、`--distrokid`、`--community` で絞ります。install / update / フラグなしでは複数選択でき、省略時は 3 拡張すべてが対象です。serve / stop では対象をちょうど 1 つ指定します。
+
+## 必要な拡張を自動で揃えたいとき
+
+```
+/extension
+/extension --suno --community
+```
+
+対象の導入状況と version を release と比較し、必要な install / update だけを実行します。Chrome の Load unpacked や reload は自動操作せず、最後に利用者が操作するディレクトリと手順を案内します。
+
+## 拡張を新規導入したいとき
+
+```
+/extension --install
+/extension --install --distrokid
+```
+
+release を取得して専用ディレクトリへ展開し、manifest を確認します。前者は全拡張、後者は distrokid-helper だけを対象にします。
+
+## 導入済み拡張を更新したいとき
+
+```
+/extension --update --suno
+```
+
+suno-helper を最新 release へ置換し、manifest version の一致を確認します。完了後は Chrome 側で拡張を reload してください。
+
+## collection server を起動したいとき
+
+```
+/extension --serve --distrokid
+```
+
+distrokid-helper 用 server の既存 process を再利用するか、新規起動して疎通を確認します。server ごとに引数や port が異なるため、`--serve` では対象 modifier を 1 つだけ指定します。
+
+## collection server を止めたいとき
+
+```
+/extension --stop --community
+```
+
+community-helper 用の対象 port を特定して server を停止し、process が残っていないことまで確認します。
+
+## つまずいたら
+
+- **release を取得できず止まる** — `gh` CLI の認証と `ext-v*` release を確認してください。利用できない場合は案内された release page から手動で取得します
+- **`--serve` で対象を求められる** — `--suno`、`--distrokid`、`--community` のうち 1 つを指定してください
+- **複数の mode を指定して止まる** — `--install` / `--update` / `--serve` / `--stop` は 1 回に 1 つだけ指定します
+- **導入後も Chrome に反映されない** — 新規導入は Load unpacked、更新は拡張管理画面で reload が必要です。表示されたディレクトリを Chrome で操作してください

--- a/site/skill-docs/extension.md
+++ b/site/skill-docs/extension.md
@@ -2,7 +2,7 @@
 
 automation と一緒に使う Chrome 拡張の導入・更新と、拡張が collection を読むためのローカル server を管理するスキルです。suno-helper、distrokid-helper、community-helper の 3 種を扱い、対象だけを modifier で絞れます。フラグなしでは各拡張の状態を調べ、未導入なら install、旧版なら update、最新版なら skip します。
 
-| mode | すること | 主な結果 |
+| mode | すること | 主な成果物 |
 |---|---|---|
 | `--install` | GitHub Release から拡張を新規導入 | `~/chrome-extensions/<name>/` |
 | `--update` | 導入済み拡張を最新 release に置換 | release と一致した manifest version |

--- a/site/skill-docs/setup.md
+++ b/site/skill-docs/setup.md
@@ -1,0 +1,66 @@
+## 何ができるか
+
+automation を使い始めるためのツール環境とチャンネル設定を整えるスキルです。初回の GCP / OAuth 設定、新規 YouTube チャンネルの開設、既存チャンネルの取り込み、設定ファイルの再生成、YouTube 側への設定同期をそれぞれ独立して実行できます。フラグなしでは tool → channel を状態判定つきで進め、完了済みの工程は再実行しません。
+
+| mode | すること | 主な成果物 |
+|---|---|---|
+| `--tool` | uv、GCP、OAuth、ADC などの利用環境を診断・設定 | `auth/client_secrets.json` / `auth/token.json` ほか |
+| `--channel` | 新規チャンネルを聞き取りから初期設定まで立ち上げ | `config/channel/*.json` / `docs/channel/*.md` |
+| `--import` | 既存 YouTube チャンネルをローカルへ取り込み | チャンネル config / localization |
+| `--regenerate` | 現在の情報から config を再生成 | `config/channel/*.json` |
+| `--push` | ローカル設定を確認後に YouTube へ同期 | branding / localization などの YouTube 設定 |
+
+## 初回セットアップをまとめて進めたいとき
+
+```
+/setup
+```
+
+ツール環境を確認してから新規チャンネルの設定へ進みます。途中で止まっても、再実行時は成果物を判定して未完了の工程から再開します。OAuth や外部反映などの不可逆操作は、工程内の承認を得るまで実行しません。
+
+## ツール環境だけ整えたいとき
+
+```
+/setup --tool
+```
+
+doctor wizard を使い、ディレクトリ、依存、GCP API、OAuth、ADC を準備します。この mode はチャンネル config を作らないため、環境構築後にチャンネルを作る場合は `--channel` を別に実行します。
+
+## 新規チャンネルを開設したいとき
+
+```
+/setup --channel
+```
+
+チャンネルの狙いと制作条件を聞き取り、config、動画尺、persona、branding、readiness を順番に整えます。外部へ反映する直前には承認が入り、失敗時は後続工程へ進みません。
+
+## 既存チャンネルを取り込みたいとき
+
+```
+/setup --import
+```
+
+YouTube 上ですでに運用しているチャンネルを読み込み、automation が扱えるローカル設定とドキュメントへ変換します。新規開設ではなく、既存資産から開始するときの入口です。
+
+## config を作り直したいとき
+
+```
+/setup --regenerate
+```
+
+現在のチャンネル情報をもとに分割 config を再生成します。通常のセットアップ全体は進めず、再生成工程だけを実行します。
+
+## ローカル設定を YouTube に反映したいとき
+
+```
+/setup --push
+```
+
+まず dry-run で変更内容を提示し、承認後に branding や localization などを同期して反映結果を確認します。ローカルとの差分確認なしに書き込むことはありません。
+
+## つまずいたら
+
+- **複数の mode を指定して止まる** — `--tool` などの mode は排他的です。目的に合うものを 1 つだけ指定してください
+- **フラグなし実行が channel の前で止まる** — tool の prerequisite または doctor が未完了です。表示された理由を解消して同じ `/setup` を再実行してください
+- **OAuth 接続で止まる** — Google Auth Platform の Branding / Audience / Clients と `client_secrets.json` を確認し、`/setup --tool` から再開してください
+- **YouTube への反映前で止まる** — 外部変更の承認待ちです。dry-run の差分を確認し、反映するかを明示してください

--- a/site/skill-docs/skill-feedback.md
+++ b/site/skill-docs/skill-feedback.md
@@ -1,0 +1,49 @@
+## 何ができるか
+
+下流チャンネルで skill を使ったときの不具合、摩擦、改善案を JSONL に残し、確認済みの項目を youtube-automation の GitHub issue へ還流するスキルです。記録は既存行を変えない append-only、還流は候補選択・重複確認・最終承認を経て 1 件ずつ進みます。YouTube Analytics から得た運営上の学びは対象外で、`--analyze` を指定した意図は `/analytics` へ委譲します。
+
+| mode | すること | 主な成果物 |
+|---|---|---|
+| 記録 | 直近の skill 利用で生じた feedback を 1 行追加 | `data/feedback/feedback-log.jsonl` |
+| 還流 | `recorded` entry を承認後に上流 issue 化 | GitHub issue URL と `filed` 状態 |
+| disposition | 解決済み・意図的な見送りを確認後に記録 | `resolved` / `wontfix` と理由・日時 |
+
+## skill の摩擦を記録したいとき
+
+```
+/skill-feedback さっきの thumbnail 生成で構図を直しにくかったので記録して
+```
+
+直近の文脈から対象 skill、`bug` / `friction` / `idea` の category、要約、再現状況を確定し、schema に準拠した JSON object を末尾へ 1 行だけ追加します。token、secret、password などは `***REDACTED***` に置換し、既存 entry は変更しません。対象 skill を特定できない場合は確認して停止します。
+
+## 記録済み feedback を上流へ還流したいとき
+
+```
+/skill-feedback 今週の feedback を上流に還流して
+```
+
+schema-valid かつ `recorded` の entry だけを候補として表示し、起票候補、解決済み、意図的に見送り、今回は保留から扱いを選びます。起票候補は本文案と open issue の類似候補を確認し、外部反映の最終承認後にだけ `feedback` label 付き issue を作成します。成功した行だけを `filed` に更新し、失敗時は後続を起票しません。
+
+## 解決済み・見送りを記録したいとき
+
+```
+/skill-feedback feedback を整理して、解決済みの項目を更新したい
+```
+
+対象行と disposition、空でない理由を利用者が確認した場合だけ `resolved` または `wontfix` にします。更新日時も記録し、未選択行、invalid 行、すでに終端状態の行は byte-for-byte で保ちます。
+
+## 運営上の学びを分析したいとき
+
+```
+/skill-feedback --analyze
+```
+
+skill 自体の不具合や摩擦ではなく、再生結果から得た学びは feedback log に記録しません。`/analytics --analyze` または伸びなかった動画向けの `/analytics --flop` を案内します。
+
+## つまずいたら
+
+- **記録する skill を特定できない** — 対象 skill 名と、期待したこと・実際に起きたことを添えて再実行してください
+- **invalid 行の警告が出る** — 行番号と schema の失敗箇所を確認してください。その行は変更せず除外され、valid な候補の処理は続きます
+- **還流候補が 0 件になる** — `filed` / `resolved` / `wontfix` は終端状態です。未還流の `recorded` entry があるか確認してください
+- **類似 issue の確認で止まる** — 重複候補を読み、新規起票するか今回スキップするかを明示してください
+- **起票直前で止まる** — GitHub への外部反映は取り消せません。件数とタイトルを確認し、「起票する」を明示した場合だけ続行します


### PR DESCRIPTION
立ち上げ・メンテ 4 スキルの手書き解説を追加します。

Closes #4796