### PR TITLE
feat: 動画解析にagentic処理モードを追加 (#4816)

### DIFF
--- a/.claude/skills/audit/config.default.yaml
+++ b/.claude/skills/audit/config.default.yaml
@@ -7,6 +7,10 @@ video:
   # Gemini モデル名 (動画入力対応モデルを指定)
   model: gemini-3.5-flash
 
+  # static は冒頭クリップ窓、agentic はモデル主導で全尺を探索する。
+  # agentic は Gemini 3.7 Flash / 3.6 Flash / 3.5 Flash-Lite のみ対応。
+  processing: static
+
   # API レート制限対策の動画間ウェイト (秒)
   delay_sec: 10
 
@@ -26,10 +30,7 @@ video:
   # `suno_preset` は SunoAI プロンプト生成 (`/music --prompt`) の初期推奨値として
   # `yt-generate-suno` が config/skills/music.yaml::prompt 空欄時の fallback で参照する。
   prompt: |
-    Analyze the opening clip window of this YouTube video as a music channel content audit.
-    Only the beginning of the video is provided as a fixed-length clip window — scope ALL
-    observations, timestamps, and averages to this clip window. Never emit timestamps
-    beyond the end of the provided clip, and do not speculate about the rest of the video.
+    Analyze this YouTube video as a music channel content audit, following the analysis scope above.
     Return ONLY valid JSON (no markdown, no code fences) with this exact shape:
     {
       "hook_structure": {
@@ -40,9 +41,9 @@ video:
       },
       "bgm_arc": {
         "intro": "timestamp range (e.g. 0:00-0:15)",
-        "peak": "timestamp of the highest-energy moment within the clip window",
-        "outro": "timestamp range of the final section within the clip window",
-        "energy_curve": "brief description of dynamics within the clip window",
+        "peak": "timestamp of the highest-energy moment within the analysis scope",
+        "outro": "timestamp range of the final section within the analysis scope",
+        "energy_curve": "brief description of dynamics within the analysis scope",
         "segments": [
           {
             "start": "M:SS",
@@ -53,16 +54,16 @@ video:
         ]
       },
       "scene_timeline": [
-        {"start": "0:00", "summary": "one-line description of what changes (clip window only)"}
+        {"start": "0:00", "summary": "one-line description of what changes (analysis scope only)"}
       ],
       "thumbnail_alignment": {
         "signature_present": <bool>,
         "color_palette_match": <bool>,
-        "notes": "what was promised by thumbnail vs delivered in the clip window"
+        "notes": "what was promised by thumbnail vs delivered in the analysis scope"
       },
       "editing_metrics": {
-        "avg_cut_sec": <number, averaged over the clip window>,
-        "text_per_min": <number, averaged over the clip window>,
+        "avg_cut_sec": <number, averaged over the analysis scope>,
+        "text_per_min": <number, averaged over the analysis scope>,
         "transition_style": "brief description"
       },
       "suno_preset": {

--- a/.claude/skills/audit/references/video.md
+++ b/.claude/skills/audit/references/video.md
@@ -14,7 +14,8 @@
 ## Overview
 
 `yt-video-analyze` で YouTube 動画を Gemini に直接渡し、以下の構造化データを抽出する。
-解析対象は全尺ではなく **動画冒頭のクリップ窓**（既定 30 秒、`analysis_window_sec` で変更可）のみ:
+既定の `static` は **動画冒頭のクリップ窓**（既定 30 秒、`analysis_window_sec` で変更可）のみを解析する。
+`agentic` は対応モデルが必要だが、モデル主導で全尺を探索して構成データを取得できる:
 
 - `hook_structure` — 0-30 秒のカット割り・テキスト出現タイミング・signature 要素
 - `bgm_arc` — イントロ尺・ピーク位置・クリップ窓内終盤のタイムスタンプ（窓内スコープ）
@@ -49,7 +50,7 @@ Step 1 のスクリプトが exit 0 で終了して `data/video_analysis/<slug>/
 
 | API | call 数 / 実行 | 変動要因 |
 |---|---|---|
-| Vertex AI Gemini（yt-video-analyze の generate_content） | 未解析の対象動画数 × 1 call（`--source benchmark`: `--top` 既定 5 / `own`: complete_collection + videos[] の合計 / `url`: 1。既存の有効な `<video_id>.json` がある動画は 0 call） | `--source` / `--top` / 対象動画数 / `--force`（キャッシュ無視で全件再解析）。1 call あたりのコストは `analysis_window_sec`（既定 30 秒）に比例。`delay_sec` は間隔制御のみで課金には無影響 |
+| Vertex AI Gemini（yt-video-analyze の generate_content） | 未解析の対象動画数 × 1 call（`--source benchmark`: `--top` 既定 5 / `own`: complete_collection + videos[] の合計 / `url`: 1。既存の有効な `<video_id>.json` がある動画は 0 call） | `--source` / `--top` / 対象動画数 / `--force`（キャッシュ無視で全件再解析）。`static` の 1 call あたりのコストは `analysis_window_sec`（既定 30 秒）に比例。`agentic` は全尺から必要な区間をモデルが探索する。`delay_sec` は間隔制御のみで課金には無影響 |
 
 - 上限 / 承認: y/N プロンプトはない。`--source` と `--top` で対象数を絞り、`analysis_window_sec` で 1 call あたりの解析コストを制御する。
 
@@ -121,6 +122,7 @@ skill-config (`.claude/skills/audit/config.default.yaml::video`):
 | 項目 | 既定 | 説明 |
 |---|---|---|
 | `model` | `gemini-3.5-flash` | Vertex AI global endpoint の動画入力対応 GA Gemini モデル |
+| `processing` | `static` | `static`（冒頭クリップ窓）または `agentic`（全尺をモデル主導で探索）。`agentic` は `gemini-3.7-flash` / `gemini-3.6-flash` / `gemini-3.5-flash-lite` のみ対応 |
 | `delay_sec` | 10 | 動画間の API レート対策ウェイト (秒) |
 | `analysis_window_sec` | 30 | 解析するクリップ窓 (秒)。動画冒頭からこの秒数のみ Gemini に渡す。bool ではない正の整数のみ有効 |
 | `prompt` | 汎用プロンプト | ジャンル/世界観に合わせて `config/skills/audit.yaml::video` で上書き推奨 |
@@ -128,10 +130,10 @@ skill-config (`.claude/skills/audit/config.default.yaml::video`):
 ## 注意事項
 
 - Gemini API には YouTube URL を直接渡す (動画ダウンロードしない)
-- **全尺は解析しない**: `video_metadata` の offset 指定で動画冒頭 `analysis_window_sec` 秒
-  （既定 30 秒、冒頭のフック相当）のみを解析する。Gemini の動画入力コストは再生尺に
-  比例するため、長尺 BGM 動画の全尺解析を避ける。窓幅は `config/skills/audit.yaml::video` の
-  `analysis_window_sec` で上書きできる（deep-merge、曲数が多い・イントロが長いチャンネル向け）
+- **`static`（既定）**: `video_metadata` の offset 指定で動画冒頭 `analysis_window_sec` 秒
+  （既定 30 秒、冒頭のフック相当）のみを解析する。窓幅は `config/skills/audit.yaml::video` で上書きできる。
+- **`agentic`**: offset を渡さず、対応 Gemini モデルへ全尺の探索を委ねる。`analysis_window_sec` は
+  使用されず、結果 JSON では `null` になる。長尺の構成データが必要な場合にのみ選ぶ。
 - Public/Unlisted のみ対応 (Private 動画は API 側で拒否される)
 - Shorts は Gemini の 1fps サンプリング制約により短尺フック構造の解析精度が落ちる。`/short` で生成・投稿した自チャンネル Shorts は本 skill の対象外として扱い、リテンション / CTR 分析は `/analytics --analyze` に任せる
 - API レート制限対策で動画間に `delay_sec` 秒スリープ
@@ -142,7 +144,7 @@ skill-config (`.claude/skills/audit/config.default.yaml::video`):
 `scene_timeline` / `thumbnail_alignment` / `editing_metrics` を入力として参照する。
 `/audit --video` が未実行のときは警告で続行するが、ベンチマークデータがあれば自動実行を提案する。
 
-**注意**: これらのデータは動画冒頭のクリップ窓（既定 30 秒）のみの分析結果。
+**注意**: `static` のデータは動画冒頭のクリップ窓（既定 30 秒）のみの分析結果。
 `bgm_arc.outro` は「動画全体のアウトロ」ではなく「窓内終盤」を指すため、下流での平均計算や
 起伏配置の設計に使う際は「設定したクリップ窓内のデータ」である前提で扱うこと。
 

--- a/.claude/skills/audit/references/video.md
+++ b/.claude/skills/audit/references/video.md
@@ -17,12 +17,14 @@
 既定の `static` は **動画冒頭のクリップ窓**（既定 30 秒、`analysis_window_sec` で変更可）のみを解析する。
 `agentic` は対応モデルが必要だが、モデル主導で全尺を探索して構成データを取得できる:
 
-- `hook_structure` — 0-30 秒のカット割り・テキスト出現タイミング・signature 要素
-- `bgm_arc` — イントロ尺・ピーク位置・クリップ窓内終盤のタイムスタンプ（窓内スコープ）
+以下の括弧内スコープは既定 `static`（クリップ窓内）の場合の説明で、`agentic` では対象がいずれも全尺になる。
+
+- `hook_structure` — 冒頭のカット割り・テキスト出現タイミング・signature 要素（static: 窓内 / agentic: 全尺の冒頭）
+- `bgm_arc` — イントロ尺・ピーク位置・終盤のタイムスタンプ（static: 窓内スコープ / agentic: 全尺スコープ）
   - `segments[]` — 曲 / BGM 区間の `start` / `end` / `track` / `description`。曲名が映像・説明から確認できない場合は `track N` とし、推測した固有名を付けない
-- `scene_timeline` — シーン境界 + 一言要約（窓内のみ）
-- `thumbnail_alignment` — サムネで提示した要素が本編（窓内）に映っているかの整合性
-- `editing_metrics` — 平均カット長・テキスト出現頻度（窓内平均）
+- `scene_timeline` — シーン境界 + 一言要約（static: 窓内のみ / agentic: 全尺）
+- `thumbnail_alignment` — サムネで提示した要素が本編に映っているかの整合性（static: 窓内 / agentic: 全尺）
+- `editing_metrics` — 平均カット長・テキスト出現頻度（static: 窓内平均 / agentic: 全尺平均）
 
 既存スキルが扱えていなかった「動画の中身」というドメインを埋め、`/channel-research --benchmark`・`/analytics --analyze`・`/audit --alignment`・`/thumbnail --compare`・`/channel-research --voice` の精度を底上げする。
 

--- a/changelog.d/4816-video-analysis-agentic-processing.added.md
+++ b/changelog.d/4816-video-analysis-agentic-processing.added.md
@@ -1,0 +1,1 @@
+- 動画解析に、全尺をモデル主導で探索する Gemini agentic processing モードを追加しました。

--- a/src/youtube_automation/commands/analytics/video_analyze.py
+++ b/src/youtube_automation/commands/analytics/video_analyze.py
@@ -53,12 +53,19 @@ PROCESSING_AGENTIC = "agentic"
 _PROCESSING_CHOICES = frozenset((PROCESSING_STATIC, PROCESSING_AGENTIC))
 _AGENTIC_MODELS = frozenset(("gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash-lite"))
 
-_STATIC_SCOPE_PROMPT = """Analyze only the fixed-length opening clip provided. Scope all observations,
-timestamps, and averages to this clip window. Never emit timestamps beyond the clip or speculate
-about the rest of the video."""
-_AGENTIC_SCOPE_PROMPT = """Use agentic video processing to inspect the full video timeline. Scope all
-observations, timestamps, and averages to the complete video, exploring the sections needed to support
-the analysis."""
+_SCOPE_PROMPT_TEMPLATE = """{action}. Scope all observations, timestamps, and averages to {scope}. {boundary}"""
+_SCOPE_PROMPT_BY_PROCESSING = {
+    PROCESSING_STATIC: _SCOPE_PROMPT_TEMPLATE.format(
+        action="Analyze only the fixed-length opening clip provided",
+        scope="this clip window",
+        boundary="Never emit timestamps beyond the clip or speculate about the rest of the video.",
+    ),
+    PROCESSING_AGENTIC: _SCOPE_PROMPT_TEMPLATE.format(
+        action="Use agentic video processing to inspect the full video timeline",
+        scope="the complete video",
+        boundary="Explore the sections needed to support the analysis.",
+    ),
+}
 
 # 任意 URL 経路では slug を一意に持てないため固定名で保存する
 URL_SOURCE_SLUG = "url"
@@ -311,7 +318,7 @@ def _processing_from_config(cfg: dict) -> str:
 
 def _prompt_for_processing(prompt: str, processing: str) -> str:
     """ユーザー prompt に実際の解析スコープを明示する。"""
-    scope = _AGENTIC_SCOPE_PROMPT if processing == PROCESSING_AGENTIC else _STATIC_SCOPE_PROMPT
+    scope = _SCOPE_PROMPT_BY_PROCESSING[processing]
     return f"{scope}\n\n{prompt}"
 
 

--- a/src/youtube_automation/commands/analytics/video_analyze.py
+++ b/src/youtube_automation/commands/analytics/video_analyze.py
@@ -48,6 +48,17 @@ SKILL_CONFIG_KEY = "audit.video"
 SOURCE_BENCHMARK = "benchmark"
 SOURCE_OWN = "own"
 SOURCE_CHOICES = (SOURCE_BENCHMARK, SOURCE_OWN)
+PROCESSING_STATIC = "static"
+PROCESSING_AGENTIC = "agentic"
+_PROCESSING_CHOICES = frozenset((PROCESSING_STATIC, PROCESSING_AGENTIC))
+_AGENTIC_MODELS = frozenset(("gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash-lite"))
+
+_STATIC_SCOPE_PROMPT = """Analyze only the fixed-length opening clip provided. Scope all observations,
+timestamps, and averages to this clip window. Never emit timestamps beyond the clip or speculate
+about the rest of the video."""
+_AGENTIC_SCOPE_PROMPT = """Use agentic video processing to inspect the full video timeline. Scope all
+observations, timestamps, and averages to the complete video, exploring the sections needed to support
+the analysis."""
 
 # 任意 URL 経路では slug を一意に持てないため固定名で保存する
 URL_SOURCE_SLUG = "url"
@@ -281,6 +292,29 @@ def _analysis_window_sec_from_config(cfg: dict) -> int:
     return value
 
 
+def _processing_from_config(cfg: dict) -> str:
+    """処理モードと agentic 対応モデルの組み合わせを API 呼出前に検証する。"""
+    processing = cfg.get("processing", PROCESSING_STATIC)
+    if not isinstance(processing, str) or processing not in _PROCESSING_CHOICES:
+        raise ConfigError(
+            f"audit.video.processing は 'static' または 'agentic' である必要があります (received: {processing!r})"
+        )
+    model = cfg.get("model")
+    if processing == PROCESSING_AGENTIC and model not in _AGENTIC_MODELS:
+        supported = ", ".join(sorted(_AGENTIC_MODELS))
+        raise ConfigError(
+            f"audit.video.processing='agentic' は対応モデルのみ使用できます (received: {model!r}; "
+            f"supported: {supported})"
+        )
+    return processing
+
+
+def _prompt_for_processing(prompt: str, processing: str) -> str:
+    """ユーザー prompt に実際の解析スコープを明示する。"""
+    scope = _AGENTIC_SCOPE_PROMPT if processing == PROCESSING_AGENTIC else _STATIC_SCOPE_PROMPT
+    return f"{scope}\n\n{prompt}"
+
+
 def _run_analysis(
     *, analyzer: VideoAnalyzer, targets: list[VideoTarget], force: bool = False
 ) -> tuple[list[dict], list[dict]]:
@@ -332,6 +366,7 @@ def main():
     data_dir = channel_dir / "data"
     reports_dir = channel_dir / "reports"
     analysis_window_sec = _analysis_window_sec_from_config(cfg)
+    processing = _processing_from_config(cfg)
 
     slug, targets = _resolve_targets(args, channel_dir=channel_dir, data_dir=data_dir)
     logger.info("解析対象: slug='%s' 件数=%d", slug, len(targets))
@@ -351,10 +386,11 @@ def main():
     analyzer = VideoAnalyzer(
         client=create_global_genai_client(),
         model=cfg["model"],
-        prompt=cfg["prompt"],
+        prompt=_prompt_for_processing(cfg["prompt"], processing),
         delay_sec=cfg["delay_sec"],
         data_dir=data_dir,
         analysis_window_sec=analysis_window_sec,
+        processing=processing,
     )
 
     results, failures = _run_analysis(analyzer=analyzer, targets=targets, force=args.force)

--- a/src/youtube_automation/infrastructure/media/video_analyzer.py
+++ b/src/youtube_automation/infrastructure/media/video_analyzer.py
@@ -58,7 +58,7 @@ class VideoAnalyzer:
     """Gemini に YouTube URL を直接渡して構造化 JSON を得る。
 
     `client` / `model` / `prompt` / `delay_sec` / `data_dir` /
-    `analysis_window_sec` は CLI 層 (境界) で 1 度だけ解決して渡す。
+    `analysis_window_sec` / `processing` は CLI 層 (境界) で 1 度だけ解決して渡す。
     analyze_url ループ内で再解決しない。
     """
 
@@ -71,6 +71,7 @@ class VideoAnalyzer:
         delay_sec: int,
         data_dir: Path,
         analysis_window_sec: int,
+        processing: str = "static",
     ) -> None:
         self.client = client
         self.model = model
@@ -78,32 +79,32 @@ class VideoAnalyzer:
         self.delay_sec = delay_sec
         self.data_dir = data_dir
         self.analysis_window_sec = analysis_window_sec
+        self.processing = processing
 
     def analyze_url(self, target: VideoTarget) -> dict[str, Any]:
-        """target.url の冒頭 `analysis_window_sec` 秒を Gemini に渡し、JSON をパースして返す。
+        """処理モードに従って target.url を Gemini に渡し、JSON をパースして返す。
 
-        `types.Part.from_uri()` は `video_metadata` を受け取れないため、
-        `types.Part(file_data=..., video_metadata=...)` で offset 付き Part を組み立てる。
+        static は offset 付き `video_metadata`、agentic は窓なしの
+        `media_processing=AGENTIC` を排他的に Part へ設定する。
 
         Raises:
             ValidationError: Gemini レスポンスが JSON にパースできない場合
         """
-        logger.info(
-            "Gemini 動画解析 (冒頭 %d 秒): %s (%s)",
-            self.analysis_window_sec,
-            target.title[:40],
-            target.video_id,
-        )
+        logger.info("Gemini 動画解析 (%s): %s (%s)", self.processing, target.title[:40], target.video_id)
+        part_kwargs: dict[str, Any] = {
+            "file_data": types.FileData(file_uri=target.url, mime_type=_VIDEO_MIME_TYPE),
+        }
+        if self.processing == "agentic":
+            part_kwargs["media_processing"] = types.MediaProcessing.AGENTIC
+        else:
+            part_kwargs["video_metadata"] = types.VideoMetadata(
+                start_offset="0s",
+                end_offset=f"{self.analysis_window_sec}s",
+            )
         response = self.client.models.generate_content(
             model=self.model,
             contents=[
-                types.Part(
-                    file_data=types.FileData(file_uri=target.url, mime_type=_VIDEO_MIME_TYPE),
-                    video_metadata=types.VideoMetadata(
-                        start_offset="0s",
-                        end_offset=f"{self.analysis_window_sec}s",
-                    ),
-                ),
+                types.Part(**part_kwargs),
                 self.prompt,
             ],
         )
@@ -114,6 +115,7 @@ class VideoAnalyzer:
             target=target,
             model=self.model,
             analysis_window_sec=self.analysis_window_sec,
+            processing=self.processing,
         )
 
     def json_path(self, target: VideoTarget) -> Path:
@@ -179,6 +181,7 @@ def _attach_metadata(
     target: VideoTarget,
     model: str,
     analysis_window_sec: int,
+    processing: str = "static",
 ) -> dict[str, Any]:
     """ドメインキーは payload を保ち、メタデータは target で上書きする (envelope)。"""
     return {
@@ -189,11 +192,11 @@ def _attach_metadata(
         "title": target.title,
         "analyzed_at": datetime.now().isoformat(timespec="seconds"),
         "model": model,
-        "analysis_window_sec": analysis_window_sec,
+        "analysis_window_sec": analysis_window_sec if processing == "static" else None,
         "analysis_scope": {
-            "start_offset_sec": 0,
-            "end_offset_sec": analysis_window_sec,
-            "description": "opening clip window",
+            "start_offset_sec": 0 if processing == "static" else None,
+            "end_offset_sec": analysis_window_sec if processing == "static" else None,
+            "description": "opening clip window" if processing == "static" else "full video (agentic processing)",
         },
     }
 

--- a/src/youtube_automation/infrastructure/media/video_analyzer.py
+++ b/src/youtube_automation/infrastructure/media/video_analyzer.py
@@ -91,20 +91,24 @@ class VideoAnalyzer:
             ValidationError: Gemini レスポンスが JSON にパースできない場合
         """
         logger.info("Gemini 動画解析 (%s): %s (%s)", self.processing, target.title[:40], target.video_id)
-        part_kwargs: dict[str, Any] = {
-            "file_data": types.FileData(file_uri=target.url, mime_type=_VIDEO_MIME_TYPE),
-        }
+        file_data = types.FileData(file_uri=target.url, mime_type=_VIDEO_MIME_TYPE)
         if self.processing == "agentic":
-            part_kwargs["media_processing"] = types.MediaProcessing.AGENTIC
+            video_part = types.Part(
+                file_data=file_data,
+                media_processing=types.MediaProcessing.AGENTIC,
+            )
         else:
-            part_kwargs["video_metadata"] = types.VideoMetadata(
-                start_offset="0s",
-                end_offset=f"{self.analysis_window_sec}s",
+            video_part = types.Part(
+                file_data=file_data,
+                video_metadata=types.VideoMetadata(
+                    start_offset="0s",
+                    end_offset=f"{self.analysis_window_sec}s",
+                ),
             )
         response = self.client.models.generate_content(
             model=self.model,
             contents=[
-                types.Part(**part_kwargs),
+                video_part,
                 self.prompt,
             ],
         )

--- a/src/youtube_automation/infrastructure/media/video_analyzer.py
+++ b/src/youtube_automation/infrastructure/media/video_analyzer.py
@@ -187,7 +187,11 @@ def _attach_metadata(
     analysis_window_sec: int,
     processing: str = "static",
 ) -> dict[str, Any]:
-    """ドメインキーは payload を保ち、メタデータは target で上書きする (envelope)。"""
+    """ドメインキーは payload を保ち、メタデータは target で上書きする (envelope)。
+
+    agentic は窓を渡さずに解析するため、窓由来のキーは `null` にして全尺スコープを名乗る。
+    """
+    is_static = processing == "static"
     return {
         **payload,
         "video_id": target.video_id,
@@ -196,11 +200,11 @@ def _attach_metadata(
         "title": target.title,
         "analyzed_at": datetime.now().isoformat(timespec="seconds"),
         "model": model,
-        "analysis_window_sec": analysis_window_sec if processing == "static" else None,
+        "analysis_window_sec": analysis_window_sec if is_static else None,
         "analysis_scope": {
-            "start_offset_sec": 0 if processing == "static" else None,
-            "end_offset_sec": analysis_window_sec if processing == "static" else None,
-            "description": "opening clip window" if processing == "static" else "full video (agentic processing)",
+            "start_offset_sec": 0 if is_static else None,
+            "end_offset_sec": analysis_window_sec if is_static else None,
+            "description": "opening clip window" if is_static else "full video (agentic processing)",
         },
     }
 

--- a/tests/commands/analytics/test_video_analyze_cli.py
+++ b/tests/commands/analytics/test_video_analyze_cli.py
@@ -28,6 +28,7 @@ from youtube_automation.commands.analytics.video_analyze import (
     _analysis_window_sec_from_config,
     _build_parser,
     _extract_video_id_from_url,
+    _processing_from_config,
     _resolve_benchmark_targets,
     _resolve_own_targets,
     _resolve_url_target,
@@ -492,6 +493,27 @@ class TestAnalysisWindowValidation:
         with pytest.raises(ConfigError, match="analysis_window_sec"):
             _analysis_window_sec_from_config(cfg)
 
+
+class TestProcessingValidation:
+    @pytest.mark.parametrize("value", ["fast", "", True])
+    def test_rejects_unknown_processing(self, value):
+        with pytest.raises(ConfigError, match="audit.video.processing"):
+            _processing_from_config({"processing": value, "model": "gemini-3.7-flash"})
+
+    def test_defaults_to_static(self):
+        assert _processing_from_config({"model": "gemini-3.5-flash"}) == "static"
+
+    def test_rejects_unsupported_agentic_model(self):
+        with pytest.raises(ConfigError, match="gemini-3.5-flash"):
+            _processing_from_config({"processing": "agentic", "model": "gemini-3.5-flash"})
+
+    @pytest.mark.parametrize(
+        "model",
+        ["gemini-3.7-flash", "gemini-3.6-flash", "gemini-3.5-flash-lite"],
+    )
+    def test_accepts_supported_agentic_models(self, model):
+        assert _processing_from_config({"processing": "agentic", "model": model}) == "agentic"
+
     @pytest.mark.parametrize("yaml_value", ["0", "-1", "'300'", "true", "false", "null"])
     def test_channel_override_invalid_window_is_rejected(self, tmp_path, yaml_value):
         # Given: config/skills/video-analyze.yaml に不正な override
@@ -583,6 +605,19 @@ class TestMainAnalysisWindowFlow:
         # Then: default の 30 秒が同じ入口から SDK metadata に届く
         contents = client.models.generate_content.call_args.kwargs["contents"]
         assert contents[0].video_metadata.end_offset == "30s"
+
+    def test_agentic_mode_flows_to_gemini_and_full_video_prompt(self, tmp_path, monkeypatch):
+        client = self._run_main_with_channel(
+            tmp_path,
+            monkeypatch,
+            "processing: agentic\nmodel: gemini-3.7-flash\ndelay_sec: 0\n",
+        )
+
+        contents = client.models.generate_content.call_args.kwargs["contents"]
+        assert contents[0].media_processing == "AGENTIC"
+        assert contents[0].video_metadata is None
+        assert "full video timeline" in contents[1]
+        assert "fixed-length opening clip" not in contents[1]
 
 
 # ----------------------------------------------------------------------------

--- a/tests/commands/analytics/test_video_analyze_cli.py
+++ b/tests/commands/analytics/test_video_analyze_cli.py
@@ -493,6 +493,21 @@ class TestAnalysisWindowValidation:
         with pytest.raises(ConfigError, match="analysis_window_sec"):
             _analysis_window_sec_from_config(cfg)
 
+    @pytest.mark.parametrize("yaml_value", ["0", "-1", "'300'", "true", "false", "null"])
+    def test_channel_override_invalid_window_is_rejected(self, tmp_path, yaml_value):
+        # Given: config/skills/video-analyze.yaml に不正な override
+        skills_dir = tmp_path / "config" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "video-analyze.yaml").write_text(
+            f"analysis_window_sec: {yaml_value}\n",
+            encoding="utf-8",
+        )
+        cfg = load_skill_config("video-analyze", use_cache=False, channel_dir=tmp_path)
+
+        # When/Then: deep-merge 後の境界検証で拒否される
+        with pytest.raises(ConfigError, match="analysis_window_sec"):
+            _analysis_window_sec_from_config(cfg)
+
 
 class TestProcessingValidation:
     @pytest.mark.parametrize("value", ["fast", "", True])
@@ -514,34 +529,9 @@ class TestProcessingValidation:
     def test_accepts_supported_agentic_models(self, model):
         assert _processing_from_config({"processing": "agentic", "model": model}) == "agentic"
 
-    @pytest.mark.parametrize("yaml_value", ["0", "-1", "'300'", "true", "false", "null"])
-    def test_channel_override_invalid_window_is_rejected(self, tmp_path, yaml_value):
-        # Given: config/skills/video-analyze.yaml に不正な override
-        skills_dir = tmp_path / "config" / "skills"
-        skills_dir.mkdir(parents=True)
-        (skills_dir / "video-analyze.yaml").write_text(
-            f"analysis_window_sec: {yaml_value}\n",
-            encoding="utf-8",
-        )
-        cfg = load_skill_config("video-analyze", use_cache=False, channel_dir=tmp_path)
-
-        # When/Then: deep-merge 後の境界検証で拒否される
-        with pytest.raises(ConfigError, match="analysis_window_sec"):
-            _analysis_window_sec_from_config(cfg)
-
 
 class TestMainAnalysisWindowFlow:
-    def _run_main_with_channel(self, tmp_path, monkeypatch, config_yaml: str) -> MagicMock:
-        from youtube_automation.configuration import reset as reset_config
-
-        skills_dir = tmp_path / "config" / "skills"
-        skills_dir.mkdir(parents=True)
-        (skills_dir / "video-analyze.yaml").write_text(config_yaml, encoding="utf-8")
-
-        monkeypatch.setenv("CHANNEL_DIR", str(tmp_path))
-        reset_config()
-        reset_skill_config("audit.video")
-
+    def _make_client(self) -> MagicMock:
         client = MagicMock()
         response = MagicMock()
         response.text = json.dumps(
@@ -559,6 +549,27 @@ class TestMainAnalysisWindowFlow:
             }
         )
         client.models.generate_content.return_value = response
+        return client
+
+    def _run_main_with_channel(
+        self,
+        tmp_path,
+        monkeypatch,
+        config_yaml: str,
+        *,
+        client: MagicMock | None = None,
+    ) -> MagicMock:
+        from youtube_automation.configuration import reset as reset_config
+
+        skills_dir = tmp_path / "config" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "video-analyze.yaml").write_text(config_yaml, encoding="utf-8")
+
+        monkeypatch.setenv("CHANNEL_DIR", str(tmp_path))
+        reset_config()
+        reset_skill_config("audit.video")
+
+        client = client if client is not None else self._make_client()
 
         try:
             with (
@@ -618,6 +629,22 @@ class TestMainAnalysisWindowFlow:
         assert contents[0].video_metadata is None
         assert "full video timeline" in contents[1]
         assert "fixed-length opening clip" not in contents[1]
+
+    def test_agentic_with_unsupported_model_rejects_before_gemini_call(self, tmp_path, monkeypatch):
+        # Given: agentic × 配布既定の非対応モデル
+        client = self._make_client()
+
+        # When/Then: 実 main() 経由で ConfigError
+        with pytest.raises(ConfigError, match="gemini-3.5-flash"):
+            self._run_main_with_channel(
+                tmp_path,
+                monkeypatch,
+                "processing: agentic\nmodel: gemini-3.5-flash\ndelay_sec: 0\n",
+                client=client,
+            )
+
+        # And: 動画入力が課金され得る generate_content の前で落ちている
+        assert client.models.generate_content.call_count == 0
 
 
 # ----------------------------------------------------------------------------

--- a/tests/infrastructure/analytics/test_retention_timeline.py
+++ b/tests/infrastructure/analytics/test_retention_timeline.py
@@ -78,6 +78,34 @@ def test_drop_outside_analysis_window_is_not_guessed() -> None:
     assert result["drops"][0]["mapping_status"] == "outside_analysis_window"
 
 
+def test_null_analysis_window_maps_and_reports_full_video() -> None:
+    result = correlate_retention_timeline(
+        video_id="VID123",
+        duration_seconds=3600,
+        retention_curve=[
+            {"elapsed_ratio": 0.2, "watch_ratio": 0.8},
+            {"elapsed_ratio": 0.5, "watch_ratio": 0.7},
+        ],
+        video_analysis={
+            "analysis_window_sec": None,
+            "scene_timeline": [{"start": "20:00", "summary": "late scene"}],
+            "bgm_arc": {"segments": [{"start": "20:00", "track": "late track"}]},
+        },
+    )
+
+    assert result["drops"][0]["elapsed_seconds"] == 1800
+    assert result["drops"][0]["scene"] == "late scene"
+    assert result["drops"][0]["bgm"] == "late track"
+    assert result["drops"][0]["mapping_status"] == "matched"
+
+    markdown = render_retention_report(
+        result,
+        analytics_path=Path("data/analytics.json"),
+        analysis_path=Path("data/analysis.json"),
+    )
+    assert "- analysis window: 動画全体" in markdown
+
+
 def test_legacy_bgm_arc_maps_to_phase() -> None:
     result = correlate_retention_timeline(
         video_id="VID123",

--- a/tests/infrastructure/media/test_video_analyzer.py
+++ b/tests/infrastructure/media/test_video_analyzer.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from google.genai import types
 from google.genai.errors import APIError
 
 from youtube_automation.application.analytics.video_report import write_video_analysis_report
@@ -272,6 +273,30 @@ class TestVideoAnalyzerAnalyzeUrl:
         assert part.file_data.file_uri == target.url
         assert part.video_metadata.start_offset == "0s"
         assert part.video_metadata.end_offset == "900s"
+
+    def test_agentic_processing_omits_video_metadata(self, tmp_path):
+        client = _make_client(json.dumps(_VALID_PAYLOAD))
+        analyzer = VideoAnalyzer(
+            client=client,
+            model="gemini-3.7-flash",
+            prompt="analyze the full video",
+            delay_sec=0,
+            data_dir=tmp_path,
+            analysis_window_sec=900,
+            processing="agentic",
+        )
+
+        result = analyzer.analyze_url(_make_target())
+
+        part = client.models.generate_content.call_args.kwargs["contents"][0]
+        assert part.media_processing == types.MediaProcessing.AGENTIC
+        assert part.video_metadata is None
+        assert result["analysis_window_sec"] is None
+        assert result["analysis_scope"] == {
+            "start_offset_sec": None,
+            "end_offset_sec": None,
+            "description": "full video (agentic processing)",
+        }
 
     def test_custom_window_is_reflected_in_end_offset(self, tmp_path):
         # Given: チャンネル側上書き相当のカスタム窓幅


### PR DESCRIPTION
動画解析に static / agentic の処理モードを追加し、対応モデル検証、排他的な Gemini Part 組み立て、モード別プロンプトと結果 envelope を実装します。

Closes #4816