### PR TITLE
test: 動画生成契約テストの起動を高速化する (#4858)

### DIFF
--- a/changelog.d/4858-generate-videos-test-harness.changed.md
+++ b/changelog.d/4858-generate-videos-test-harness.changed.md
@@ -1,0 +1,1 @@
+- `generate_videos.sh` の shell 契約テストで stub command を同一 shell 内から呼び、検出力を維持したまま実行時間を短縮

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -78,17 +78,21 @@ def _create_stub_bin(tmp_path: Path) -> Path:
     _write_executable(
         bin_dir / "afinfo",
         """#!/bin/bash
+afinfo() {
 printf 'File:           %s\\nestimated duration: %s sec\\n' "$1" "${FFPROBE_DURATION:-1.00}"
+}
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then afinfo "$@"; fi
+true
 """,
     )
     _write_executable(
         bin_dir / "ffprobe",
         """#!/bin/bash
-set -eu
+ffprobe() {
 args="$*"
 input_path="${!#}"
 if [[ "${FFPROBE_OUTPUT_FAIL:-0}" == "1" && "$input_path" == *"-Master.mp4" ]]; then
-    exit 1
+    return 1
 fi
 if [[ "$args" == *"format=duration"* ]]; then
     if [[ "$input_path" == *"-Master.mp4" && -n "${FFPROBE_OUTPUT_DURATION+x}" ]]; then
@@ -98,42 +102,44 @@ if [[ "$args" == *"format=duration"* ]]; then
     else
         printf '%s\\n' "${FFPROBE_DURATION:-1.00}"
     fi
-    exit 0
+    return 0
 fi
 if [[ "$args" == *"stream=r_frame_rate"* ]]; then
     printf '%s\\n' "${FFPROBE_OUTPUT_FRAME_RATE-24/1}"
-    exit 0
+    return 0
 fi
 if [[ "$args" == *"stream=width,height,pix_fmt,r_frame_rate"* ]]; then
     printf '%s\\n' "${FFPROBE_STREAM_OUTPUT}"
-    exit 0
+    return 0
 fi
 if [[ "$args" == *"stream=bit_rate"* ]]; then
     printf '%s\\n' "${FFPROBE_STREAM_BITRATE_OUTPUT:-}"
-    exit 0
+    return 0
 fi
 if [[ "$args" == *"format=bit_rate"* ]]; then
     printf '%s\\n' "${FFPROBE_FORMAT_BITRATE_OUTPUT:-}"
-    exit 0
+    return 0
 fi
-exit 0
+}
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffprobe "$@"; fi
+true
 """,
     )
     _write_executable(
         bin_dir / "ffmpeg",
         """#!/bin/bash
-set -eu
+ffmpeg() {
 if [[ "$*" == *"-encoders"* ]]; then
     printf ' A..... aac \\n'
     if [[ -n "${FFMPEG_ENCODERS:-}" ]]; then printf '%b' "$FFMPEG_ENCODERS"; fi
-    exit 0
+    return 0
 fi
 
 if [[ -n "${FFMPEG_LOG:-}" ]]; then
     printf '%s\\n' "$*" >> "${FFMPEG_LOG}"
 fi
 if [[ -n "${FFMPEG_FAIL_MATCH:-}" && "$*" == *"${FFMPEG_FAIL_MATCH}"* ]]; then
-    exit 9
+    return 9
 fi
 
 progress_path=""
@@ -154,17 +160,19 @@ if [[ -n "$progress_path" ]]; then
 fi
 
 output_path="${!#}"
-mkdir -p "$(dirname "$output_path")"
 printf 'stub-output' > "$output_path"
 if [[ -n "$duration" ]]; then
     printf '%s\\n' "$duration" > "${output_path}.duration"
 fi
+}
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffmpeg "$@"; fi
+true
 """,
     )
     _write_executable(
         bin_dir / "jq",
         """#!/bin/bash
-set -eu
+jq() {
 expr=""
 file=""
 for arg in "$@"; do
@@ -255,6 +263,49 @@ PY
     *".overlays.encoder.framerate"*) printf '%s\\n' "${OVERLAY_ENCODER_FRAMERATE:-}" ;;
     *) printf '\\n' ;;
 esac
+}
+
+uv() {
+    if [[ -n "${UV_LOG:-}" ]]; then
+        command uv "$@"
+        return
+    fi
+    if [[ "$*" != *"youtube_automation.infrastructure.media.audio_visualizer_mask"* ]]; then
+        printf 'unexpected uv invocation: %s\\n' "$*" >&2
+        return 2
+    fi
+    local output="" prev="" arg
+    for arg in "$@"; do
+        if [[ "$prev" == "--output" ]]; then output="$arg"; fi
+        prev="$arg"
+    done
+    if [[ -z "$output" ]]; then
+        printf 'audio visualizer mask output is required\\n' >&2
+        return 2
+    fi
+    printf 'stub-mask' > "$output"
+}
+
+dirname() {
+    local path="${1%/}" parent
+    parent="${path%/*}"
+    if [[ -z "$parent" ]]; then parent="/"; fi
+    printf '%s\\n' "$parent"
+}
+
+basename() {
+    local path="${1%/}"
+    printf '%s\\n' "${path##*/}"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    jq "$@"
+fi
+stub_bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$stub_bin_dir/afinfo"
+source "$stub_bin_dir/ffprobe"
+source "$stub_bin_dir/ffmpeg"
+true
 """,
     )
     _write_executable(
@@ -289,6 +340,12 @@ def _shared_stub_bin(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]
     数百 ms かかるため、テストごとに stub を作り直すと 1 テストあたり
     0.5〜0.8s のオーバーヘッドになる。stub は環境変数と引数だけで挙動が決まり
     bin ディレクトリ側に状態を持たないので、session 全体で安全に共有できる。
+
+    jq / ffprobe / ffmpeg stub と単純な path helper は ``BASH_ENV`` から function としても読み込む。
+    overlay 設定を多数読む 1 回の script 実行で同じ短命 shell を数十回起動するコスト
+    だけを除き、各引数と戻り値、および production script の分岐は従来どおり検査する。
+    runtime mask の通常ケースも function で出力を再現するが、``UV_LOG`` を指定する
+    起動契約テストは PATH 上の専用 executable へ委譲して実際の argv を検査する。
     """
     global _SHARED_STUB_BIN
     _SHARED_STUB_BIN = _create_stub_bin(tmp_path_factory.mktemp("shared-stub"))
@@ -324,6 +381,7 @@ def _run_generate_videos(
     env["FFPROBE_STREAM_OUTPUT"] = stream_output
     env["FFPROBE_STREAM_BITRATE_OUTPUT"] = stream_bitrate_output
     env["FFMPEG_LOG"] = str(ffmpeg_log)
+    env["BASH_ENV"] = str(bin_dir / "jq")
     if extra_env:
         env.update(extra_env)
     script_args = extra_args or []

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -89,6 +89,8 @@ true
         bin_dir / "ffprobe",
         """#!/bin/bash
 ffprobe() {
+# BASH_ENV 経由で production script と同じ shell に載るため、作業変数は必ず local にする。
+local args input_path
 args="$*"
 input_path="${!#}"
 if [[ "${FFPROBE_OUTPUT_FAIL:-0}" == "1" && "$input_path" == *"-Master.mp4" ]]; then
@@ -129,6 +131,9 @@ true
         bin_dir / "ffmpeg",
         """#!/bin/bash
 ffmpeg() {
+# generate_videos.sh は ffmpeg を command substitution 外から直接呼ぶため、
+# 作業変数を local にしないと script 側の同名変数 (duration 等) を壊す。
+local progress_path duration prev arg output_path output_dir
 if [[ "$*" == *"-encoders"* ]]; then
     printf ' A..... aac \\n'
     if [[ -n "${FFMPEG_ENCODERS:-}" ]]; then printf '%b' "$FFMPEG_ENCODERS"; fi
@@ -160,6 +165,12 @@ if [[ -n "$progress_path" ]]; then
 fi
 
 output_path="${!#}"
+# 実 ffmpeg 同様に出力先ディレクトリが無ければ作る（旧 stub の `mkdir -p` 相当を
+# 外部プロセス起動なしで再現する）。
+output_dir="${output_path%/*}"
+if [[ -n "$output_dir" && "$output_dir" != "$output_path" && ! -d "$output_dir" ]]; then
+    mkdir -p "$output_dir"
+fi
 printf 'stub-output' > "$output_path"
 if [[ -n "$duration" ]]; then
     printf '%s\\n' "$duration" > "${output_path}.duration"
@@ -173,6 +184,7 @@ true
         bin_dir / "jq",
         """#!/bin/bash
 jq() {
+local expr file arg
 expr=""
 file=""
 for arg in "$@"; do
@@ -265,46 +277,70 @@ PY
 esac
 }
 
+# runtime mask だけ function で高速に再現し、その他の `uv run <cmd>` は stub bin 上の
+# 同名 stub へ委譲する。stub の無い呼び出しだけを未知として失敗させるので、
+# 新しい `uv run` 経路を検証するテストは stub bin に実行ファイルを足すだけで済む。
 uv() {
     if [[ -n "${UV_LOG:-}" ]]; then
         command uv "$@"
         return
     fi
-    if [[ "$*" != *"youtube_automation.infrastructure.media.audio_visualizer_mask"* ]]; then
-        printf 'unexpected uv invocation: %s\\n' "$*" >&2
-        return 2
+    if [[ "$*" == *"youtube_automation.infrastructure.media.audio_visualizer_mask"* ]]; then
+        local output="" prev="" arg
+        for arg in "$@"; do
+            if [[ "$prev" == "--output" ]]; then output="$arg"; fi
+            prev="$arg"
+        done
+        if [[ -z "$output" ]]; then
+            printf 'audio visualizer mask output is required\\n' >&2
+            return 2
+        fi
+        printf 'stub-mask' > "$output"
+        return 0
     fi
-    local output="" prev="" arg
-    for arg in "$@"; do
-        if [[ "$prev" == "--output" ]]; then output="$arg"; fi
-        prev="$arg"
-    done
-    if [[ -z "$output" ]]; then
-        printf 'audio visualizer mask output is required\\n' >&2
-        return 2
+    if [[ "${1:-}" == "run" && -n "${2:-}" && -x "${_STUB_BIN_DIR:-}/${2}" ]]; then
+        local target="$2"
+        shift 2
+        "${_STUB_BIN_DIR}/${target}" "$@"
+        return
     fi
-    printf 'stub-mask' > "$output"
+    printf 'unexpected uv invocation: %s\\n' "$*" >&2
+    return 2
 }
 
+# BASH_ENV 経由で bash プロセス全体の dirname / basename を置き換えるため、
+# GNU coreutils と同じ結果を返す（スラッシュ非包含なら `.`、末尾スラッシュは無視）。
 dirname() {
-    local path="${1%/}" parent
+    local path="${1:-}" parent
+    while [[ "$path" == */ && "$path" != "/" ]]; do path="${path%/}"; done
+    if [[ "$path" != */* ]]; then
+        printf '.\\n'
+        return
+    fi
     parent="${path%/*}"
     if [[ -z "$parent" ]]; then parent="/"; fi
     printf '%s\\n' "$parent"
 }
 
 basename() {
-    local path="${1%/}"
-    printf '%s\\n' "${path##*/}"
+    local path="${1:-}" name
+    while [[ "$path" == */ && "$path" != "/" ]]; do path="${path%/}"; done
+    if [[ "$path" == "/" ]]; then
+        printf '/\\n'
+        return
+    fi
+    name="${path##*/}"
+    if [[ -n "${2:-}" && "$name" != "$2" ]]; then name="${name%"$2"}"; fi
+    printf '%s\\n' "$name"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     jq "$@"
 fi
-stub_bin_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$stub_bin_dir/afinfo"
-source "$stub_bin_dir/ffprobe"
-source "$stub_bin_dir/ffmpeg"
+_STUB_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$_STUB_BIN_DIR/afinfo"
+source "$_STUB_BIN_DIR/ffprobe"
+source "$_STUB_BIN_DIR/ffmpeg"
 true
 """,
     )
@@ -346,6 +382,17 @@ def _shared_stub_bin(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]
     だけを除き、各引数と戻り値、および production script の分岐は従来どおり検査する。
     runtime mask の通常ケースも function で出力を再現するが、``UV_LOG`` を指定する
     起動契約テストは PATH 上の専用 executable へ委譲して実際の argv を検査する。
+
+    新規テストを書くときの注意（function は bash プロセス全体で有効なため）:
+
+    - ``uv run <cmd>`` は stub bin 上の同名 stub があればそこへ委譲する。新しい
+      ``uv run`` 経路を検証したいときは stub bin に実行ファイルを足す（stub の無い
+      呼び出しだけが ``unexpected uv invocation`` で失敗する）
+    - ``dirname`` / ``basename`` は GNU coreutils と同じ結果を返すので、相対パスや
+      裸のファイル名を渡しても実コマンドと差が出ない
+    - stub 内の作業変数はすべて ``local``。ffmpeg のように command substitution 外から
+      直接呼ばれる stub が production script の同名変数を壊さないようにしている
+    - ffmpeg stub は実 ffmpeg 同様に出力先ディレクトリが無ければ作る
     """
     global _SHARED_STUB_BIN
     _SHARED_STUB_BIN = _create_stub_bin(tmp_path_factory.mktemp("shared-stub"))

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -165,8 +165,7 @@ if [[ -n "$progress_path" ]]; then
 fi
 
 output_path="${!#}"
-# 実 ffmpeg 同様に出力先ディレクトリが無ければ作る（旧 stub の `mkdir -p` 相当を
-# 外部プロセス起動なしで再現する）。
+# 旧 stub の `mkdir -p` 相当を外部プロセス起動なしで再現する。
 output_dir="${output_path%/*}"
 if [[ -n "$output_dir" && "$output_dir" != "$output_path" && ! -d "$output_dir" ]]; then
     mkdir -p "$output_dir"
@@ -392,7 +391,10 @@ def _shared_stub_bin(tmp_path_factory: pytest.TempPathFactory) -> Iterator[Path]
       裸のファイル名を渡しても実コマンドと差が出ない
     - stub 内の作業変数はすべて ``local``。ffmpeg のように command substitution 外から
       直接呼ばれる stub が production script の同名変数を壊さないようにしている
-    - ffmpeg stub は実 ffmpeg 同様に出力先ディレクトリが無ければ作る
+    - ffmpeg stub は旧 stub と同様に出力先ディレクトリが無ければ作る
+    - stub bin の実行ファイルにも ``BASH_ENV`` が継承され、この定義が再度 source
+      される。新しい stub から jq / ffmpeg / dirname 等を独立プロセスとして呼ぶ場合は、
+      function の上書きや直接実行 guard による二重実行が起きないことを確認する
     """
     global _SHARED_STUB_BIN
     _SHARED_STUB_BIN = _create_stub_bin(tmp_path_factory.mktemp("shared-stub"))

--- a/tests/test_generate_videos_script.py
+++ b/tests/test_generate_videos_script.py
@@ -81,7 +81,7 @@ def _create_stub_bin(tmp_path: Path) -> Path:
 afinfo() {
 printf 'File:           %s\\nestimated duration: %s sec\\n' "$1" "${FFPROBE_DURATION:-1.00}"
 }
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then afinfo "$@"; fi
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then afinfo "$@"; exit $?; fi
 true
 """,
     )
@@ -123,7 +123,7 @@ if [[ "$args" == *"format=bit_rate"* ]]; then
     return 0
 fi
 }
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffprobe "$@"; fi
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffprobe "$@"; exit $?; fi
 true
 """,
     )
@@ -175,7 +175,7 @@ if [[ -n "$duration" ]]; then
     printf '%s\\n' "$duration" > "${output_path}.duration"
 fi
 }
-if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffmpeg "$@"; fi
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ffmpeg "$@"; exit $?; fi
 true
 """,
     )
@@ -335,6 +335,7 @@ basename() {
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     jq "$@"
+    exit $?
 fi
 _STUB_BIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$_STUB_BIN_DIR/afinfo"


### PR DESCRIPTION
## Summary

- `generate_videos.sh` 契約テストの jq / ffprobe / ffmpeg / path helper stub を `BASH_ENV` から shell function として再利用
- runtime mask の通常ケースでは project environment 解決を stub 化し、専用起動契約テストでは従来どおり executable への argv を検査
- テスト削除、skip/xfail追加、assertion変更、production code変更なし

## Performance

計測コマンド（変更前後で同一、各3回）:

```bash
uv run --no-sync pytest tests/test_generate_videos_script.py -n auto --durations=20 -q
```

| 状態 | run 1 | run 2 | run 3 | 中央値 |
|---|---:|---:|---:|---:|
| Before | 93.904s | 91.656s | 93.620s | 93.620s |
| After | 63.739s | 64.674s | 63.629s | 63.739s |

中央値で **31.92%短縮**。すべて `115 passed, 7 skipped`。

## Testing

- `uv run --no-sync pytest tests/test_generate_videos_script.py -q`
- `uv run --no-sync pytest tests/repo/test_pytest_lane_contract.py tests/repo/test_select_affected_tests.py -n auto -q`
- `uv run --no-sync ruff check tests/test_generate_videos_script.py`
- `python .github/scripts/validate-changelog-fragments.py`

Closes #4858