### PR TITLE
ci: pytest全件実行を並列lane化する (#4860)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
       windows: ${{ steps.classify.outputs.windows }}
       adr: ${{ steps.classify.outputs.adr }}
       test_plan: ${{ steps.test-plan.outputs.plan }}
+      test_execution: ${{ steps.test-plan.outputs.execution }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -52,10 +53,18 @@ jobs:
           bash .github/scripts/classify-ci-paths.sh "$RUNNER_TEMP/changed-paths.txt" | tee -a "$GITHUB_OUTPUT"
       - name: Build affected-test plan
         id: test-plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -eu
           plan=$(python .github/scripts/select-affected-tests.py --format json "$RUNNER_TEMP/changed-paths.txt")
           printf 'plan=%s\n' "$plan" >> "$GITHUB_OUTPUT"
+          mode=$(python -c 'import json,sys; print(json.loads(sys.argv[1])["mode"])' "$plan")
+          if [ "$EVENT_NAME" = "pull_request" ] && [ "$mode" = "selected" ]; then
+            echo "execution=selected" >> "$GITHUB_OUTPUT"
+          else
+            echo "execution=full" >> "$GITHUB_OUTPUT"
+          fi
 
   lint:
     needs: changes
@@ -110,21 +119,16 @@ jobs:
               ;;
           esac
           PYSCN_DIFF_BASE="$base" nix develop --command uv run python .github/scripts/pyscn-diff-gate.py
-  test:
+  test-selected:
     needs: changes
+    if: needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'selected'
     runs-on: ubuntu-latest
     steps:
-      - name: No Python tests required
-        if: needs.changes.outputs.python != 'true'
-        run: echo "Extension-only change; Python tests are not applicable."
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        if: needs.changes.outputs.python == 'true'
         with:
           fetch-depth: 0
       - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
-        if: needs.changes.outputs.python == 'true'
       - name: Cache uv
-        if: needs.changes.outputs.python == 'true'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/uv
@@ -132,12 +136,9 @@ jobs:
           restore-keys: |
             uv-${{ runner.os }}-
       - name: Install dependencies
-        if: needs.changes.outputs.python == 'true'
         run: nix develop --command uv sync
-      - name: Test
-        if: needs.changes.outputs.python == 'true'
+      - name: Selected tests
         env:
-          EVENT_NAME: ${{ github.event_name }}
           TEST_PLAN_JSON: ${{ needs.changes.outputs.test_plan }}
         run: |
           set -euo pipefail
@@ -172,7 +173,6 @@ jobs:
           print(*targets, sep="\n")
           PY
           mapfile -t plan_lines < "$plan_file"
-          plan_mode="${plan_lines[0]}"
           targets=("${plan_lines[@]:1}")
           total_count=$(python - <<'PY'
           from pathlib import Path
@@ -186,12 +186,105 @@ jobs:
           )
           PY
           )
-          if [ "$EVENT_NAME" = "pull_request" ] && [ "$plan_mode" = "selected" ]; then
-            echo "Selected pytest targets: ${#targets[@]}/${total_count}"
-            nix develop --command uv run pytest -n auto -- "${targets[@]}"
+          echo "Selected pytest targets: ${#targets[@]}/${total_count}"
+          nix develop --command uv run pytest -n auto -- "${targets[@]}"
+
+  test-behavioral:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'full'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - name: Cache uv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+      - name: Install dependencies
+        run: nix develop --command uv sync
+      - name: Behavioral tests
+        run: nix develop --command uv run pytest -n auto -m "not repo_contract and not slow"
+
+  test-repository-contract:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'full'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - name: Cache uv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+      - name: Install dependencies
+        run: nix develop --command uv sync
+      - name: Repository contract tests
+        run: nix develop --command uv run pytest -n auto -m "repo_contract and not slow"
+
+  test-slow:
+    needs: changes
+    if: needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'full'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31.11.0
+      - name: Cache uv
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/uv
+          key: uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            uv-${{ runner.os }}-
+      - name: Install dependencies
+        run: nix develop --command uv sync
+      - name: Slow tests
+        run: nix develop --command uv run pytest -n auto -m slow
+
+  # branch protection の required check 名を維持し、selected/full/extension-only の
+  # いずれでも実行された lane の成功だけを集約する。
+  test:
+    needs: [changes, test-selected, test-behavioral, test-repository-contract, test-slow]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify test lanes
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          PYTHON_CHANGED: ${{ needs.changes.outputs.python }}
+          TEST_EXECUTION: ${{ needs.changes.outputs.test_execution }}
+          SELECTED_RESULT: ${{ needs.test-selected.result }}
+          BEHAVIORAL_RESULT: ${{ needs.test-behavioral.result }}
+          REPOSITORY_CONTRACT_RESULT: ${{ needs.test-repository-contract.result }}
+          SLOW_RESULT: ${{ needs.test-slow.result }}
+        run: |
+          set -euo pipefail
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "changes job did not succeed: $CHANGES_RESULT" >&2
+            exit 1
+          fi
+          if [ "$PYTHON_CHANGED" != "true" ]; then
+            echo "Python tests are not applicable."
+          elif [ "$TEST_EXECUTION" = "selected" ]; then
+            test "$SELECTED_RESULT" = "success"
+          elif [ "$TEST_EXECUTION" = "full" ]; then
+            test "$BEHAVIORAL_RESULT" = "success"
+            test "$REPOSITORY_CONTRACT_RESULT" = "success"
+            test "$SLOW_RESULT" = "success"
           else
-            echo "Full pytest suite: ${total_count}/${total_count} targets"
-            nix develop --command uv run pytest -n auto
+            echo "Unknown test execution mode: $TEST_EXECUTION" >&2
+            exit 1
           fi
 
   build-smoke:

--- a/docs/development.md
+++ b/docs/development.md
@@ -51,7 +51,7 @@ devShell の shellHook が実行する `uv sync` で main dependencies と defau
 uv run pytest -n auto                            # 全スイートを CPU コア数の worker で並列実行
 uv run pytest tests/ --ignore=tests/integration -n auto   # ユニットのみ並列実行
 uv run pytest tests/ --ignore=tests/integration -n auto -m "not repo_contract and not slow"  # behavioral fast lane
-uv run pytest tests/ --ignore=tests/integration -n auto -m repo_contract  # docs / CI / packaging 契約
+uv run pytest tests/ --ignore=tests/integration -n auto -m "repo_contract and not slow"  # docs / CI / packaging 契約（slow との重複なし）
 uv run pytest tests/ --ignore=tests/integration -n auto -m slow           # 実 tool / process / 待機を含む lane
 python .github/scripts/run-affected-tests.py                              # worktree差分へCI共通selectorを適用
 ```
@@ -74,7 +74,8 @@ python .github/scripts/run-affected-tests.py                              # work
 - **CI では `-n auto` を有効化済み**（`.github/workflows/ci.yml` の test ジョブ）
 - **外部 GitHub Actions は full commit SHA で固定**し、追跡する stable version を同じ `uses:` 行のコメントに残す。複数 workflow で同じ action を使う場合も SHA/version を統一し、`tests/repo/test_github_actions_pinning.py` で mutable ref・drift・未棚卸し action を拒否する
 - **CI の changed-path 分岐**: `.github/scripts/classify-ci-paths.sh` が PR と `main` push の差分を Python / packaging / Windows / ADR / 3 helper に分類する。branch protection の required check である `lint` / `test` job は path filter や job-level `if` で消さず、extension-only 変更では成功する軽量 step を返して Nix・uv・pytest を起動しない。空 diff は全 gate を有効化する fail-safe とし、分類変更時は `tests/repo/test_actions_parallel_workflows.py` の対応表も更新する
-- **影響テスト選別エンジン**: `.github/scripts/select-affected-tests.py <changed-paths-file>` は、1行1pathの変更一覧から production import の推移的な逆参照、鏡像 test、直接変更 test、repository契約の明示対応表を統合し、pytest targetを決定的に1行1件で返す。`--format json` でも同じplanを出力する。空入力、削除・rename旧path、未知/config/docs path、解析失敗、`tests/conftest.py`・helper・fixture・依存lock等のfail-safe pathでは `ALL` を返す。markerでは絞り込まない。PR の `test` job とローカルの `python .github/scripts/run-affected-tests.py` はselected planを安全なargvで実行しtarget数/全test module数を記録する。local runnerはmerge-base以降のcommitに加えstaged・unstaged・untracked pathも統合する。`ALL` と `main` push はexact `pytest -n auto`の全suiteを実行するため、選別漏れはmerge後に検出される。extension-only の required job lightweight success は維持する
+- **全件 pytest の並列 lane**: `main` push と影響テスト選別が `ALL` を返した PR は、behavioral（`not repo_contract and not slow`）/ repository contract（`repo_contract and not slow`）/ slow（`slow`）の排他的かつ網羅的な3 jobを独立runnerで並列実行する。通常 PR の selected plan は専用jobで対象ファイルを1回だけ実行する。branch protection の required `test` job は `changes` job 自体の成否と実行対象laneの成功を集約し、extension-only でも軽量成功を返す。`changes` が失敗すると分類outputが空になりlaneが丸ごとskipされるため、`needs.changes.result` を先に検査して空outputを「Python変更なし」と誤判定しない。lane を同一runnerへ詰め込むと複数の `pytest -n auto` がCPU・Nixキャッシュを奪い合い、timeoutと低速化を招くため禁止する
+- **影響テスト選別エンジン**: `.github/scripts/select-affected-tests.py <changed-paths-file>` は、1行1pathの変更一覧から production import の推移的な逆参照、鏡像 test、直接変更 test、repository契約の明示対応表を統合し、pytest targetを決定的に1行1件で返す。`--format json` でも同じplanを出力する。空入力、削除・rename旧path、未知/config/docs path、解析失敗、`tests/conftest.py`・helper・fixture・依存lock等のfail-safe pathでは `ALL` を返す。markerでは絞り込まない。PR の `test` job とローカルの `python .github/scripts/run-affected-tests.py` はselected planを安全なargvで実行しtarget数/全test module数を記録する。local runnerはmerge-base以降のcommitに加えstaged・unstaged・untracked pathも統合する。`ALL` と `main` push は排他的な3 marker laneの和で全suiteを実行するため、選別漏れはmerge後に検出される。extension-only の required job lightweight success は維持する
 - worker ごとの分離: `tests/conftest.py` が `CHANNEL_DIR` の tmp コピーを **worker プロセスごとに独立して** 作り直す（controller が自動設定した値を環境変数継承でそのまま共有しない）。ユーザーが明示的に `CHANNEL_DIR` を指定した場合は全 worker がその指定を尊重する
 - 注意: nix devShell / CLI を実 subprocess で叩く契約テストはホスト負荷に敏感で、混雑したマシンでは並列時に所要時間が大きく伸びることがある
 

--- a/tests/repo/test_actions_parallel_workflows.py
+++ b/tests/repo/test_actions_parallel_workflows.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,18 @@ _CI_LINT_PARALLEL_STEPS = {
     "Ruff check": "nix develop --command uv run ruff check .",
     "Ruff format check": "nix develop --command uv run ruff format --check .",
     "pyscn check": "nix develop --command uv run pyscn check src/youtube_automation",
+}
+
+_CI_FULL_TEST_JOBS = {
+    "test-behavioral": (
+        "Behavioral tests",
+        'nix develop --command uv run pytest -n auto -m "not repo_contract and not slow"',
+    ),
+    "test-repository-contract": (
+        "Repository contract tests",
+        'nix develop --command uv run pytest -n auto -m "repo_contract and not slow"',
+    ),
+    "test-slow": ("Slow tests", "nix develop --command uv run pytest -n auto -m slow"),
 }
 
 _SUNO_FAST_PARALLEL_STEPS = {
@@ -255,8 +268,8 @@ def test_ci_path_classifier_selects_only_responsible_gates(
     assert {key for key, enabled in classified.items() if enabled} == expected_true
 
 
-def test_ci_required_jobs_always_report_but_gate_heavy_python_steps() -> None:
-    """Required lint/test job は常時存在し、extension-only 時は重い step だけを省略する。"""
+def test_ci_required_jobs_always_report_and_aggregate_only_successful_lanes() -> None:
+    """Required lint/test は常時存在し、test は実行対象 lane の成功だけを集約する。"""
     workflow = _load_workflow(_CI_WORKFLOW_PATH)
     jobs = workflow["jobs"]
 
@@ -264,17 +277,27 @@ def test_ci_required_jobs_always_report_but_gate_heavy_python_steps() -> None:
         trigger = _on_section(workflow)[trigger_name]
         assert "paths" not in trigger and "paths-ignore" not in trigger
 
-    for job_name in ("lint", "test"):
-        job = jobs[job_name]
-        assert job.get("needs") == "changes"
-        assert "if" not in job
-        steps = job["steps"]
-        assert any(step.get("if") == "needs.changes.outputs.python != 'true'" for step in steps)
-        heavy_steps = [step for step in steps if step.get("uses") or "nix develop" in str(step.get("run", ""))]
-        assert heavy_steps
-        assert all(step.get("if") == "needs.changes.outputs.python == 'true'" for step in heavy_steps)
-        for group in _parallel_groups(steps):
-            assert all(step.get("if") == "needs.changes.outputs.python == 'true'" for step in group)
+    lint = jobs["lint"]
+    assert lint.get("needs") == "changes"
+    assert "if" not in lint
+    lint_steps = lint["steps"]
+    assert any(step.get("if") == "needs.changes.outputs.python != 'true'" for step in lint_steps)
+    heavy_steps = [step for step in lint_steps if step.get("uses") or "nix develop" in str(step.get("run", ""))]
+    assert heavy_steps
+    assert all(step.get("if") == "needs.changes.outputs.python == 'true'" for step in heavy_steps)
+
+    test = jobs["test"]
+    assert test["if"] == "always()"
+    assert set(test["needs"]) == {"changes", "test-selected", *_CI_FULL_TEST_JOBS}
+    assert all("nix develop" not in str(step.get("run", "")) for step in test["steps"])
+    gate = _top_level_step(test["steps"], "Verify test lanes")
+    assert gate["env"]["CHANGES_RESULT"] == "${{ needs.changes.result }}"
+    assert gate["env"]["SELECTED_RESULT"] == "${{ needs.test-selected.result }}"
+    assert gate["env"]["SLOW_RESULT"] == "${{ needs.test-slow.result }}"
+    assert 'test "$SELECTED_RESULT" = "success"' in gate["run"]
+    assert 'test "$BEHAVIORAL_RESULT" = "success"' in gate["run"]
+    assert 'test "$REPOSITORY_CONTRACT_RESULT" = "success"' in gate["run"]
+    assert 'test "$SLOW_RESULT" = "success"' in gate["run"]
 
     assert jobs["build-smoke"]["if"] == "needs.changes.outputs.packaging == 'true'"
     assert jobs["windows-cost-tracker"]["if"] == "needs.changes.outputs.windows == 'true'"
@@ -287,50 +310,65 @@ def test_ci_required_jobs_always_report_but_gate_heavy_python_steps() -> None:
     assert jobs["adr-numbering"]["if"] == "needs.changes.outputs.adr == 'true'"
 
 
-def test_ci_passes_selector_plan_as_job_output_without_shell_interpolation() -> None:
+def test_ci_passes_selector_plan_and_execution_mode_as_job_outputs() -> None:
     workflow = _load_workflow(_CI_WORKFLOW_PATH)
     changes = workflow["jobs"]["changes"]
-    test_job = workflow["jobs"]["test"]
+    selected_job = workflow["jobs"]["test-selected"]
 
     assert changes["outputs"]["test_plan"] == "${{ steps.test-plan.outputs.plan }}"
+    assert changes["outputs"]["test_execution"] == "${{ steps.test-plan.outputs.execution }}"
     plan_step = _top_level_step(changes["steps"], "Build affected-test plan")
     assert plan_step["id"] == "test-plan"
+    assert plan_step["env"] == {"EVENT_NAME": "${{ github.event_name }}"}
     assert "select-affected-tests.py --format json" in plan_step["run"]
     assert "changed-paths.txt" in plan_step["run"]
-    assert "GITHUB_OUTPUT" in plan_step["run"]
+    assert "execution=selected" in plan_step["run"]
+    assert "execution=full" in plan_step["run"]
 
-    test_step = _top_level_step(test_job["steps"], "Test")
-    assert test_step["env"] == {
-        "EVENT_NAME": "${{ github.event_name }}",
-        "TEST_PLAN_JSON": "${{ needs.changes.outputs.test_plan }}",
-    }
-    run = test_step["run"]
-    assert "${{" not in run
-    assert "eval " not in run
-    assert "xargs" not in run
+    selected = _top_level_step(selected_job["steps"], "Selected tests")
+    assert selected["env"] == {"TEST_PLAN_JSON": "${{ needs.changes.outputs.test_plan }}"}
+    assert "${{" not in selected["run"]
+    assert "eval " not in selected["run"]
+    assert "xargs" not in selected["run"]
 
 
-def test_ci_pr_selected_plan_uses_safe_array_while_main_and_all_run_exact_full_suite() -> None:
-    workflow = _load_workflow(_CI_WORKFLOW_PATH)
-    jobs = workflow["jobs"]
-    assert "test" in jobs
-    assert "if" not in jobs["test"]
+def test_ci_run_scripts_read_context_values_through_env_indirection() -> None:
+    """`run:` へ `${{ }}` を直接展開せず env 経由で受け渡す規約を全 step で固定する。"""
+    jobs = _load_workflow(_CI_WORKFLOW_PATH)["jobs"]
 
-    run = _top_level_step(jobs["test"]["steps"], "Test")["run"]
-    assert '[ "$EVENT_NAME" = "pull_request" ]' in run
-    assert '[ "$plan_mode" = "selected" ]' in run
-    assert 'targets=("${plan_lines[@]:1}")' in run
-    assert 'pytest -n auto -- "${targets[@]}"' in run
-    assert "Selected pytest targets: ${#targets[@]}/${total_count}" in run
-    assert "nix develop --command uv run pytest -n auto\n" in run
-    assert "-m repo_contract" not in run
-    assert "not repo_contract and not slow" not in run
+    for job_name, job in jobs.items():
+        for step in job.get("steps") or []:
+            for target in [step, *(step.get("parallel") or [])]:
+                run = target.get("run")
+                if not isinstance(run, str):
+                    continue
+                label = f"{job_name} / {target.get('name', target.get('id', run.splitlines()[0]))}"
+                assert "${{" not in run, f"run へ ${{{{ }}}} を直接埋め込まない: {label}"
 
 
-def _run_ci_test_step(
-    tmp_path: Path, *, event_name: str, payload: dict[str, object]
+def test_ci_selected_and_full_plans_use_separate_runner_jobs() -> None:
+    jobs = _load_workflow(_CI_WORKFLOW_PATH)["jobs"]
+    selected_job = jobs["test-selected"]
+    assert selected_job["if"] == (
+        "needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'selected'"
+    )
+    selected = _top_level_step(selected_job["steps"], "Selected tests")
+    assert 'targets=("${plan_lines[@]:1}")' in selected["run"]
+    assert 'pytest -n auto -- "${targets[@]}"' in selected["run"]
+
+    for job_name, (step_name, command) in _CI_FULL_TEST_JOBS.items():
+        job = jobs[job_name]
+        assert job["needs"] == "changes"
+        assert job["if"] == ("needs.changes.outputs.python == 'true' && needs.changes.outputs.test_execution == 'full'")
+        assert _top_level_step(job["steps"], step_name)["run"] == command
+        assert not _parallel_groups(job["steps"]), "各 full lane は独立 runner で実行する"
+
+
+def _run_selected_test_step(
+    tmp_path: Path, *, payload: dict[str, object]
 ) -> tuple[subprocess.CompletedProcess[str], list[str]]:
-    run = _top_level_step(_load_workflow(_CI_WORKFLOW_PATH)["jobs"]["test"]["steps"], "Test")["run"]
+    steps = _load_workflow(_CI_WORKFLOW_PATH)["jobs"]["test-selected"]["steps"]
+    run = _top_level_step(steps, "Selected tests")["run"]
     repository = tmp_path / "repository"
     (repository / "tests").mkdir(parents=True)
     (repository / "tests/test_selected.py").write_text("", encoding="utf-8")
@@ -349,7 +387,6 @@ def _run_ci_test_step(
         cwd=repository,
         env=os.environ
         | {
-            "EVENT_NAME": event_name,
             "TEST_PLAN_JSON": json.dumps(payload),
             "RUNNER_TEMP": str(runner_temp),
             "NIX_ARGS_LOG": str(args_log),
@@ -364,9 +401,8 @@ def _run_ci_test_step(
 
 
 def test_ci_pr_executes_only_selected_targets_and_logs_selected_over_total(tmp_path: Path) -> None:
-    result, arguments = _run_ci_test_step(
+    result, arguments = _run_selected_test_step(
         tmp_path,
-        event_name="pull_request",
         payload={"mode": "selected", "targets": ["tests/test_selected.py"]},
     )
 
@@ -385,21 +421,139 @@ def test_ci_pr_executes_only_selected_targets_and_logs_selected_over_total(tmp_p
     ]
 
 
-@pytest.mark.parametrize(
-    ("event_name", "payload"),
-    [
-        ("push", {"mode": "selected", "targets": ["tests/test_selected.py"]}),
-        ("pull_request", {"mode": "all", "targets": []}),
-    ],
-)
-def test_ci_main_push_and_pr_fail_safe_execute_exact_full_suite(
-    tmp_path: Path, event_name: str, payload: dict[str, object]
-) -> None:
-    result, arguments = _run_ci_test_step(tmp_path, event_name=event_name, payload=payload)
+def _run_ci_test_plan_step(tmp_path: Path, *, event_name: str, plan: dict[str, object]) -> dict[str, str]:
+    """`Build affected-test plan` step を実際に実行し、`GITHUB_OUTPUT` の内容を返す。"""
+    steps = _load_workflow(_CI_WORKFLOW_PATH)["jobs"]["changes"]["steps"]
+    run = _top_level_step(steps, "Build affected-test plan")["run"]
+    plan_file = tmp_path / "plan.json"
+    plan_file.write_text(json.dumps(plan), encoding="utf-8")
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    python_stub = fake_bin / "python"
+    python_stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'case "$1" in\n'
+        '  *select-affected-tests.py) cat "$PLAN_JSON_FILE" ;;\n'
+        '  *) exec "$REAL_PYTHON" "$@" ;;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    python_stub.chmod(0o755)
+    runner_temp = tmp_path / "runner-temp"
+    runner_temp.mkdir()
+    github_output = tmp_path / "github-output.txt"
+    github_output.touch()
+
+    result = subprocess.run(
+        ["bash", "-c", run],
+        cwd=tmp_path,
+        env=os.environ
+        | {
+            "EVENT_NAME": event_name,
+            "PLAN_JSON_FILE": str(plan_file),
+            "REAL_PYTHON": sys.executable,
+            "RUNNER_TEMP": str(runner_temp),
+            "GITHUB_OUTPUT": str(github_output),
+            "PATH": f"{fake_bin}:{os.environ['PATH']}",
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
 
     assert result.returncode == 0, result.stdout + result.stderr
-    assert "Full pytest suite: 2/2 targets" in result.stdout
-    assert arguments == ["develop", "--command", "uv", "run", "pytest", "-n", "auto"]
+    return {
+        key: value
+        for line in github_output.read_text(encoding="utf-8").splitlines()
+        for key, value in [line.split("=", maxsplit=1)]
+    }
+
+
+@pytest.mark.parametrize(
+    ("event_name", "plan", "expected_execution"),
+    [
+        ("pull_request", {"mode": "selected", "targets": ["tests/test_selected.py"]}, "selected"),
+        ("pull_request", {"mode": "all", "targets": []}, "full"),
+        ("push", {"mode": "selected", "targets": ["tests/test_selected.py"]}, "full"),
+        ("push", {"mode": "all", "targets": []}, "full"),
+    ],
+)
+def test_ci_test_plan_step_runs_selected_only_for_pr_selected_plans(
+    tmp_path: Path, event_name: str, plan: dict[str, object], expected_execution: str
+) -> None:
+    """main push と ALL plan の fail-safe が full lane を選ぶことを実行して固定する。"""
+    outputs = _run_ci_test_plan_step(tmp_path, event_name=event_name, plan=plan)
+
+    assert outputs["plan"] == json.dumps(plan)
+    assert outputs["execution"] == expected_execution
+
+
+def _run_verify_test_lanes_step(
+    *,
+    changes_result: str = "success",
+    python_changed: str = "true",
+    test_execution: str = "full",
+    selected_result: str = "skipped",
+    behavioral_result: str = "success",
+    repository_contract_result: str = "success",
+    slow_result: str = "success",
+) -> subprocess.CompletedProcess[str]:
+    steps = _load_workflow(_CI_WORKFLOW_PATH)["jobs"]["test"]["steps"]
+    run = _top_level_step(steps, "Verify test lanes")["run"]
+    return subprocess.run(
+        ["bash", "-c", run],
+        env=os.environ
+        | {
+            "CHANGES_RESULT": changes_result,
+            "PYTHON_CHANGED": python_changed,
+            "TEST_EXECUTION": test_execution,
+            "SELECTED_RESULT": selected_result,
+            "BEHAVIORAL_RESULT": behavioral_result,
+            "REPOSITORY_CONTRACT_RESULT": repository_contract_result,
+            "SLOW_RESULT": slow_result,
+        },
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"python_changed": "false", "test_execution": ""}, id="no-python"),
+        pytest.param(
+            {"test_execution": "selected", "selected_result": "success", "behavioral_result": "skipped"},
+            id="selected-pass",
+        ),
+        pytest.param({"test_execution": "full"}, id="full-pass"),
+    ],
+)
+def test_ci_test_gate_succeeds_only_when_every_applicable_lane_succeeded(overrides: dict[str, str]) -> None:
+    result = _run_verify_test_lanes_step(**overrides)
+
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        pytest.param({"changes_result": "failure", "python_changed": "", "test_execution": ""}, id="changes-failed"),
+        pytest.param(
+            {"changes_result": "cancelled", "python_changed": "", "test_execution": ""},
+            id="changes-cancelled",
+        ),
+        pytest.param({"test_execution": "selected", "selected_result": "failure"}, id="selected-failed"),
+        pytest.param({"test_execution": "full", "behavioral_result": "failure"}, id="behavioral-failed"),
+        pytest.param({"test_execution": "full", "repository_contract_result": "failure"}, id="contract-failed"),
+        pytest.param({"test_execution": "full", "slow_result": "failure"}, id="slow-failed"),
+        pytest.param({"test_execution": ""}, id="unknown-execution-mode"),
+    ],
+)
+def test_ci_test_gate_fails_when_a_lane_or_the_classifier_did_not_succeed(overrides: dict[str, str]) -> None:
+    result = _run_verify_test_lanes_step(**overrides)
+
+    assert result.returncode != 0, result.stdout + result.stderr
 
 
 def test_extensions_jobs_are_gated_by_their_changed_path_outputs() -> None:

--- a/tests/repo/test_pytest_lane_contract.py
+++ b/tests/repo/test_pytest_lane_contract.py
@@ -194,20 +194,24 @@ def test_slow_node_ids_reference_existing_modules_and_tests() -> None:
     assert collected == set(expected)
 
 
-def test_ci_main_push_and_fail_safe_run_full_suite_without_lane_filters() -> None:
+def test_ci_main_push_and_fail_safe_run_exhaustive_non_overlapping_lanes() -> None:
     workflow = (ROOT / ".github/workflows/ci.yml").read_text(encoding="utf-8")
 
     assert '[ "$EVENT_NAME" = "pull_request" ]' in workflow
-    assert '[ "$plan_mode" = "selected" ]' in workflow
-    assert "nix develop --command uv run pytest -n auto\n" in workflow
-    assert '-m "not repo_contract and not slow"' not in workflow
-    assert "-m repo_contract" not in workflow
+    assert '[ "$mode" = "selected" ]' in workflow
+    assert workflow.count('-m "not repo_contract and not slow"') == 1
+    assert workflow.count('-m "repo_contract and not slow"') == 1
+    assert workflow.count("-m slow") == 1
 
 
 def test_development_documents_each_pytest_lane_command() -> None:
     development = (ROOT / "docs/development.md").read_text(encoding="utf-8")
 
-    for expression in ('-m "not repo_contract and not slow"', "-m repo_contract", "-m slow"):
+    for expression in (
+        '-m "not repo_contract and not slow"',
+        '-m "repo_contract and not slow"',
+        "-m slow",
+    ):
         assert expression in development
 
 

--- a/tests/repo/test_release_notes_contract.py
+++ b/tests/repo/test_release_notes_contract.py
@@ -139,10 +139,20 @@ def test_release_note_rejects_nonexistent_tag(tmp_path: Path) -> None:
 
 def test_ci_python_test_checkout_fetches_full_tag_history() -> None:
     workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8"))
-    test_job = workflow["jobs"]["test"]
-    checkout = next(step for step in test_job["steps"] if str(step.get("uses", "")).startswith("actions/checkout@"))
+    test_jobs = (
+        "test-selected",
+        "test-behavioral",
+        "test-repository-contract",
+        "test-slow",
+    )
 
-    assert checkout["with"]["fetch-depth"] == 0
+    for job_name in test_jobs:
+        checkout = next(
+            step
+            for step in workflow["jobs"][job_name]["steps"]
+            if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
+        assert checkout["with"]["fetch-depth"] == 0, job_name
 
 
 def test_python_publish_orders_release_authoring_review_approval_and_pull_request() -> None:


### PR DESCRIPTION
## Summary

- full pytest を behavioral / repository contract / slow の排他的3 laneに分割し、required `test` job 内で並列実行
- PR の selected affected-test plan は従来どおり対象だけを1回実行
- workflow contract と lane contract を更新し、重複なし・全件網羅・required job維持を固定
- 開発ドキュメントへ CI lane 契約を追記

Closes #4860

## Testing

- `uv run --no-sync pytest tests/repo/test_actions_parallel_workflows.py tests/repo/test_pytest_lane_contract.py -q`
- `uv run --no-sync ruff check tests/repo/test_actions_parallel_workflows.py tests/repo/test_pytest_lane_contract.py`
- `uv run --no-sync ruff format --check tests/repo/test_actions_parallel_workflows.py tests/repo/test_pytest_lane_contract.py`
- `python .github/scripts/validate-changelog-fragments.py`
- `git diff --check`
