### PR TITLE
docs: ADR-0013 に registry 台帳化の Amendment を追記し dogfood を一般定義へ戻す (#4879)

### DIFF
--- a/changelog.d/4879-adr-0029-followup.changed.md
+++ b/changelog.d/4879-adr-0029-followup.changed.md
@@ -1,0 +1,3 @@
+- ADR-0013 に、channel registry が dashboard 専用の読み取りファイルから fan-out と channel export が共有する台帳へ広がる Amendment を追記した（#4879）。
+- 用語集の dogfood を撤回済み cutover 計画専用の定義から first-party での 1 周実走という一般定義へ戻した（#4879）。
+- ADR-0029 に逆移行手段・廃止の仕方の Considered Options と、workspace の達成事項・first-party 固有物・ディスク二重化の記述を補った（#4879）。

--- a/docs/adr/0013-multi-channel-dashboard.md
+++ b/docs/adr/0013-multi-channel-dashboard.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-accepted (2026-06-23)、amended (2026-07-21, #2386, #2397)。旧 2 フェーズ案を廃止し、本リポジトリ内で保守する単一構成へ置き換える。
+accepted (2026-06-23)、amended (2026-07-21, #2386, #2397)、amended (2026-09-03, #4879)。旧 2 フェーズ案を廃止し、本リポジトリ内で保守する単一構成へ置き換える。
 
 ## Context
 
@@ -71,3 +71,9 @@ accepted (2026-06-23)、amended (2026-07-21, #2386, #2397)。旧 2 フェーズ�
 
 - ADR-0021（tayk は別リポジトリ。dashboard 限定例外）
 - #2384 / #2385 / #2387 / #2397
+
+## Amendment: channel registry の台帳化（2026-09-03, #4879）
+
+ADR-0029 により、channel registry（`~/.config/tayk/channels.json`）は dashboard の表示対象を発見するための読み取り専用ファイルから、**dashboard の表示対象と fan-out（`yt-channels update`）の適格チャンネルの両方を列挙する台帳**へ役割が広がる。writer は `yt-channel-export`（戻し先の絶対パスを追加するだけで、既にあれば no-op）であり、dashboard は引き続き読むだけである。schema（絶対パス文字列の JSON 配列）、`list[Path]` を返す loader、チャンネル単位の部分エラー隔離は変えないため、dashboard 側の変更はない。
+
+registry へ属性を足す、dashboard から registry を書く、登録 UX を dashboard に持たせるといった提案は、本 ADR ではなく ADR-0029 側の論点として扱う。登録 UX の不在と `~/.config/tayk/` が tayk と共有される点は未解決のまま残る。

--- a/docs/adr/0029-return-to-single-channel-repos.md
+++ b/docs/adr/0029-return-to-single-channel-repos.md
@@ -18,6 +18,8 @@ ADR-0022 は運営者の 6 チャンネルを `channels/<slug>/` として 1 リ
 4. **「cutover までのつなぎ」という前提が撤回された。** ADR-0021 の Amendment（2026-09-01, #4779）で Python 版のメンテナンスモード純化と cutover は撤回され、本リポジトリはアクティブ開発を継続する。workspace は一時的な例外投資ではなく恒久構造になってしまい、上記 1・2 のコストを恒久に払うことになる。
 5. **重複コストには別解が立つ。** ADR-0022 の動機である sync / update の重複は、構造を同居させなくても「channel registry を回って各リポで同じ更新を 1 操作で実行する」fan-out で解消できる。「一元管理」を *置き場を 1 つにする* 意味から *操作を 1 回にする* 意味へ再定義する。
 
+workspace が達成したものは記録しておく。`yt-skills sync` / automation-update をチャンネル数分でなく 1 回にしたこと、git 管理対象をデータ 4 分類に忠実化して旧 6 リポジトリで約 4.7GB あった git 管理ファイルを管理外にしたこと、`--channel` を自チャンネルに予約して benchmark 系を `--competitor` に分けたことは、いずれも実現した。本 ADR はこのうち後ろ 2 つを維持し（§Decision 10）、前者だけを fan-out で置き換える。
+
 ## Decision
 
 1. **構造: 1 チャンネル = 1 リポジトリ = 1 cwd を正規形に戻す。** workspace 経路（`channels/<slug>/` の規約検出、`--channel` / `CHANNEL` によるチャンネル選択、`yt-channel-import`、`yt-workspace-guard`、`yt-workspace-status`）は deprecated とし、削除リリースで物理削除する。
@@ -57,6 +59,8 @@ ADR-0022 は運営者の 6 チャンネルを `channels/<slug>/` として 1 リ
 - **cloud runner**: cloud session は「チャンネルリポジトリに commit 済みの skills」を正とし、cloud 側では追従しない（`CI` で no-op）。hybrid cloud（#4070）の前提は変わらない
 - **移行期間**: workspace と独立リポジトリが併存し、dashboard には export 済みチャンネルが両方のパスで並ぶ。fan-out は workspace 内エントリを skip する
 - **git 履歴**: 001〜006ch は workspace 移行時に旧リポジトリの履歴を捨てており、今回さらに workspace の履歴も捨てる（2 度目）。復旧は Suno プレイリスト・YouTube・export 後の初回 commit を正とする
+- **first-party の workspace root 固有物**: `.claude/CLAUDE.local.md` / `settings.local.json` / `scripts/collect_reporting.sh` + launchd plist / 手書き `docs/*.md` は export の責務外であり、runbook の「手で持ち込む物の一覧」に従って手で持ち直す。同居運用のために生まれた物で、単一リポジトリ回帰で大半は不要になる
+- **ディスク**: export はメディアを含む `channels/<slug>/` の実体を丸ごと copy する（003ch は約 12GB）ため、workspace 側を残置する期間はチャンネル分のディスクを二重に使う。workspace 側の削除は独立リポジトリで 1 周確認した後に手で行う
 
 ## Considered Options
 
@@ -79,9 +83,21 @@ ADR-0022 は運営者の 6 チャンネルを `channels/<slug>/` として 1 リ
 1. **per-channel `pyproject` + `.venv` の維持（採用）** — skills 内 `uv run yt-*` 552 箇所と hook・cloud runner が無傷
 2. **`uv tool install` による global 化** — 552 箇所の書き換えと cloud 経路の再設計が必要で費用対効果が合わない
 
+### 逆移行の手段
+
+1. **`yt-channel-export`（copy + 検証、workspace 無変更）（採用）** — `yt-channel-import` と対称で、staging → 検証 → publish の idiom を流用できる。切り戻しは dest を消すだけ
+2. **archive 済み旧リポジトリの復活** — workspace 移行後の state / collections / reports が無く、履歴の継ぎ足しは 2 系統の履歴を混ぜる。007ch は旧リポジトリ自体が無い
+3. **手動 copy（runbook のみ）** — 7 回繰り返す手作業で symlink / auth / `.gitignore` の漏れが出る。external の workspace 利用者にも同じ手順を配る必要がある
+
+### 廃止の仕方
+
+1. **警告リリース → 削除リリースの 2 段（採用）** — semver 規則に従い、削除は 7 チャンネルの export 完了 + workspace archive をゲートにする
+2. **即削除** — first-party 7 チャンネルが export を終える前に経路が消え、external の workspace 利用者にも予告なしの breaking になる
+3. **恒久併存** — ADR-0022 が「全 CLI が 2 構造対応になり最悪」と退けた構造そのもの。Context 2 のコストを恒久に払う
+
 ## Related
 
-- ADR-0013（multi-channel dashboard — channel registry の由来）
+- ADR-0013（multi-channel dashboard — channel registry の由来。台帳化の Amendment は 2026-09-03, #4879）
 - ADR-0021 Amendment（メンテナンスモード撤回、2026-09-01）
 - ADR-0022（マルチチャンネル workspace — 本 ADR が supersede）
 - ADR-0024（クラウド移譲原則 — cloud は commit 済み skills を読む）

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,7 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 **cutover**: 撤回済みの計画で、first-party 下流の日常運用が tayk のみで回るようになった時点で Python 版のメンテナンスを終了するとしていたイベント。実施しない。
 
-**dogfood**: 撤回済みの cutover 判断のために計画していた受け入れ検証。first-party 2 リポジトリで各コレクション 1 本のフルライフサイクルを実走させ、期間ではなく完走で判定するとしていた。
+**dogfood**: first-party チャンネルで新機能や移行手順のフルライフサイクル 1 周を実走し、期間ではなく完走で受け入れを判定すること。ADR-0022 の workspace 移行と ADR-0029 の逆移行は、いずれも 1 チャンネルで dogfood してから残りへ広げる。撤回済みの cutover 計画では、first-party 2 リポジトリで各コレクション 1 本を実走する cutover 判断の受け入れ検証を同じ語で指していた。
 
 **critical regression**: 撤回済みの計画で cutover をブロックする欠陥として定義していた区分。誤公開・誤メタデータ、analytics 履歴または collection 成果物のデータ破壊、auth 破壊の 3 種に限る。
 


### PR DESCRIPTION
## 概要

ADR-0029（#4891）起草時の grilling 合意から漏れていた点を補う docs のみの PR。#4879 の補遺。

- **ADR-0013 Amendment**: channel registry は dashboard 専用の読み取りファイルから、fan-out（`yt-channels update`）の適格チャンネル列挙と `yt-channel-export` の書き込みを受ける台帳へ役割が広がる。schema / loader / 部分エラー隔離は不変
- **用語集 dogfood**: 「撤回済みの cutover 判断用の検証」から「first-party で 1 周実走して完走で判定する」一般定義へ戻す（ADR-0029 本文が「dogfood 対象」と使っており矛盾していた）
- **ADR-0029 補筆**: Considered Options に「逆移行の手段」「廃止の仕方」の 2 軸、Context に workspace の達成事項、Consequences に first-party 固有物の持ち直しとディスク二重化

## 検証

- `python .github/scripts/validate-changelog-fragments.py` → valid
- `pytest tests/repo/test_skill_docs_consistency.py tests/repo/test_site_repository_contract.py tests/repo/test_b6_integration_contract.py` → 102 passed

Closes なし（#4879 は close 済み。補遺としてコメントでリンク）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
