### PR TITLE
feat(suno): Studio Multitrack ZIPを受理する (#4922)

### DIFF
--- a/changelog.d/4922-studio-multitrack-zip.added.md
+++ b/changelog.d/4922-studio-multitrack-zip.added.md
@@ -1,0 +1,1 @@
+- Suno Studio Multitrack ZIP の数字 prefix 付き WAV を曲名へ照合し、同一 entry のトラックを a / b variant へ順番に配置できるようにした（#4922）。

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -19,6 +19,7 @@ from youtube_automation.domains.suno.downloaded.models import (
 from youtube_automation.domains.suno.name_matching import (
     SunoNameIndex,
     split_suno_duplicate_stem,
+    split_suno_studio_track_prefix,
     suno_name_lookup_candidates,
 )
 
@@ -110,16 +111,17 @@ _OUTPUT_STEM_SEPARATOR_RE = re.compile(r"[\\/]+")
 _OUTPUT_STEM_SPACE_RE = re.compile(r"\s+")
 
 
-def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str]]:
+def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str, int | None]]:
     member_path = PurePosixPath(filename)
     relative_stem = member_path.with_suffix("").as_posix()
     raw_stems = [relative_stem, member_path.stem]
-    deduped: list[tuple[str, str]] = []
+    deduped: list[tuple[str, str, int | None]] = []
     for raw_stem in raw_stems:
         stem, duplicate_number = split_suno_duplicate_stem(raw_stem)
+        _, studio_track_number = split_suno_studio_track_prefix(stem)
         variant = "b" if duplicate_number == 1 else "a"
         for candidate in suno_name_lookup_candidates(stem):
-            item = (candidate, variant)
+            item = (candidate, variant, studio_track_number if duplicate_number == 0 else None)
             if item not in deduped:
                 deduped.append(item)
     return deduped
@@ -271,23 +273,54 @@ def _extract_and_rename_music_to_dir(
             audio_infos = [
                 info for info in infos if not info.is_dir() and Path(info.filename).suffix.lower() in _AUDIO_EXTENSIONS
             ]
-            extracted_audio: list[tuple[Path, str, int, str]] = []
-            for info in audio_infos:
+            extracted_audio: list[tuple[Path, str, int, str, int | None, int]] = []
+            for archive_order, info in enumerate(audio_infos):
                 if not _is_safe_zip_member(info.filename):
                     print(f"[yt-collection-serve] 危険な ZIP entry をスキップします: {info.filename}")
                     continue
                 extracted_path = Path(zf.extract(info, tmp_dir))
                 lookup_candidates = _zip_member_lookup_candidates(info.filename)
-                resolved = name_index.resolve_with_candidate(candidate for candidate, _ in lookup_candidates)
+                resolved = name_index.resolve_with_candidate(candidate for candidate, _, _ in lookup_candidates)
                 if resolved is None:
                     print(f"[yt-collection-serve] prompts に未対応の音声ファイルをスキップします: {info.filename}")
                     continue
                 track_num, lookup = resolved
-                variant = next(value for candidate, value in lookup_candidates if candidate == lookup)
-                extracted_audio.append((extracted_path, lookup, track_num, variant))
+                variant, studio_track_number = next(
+                    (variant, studio_track_number)
+                    for candidate, variant, studio_track_number in lookup_candidates
+                    if candidate == lookup
+                )
+                extracted_audio.append((extracted_path, lookup, track_num, variant, studio_track_number, archive_order))
+
+        studio_matches: dict[int, list[tuple[int, int, int]]] = {}
+        occupied_variants: dict[int, set[str]] = {}
+        for index, (_, _, track_num, variant, studio_track_number, archive_order) in enumerate(extracted_audio):
+            if studio_track_number is None:
+                occupied_variants.setdefault(track_num, set()).add(variant)
+            else:
+                studio_matches.setdefault(track_num, []).append((studio_track_number, archive_order, index))
+        for track_num, matches in studio_matches.items():
+            matches.sort()
+            free_variants = [
+                variant for variant in ("a", "b") if variant not in occupied_variants.get(track_num, set())
+            ]
+            if len(matches) > len(free_variants):
+                paths = [extracted_audio[index][0] for _, _, index in matches]
+                names = ", ".join(path.name for path in paths)
+                raise ValueError(f"entry {track_num:02d} matched more files than variants (a/b): {names}")
+            for (_, _, index), variant in zip(matches, free_variants, strict=False):
+                extracted_path, lookup, _, _, studio_track_number, archive_order = extracted_audio[index]
+                extracted_audio[index] = (
+                    extracted_path,
+                    lookup,
+                    track_num,
+                    variant,
+                    studio_track_number,
+                    archive_order,
+                )
 
         moved_count = 0
-        for extracted, lookup, track_num, variant in extracted_audio:
+        for extracted, lookup, track_num, variant, _, _ in extracted_audio:
             if not extracted.is_file():
                 print(f"[yt-collection-serve] ZIP entry の展開結果が見つかりません: {extracted}")
                 continue

--- a/src/youtube_automation/domains/suno/downloaded/archive.py
+++ b/src/youtube_automation/domains/suno/downloaded/archive.py
@@ -20,6 +20,7 @@ from youtube_automation.domains.suno.name_matching import (
     SunoNameIndex,
     split_suno_duplicate_stem,
     split_suno_studio_track_prefix,
+    suno_filename_lookup_candidates,
     suno_name_lookup_candidates,
 )
 
@@ -33,6 +34,18 @@ _ZIP_MAX_ENTRIES = 1000
 class DownloadedArchiveResult:
     audio_count: int
     placed_count: int
+
+
+@dataclass(slots=True)
+class _ExtractedAudio:
+    """ZIP から展開した 1 メンバーの配置先。`variant` だけが Studio トラック順の割当で書き換わる。"""
+
+    path: Path
+    lookup: str
+    track_num: int
+    variant: str
+    studio_track_number: int | None
+    archive_order: int
 
 
 def count_audio_files(music_dir: Path) -> int:
@@ -111,6 +124,14 @@ _OUTPUT_STEM_SEPARATOR_RE = re.compile(r"[\\/]+")
 _OUTPUT_STEM_SPACE_RE = re.compile(r"\s+")
 
 
+def _studio_track_prefix_aliases(stem: str) -> tuple[frozenset[str], int | None]:
+    """Studio の数字 prefix を剥がしてはじめて得られる候補と、そのトラック番号を返す。"""
+    base, studio_track_number = split_suno_studio_track_prefix(stem)
+    if studio_track_number is None:
+        return frozenset(), None
+    return frozenset(suno_name_lookup_candidates(base)), studio_track_number
+
+
 def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str, int | None]]:
     member_path = PurePosixPath(filename)
     relative_stem = member_path.with_suffix("").as_posix()
@@ -118,13 +139,22 @@ def _zip_member_lookup_candidates(filename: str) -> list[tuple[str, str, int | N
     deduped: list[tuple[str, str, int | None]] = []
     for raw_stem in raw_stems:
         stem, duplicate_number = split_suno_duplicate_stem(raw_stem)
-        _, studio_track_number = split_suno_studio_track_prefix(stem)
+        studio_aliases, studio_track_number = _studio_track_prefix_aliases(stem)
         variant = "b" if duplicate_number == 1 else "a"
-        for candidate in suno_name_lookup_candidates(stem):
-            item = (candidate, variant, studio_track_number if duplicate_number == 0 else None)
+        for candidate in suno_filename_lookup_candidates(stem):
+            # prefix を剥がしてはじめて照合できた候補だけを Studio トラックとして扱う。
+            # 数字始まりの曲名が prefix なしで一致した場合は既存どおり重複連番で variant を決める
+            is_studio_alias = candidate in studio_aliases and duplicate_number == 0
+            item = (candidate, variant, studio_track_number if is_studio_alias else None)
             if item not in deduped:
                 deduped.append(item)
     return deduped
+
+
+def _studio_track_sort_key(item: _ExtractedAudio) -> tuple[int, int]:
+    """Studio トラック番号を数値昇順に、同番号は ZIP 内の出現順に並べる。"""
+    track_number = item.studio_track_number
+    return (-1 if track_number is None else track_number, item.archive_order)
 
 
 def _sanitize_output_stem(stem: str) -> str:
@@ -162,15 +192,20 @@ def _build_name_to_index(coll_dir: Path, prompt_entries_reader: PromptEntriesRea
     return SunoNameIndex.build(alias_groups)
 
 
-def _music_stem_lookup_candidates(stem: str) -> list[tuple[str, int]]:
-    """非正準形 stem から (照合候補, 重複連番) を列挙する。重複連番 0 は suffix なしの基準ファイル。"""
-    candidates: list[tuple[str, int]] = []
-    for candidate in suno_name_lookup_candidates(stem):
-        candidates.append((candidate, 0))
+def _music_stem_lookup_candidates(stem: str) -> list[tuple[str, int, int | None]]:
+    """非正準形 stem から (照合候補, 重複連番, Studio トラック番号) を列挙する。
+
+    重複連番 0 は suffix なしの基準ファイル。Studio トラック番号は数字 prefix を
+    剥がしてはじめて照合できた候補にだけ付き、ZIP 経路と同じ順序で variant を決めるために使う。
+    """
+    candidates: list[tuple[str, int, int | None]] = []
+    studio_aliases, studio_track_number = _studio_track_prefix_aliases(stem)
+    for candidate in suno_filename_lookup_candidates(stem):
+        candidates.append((candidate, 0, studio_track_number if candidate in studio_aliases else None))
     base, dup_no = split_suno_duplicate_stem(stem)
     if dup_no:
         for candidate in suno_name_lookup_candidates(base):
-            item = (candidate, dup_no)
+            item = (candidate, dup_no, None)
             if item not in candidates:
                 candidates.append(item)
     return candidates
@@ -193,7 +228,9 @@ def canonicalize_noncanonical_music_files(
         return []
 
     occupied_variants: dict[int, set[str]] = {}
-    matched_files: dict[int, list[tuple[int, str, Path, str]]] = {}
+    # ソートキーは (重複連番, Studio トラック番号, ファイル名)。Studio トラック番号は数値で比較するため
+    # `2 Title.wav` と `10 Title.wav` がファイル名の辞書順で逆転しない。prefix なしは -1 で先頭に置く
+    matched_files: dict[int, list[tuple[int, int, str, Path, str]]] = {}
     for audio_path in sorted(music_dir.iterdir()):
         if not audio_path.is_file() or audio_path.suffix.lower() not in _AUDIO_EXTENSIONS:
             continue
@@ -204,11 +241,14 @@ def canonicalize_noncanonical_music_files(
             )
             continue
         lookup_candidates = _music_stem_lookup_candidates(audio_path.stem)
-        resolved = name_index.resolve_with_candidate(candidate for candidate, _ in lookup_candidates)
+        resolved = name_index.resolve_with_candidate(candidate for candidate, _, _ in lookup_candidates)
         if resolved is not None:
             track_num, lookup = resolved
-            dup_no = next(number for candidate, number in lookup_candidates if candidate == lookup)
-            matched_files.setdefault(track_num, []).append((dup_no, audio_path.name, audio_path, lookup))
+            dup_no, studio_track_number = next(
+                (number, studio) for candidate, number, studio in lookup_candidates if candidate == lookup
+            )
+            track_order = -1 if studio_track_number is None else studio_track_number
+            matched_files.setdefault(track_num, []).append((dup_no, track_order, audio_path.name, audio_path, lookup))
 
     renames: list[tuple[Path, Path]] = []
     planned_dests: set[str] = set()
@@ -216,11 +256,11 @@ def canonicalize_noncanonical_music_files(
         files.sort()
         free_variants = [v for v in ("a", "b") if v not in occupied_variants.get(track_num, set())]
         if len(files) > len(free_variants):
-            names = ", ".join(name for _, name, _, _ in files)
+            names = ", ".join(name for _, _, name, _, _ in files)
             raise ValueError(
                 f"entry {track_num:02d} へ照合されたファイルが variant (a/b) の空きを超えています: {names}"
             )
-        for (_, _, audio_path, lookup), variant in zip(files, free_variants, strict=False):
+        for (_, _, _, audio_path, lookup), variant in zip(files, free_variants, strict=False):
             new_name = f"{track_num:02d}{variant}-{_sanitize_output_stem(lookup)}{audio_path.suffix.lower()}"
             dest = music_dir / new_name
             if dest.exists() or new_name in planned_dests:
@@ -273,7 +313,7 @@ def _extract_and_rename_music_to_dir(
             audio_infos = [
                 info for info in infos if not info.is_dir() and Path(info.filename).suffix.lower() in _AUDIO_EXTENSIONS
             ]
-            extracted_audio: list[tuple[Path, str, int, str, int | None, int]] = []
+            extracted_audio: list[_ExtractedAudio] = []
             for archive_order, info in enumerate(audio_infos):
                 if not _is_safe_zip_member(info.filename):
                     print(f"[yt-collection-serve] 危険な ZIP entry をスキップします: {info.filename}")
@@ -290,48 +330,49 @@ def _extract_and_rename_music_to_dir(
                     for candidate, variant, studio_track_number in lookup_candidates
                     if candidate == lookup
                 )
-                extracted_audio.append((extracted_path, lookup, track_num, variant, studio_track_number, archive_order))
+                extracted_audio.append(
+                    _ExtractedAudio(
+                        path=extracted_path,
+                        lookup=lookup,
+                        track_num=track_num,
+                        variant=variant,
+                        studio_track_number=studio_track_number,
+                        archive_order=archive_order,
+                    )
+                )
 
-        studio_matches: dict[int, list[tuple[int, int, int]]] = {}
+        studio_matches: dict[int, list[_ExtractedAudio]] = {}
         occupied_variants: dict[int, set[str]] = {}
-        for index, (_, _, track_num, variant, studio_track_number, archive_order) in enumerate(extracted_audio):
-            if studio_track_number is None:
-                occupied_variants.setdefault(track_num, set()).add(variant)
+        for item in extracted_audio:
+            if item.studio_track_number is None:
+                occupied_variants.setdefault(item.track_num, set()).add(item.variant)
             else:
-                studio_matches.setdefault(track_num, []).append((studio_track_number, archive_order, index))
+                studio_matches.setdefault(item.track_num, []).append(item)
         for track_num, matches in studio_matches.items():
-            matches.sort()
+            # Studio のトラック番号は数値で昇順に並べる。同番号は ZIP 内の出現順で決める
+            matches.sort(key=_studio_track_sort_key)
             free_variants = [
                 variant for variant in ("a", "b") if variant not in occupied_variants.get(track_num, set())
             ]
             if len(matches) > len(free_variants):
-                paths = [extracted_audio[index][0] for _, _, index in matches]
-                names = ", ".join(path.name for path in paths)
+                names = ", ".join(item.path.name for item in matches)
                 raise ValueError(f"entry {track_num:02d} matched more files than variants (a/b): {names}")
-            for (_, _, index), variant in zip(matches, free_variants, strict=False):
-                extracted_path, lookup, _, _, studio_track_number, archive_order = extracted_audio[index]
-                extracted_audio[index] = (
-                    extracted_path,
-                    lookup,
-                    track_num,
-                    variant,
-                    studio_track_number,
-                    archive_order,
-                )
+            for item, variant in zip(matches, free_variants, strict=False):
+                item.variant = variant
 
         moved_count = 0
-        for extracted, lookup, track_num, variant, _, _ in extracted_audio:
-            if not extracted.is_file():
-                print(f"[yt-collection-serve] ZIP entry の展開結果が見つかりません: {extracted}")
+        for item in extracted_audio:
+            if not item.path.is_file():
+                print(f"[yt-collection-serve] ZIP entry の展開結果が見つかりません: {item.path}")
                 continue
-            ext = extracted.suffix.lower()
+            ext = item.path.suffix.lower()
             if ext not in _AUDIO_EXTENSIONS:
                 continue
-            new_name = f"{track_num:02d}{variant}-{_sanitize_output_stem(lookup)}{ext}"
+            new_name = f"{item.track_num:02d}{item.variant}-{_sanitize_output_stem(item.lookup)}{ext}"
             dest = target_dir / new_name
             if dest.exists():
                 raise ValueError(f"ZIP extraction output name collision: {dest.name}")
-            shutil.move(str(extracted), str(dest))
+            shutil.move(str(item.path), str(dest))
             moved_count += 1
 
         print(f"[yt-collection-serve] 展開完了: {moved_count} files → {target_dir}")

--- a/src/youtube_automation/domains/suno/name_matching.py
+++ b/src/youtube_automation/domains/suno/name_matching.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TypeVar
 
 _SUNO_TRACK_PREFIX_RE = re.compile(r"^Track\s+\d+\s+(.+)$", re.IGNORECASE)
+_SUNO_STUDIO_TRACK_PREFIX_RE = re.compile(r"^(?P<track_number>\d+)\s+(?P<title>.+)$")
 _LATIN_TITLE_TAIL_RE = re.compile(r"([A-Za-z][A-Za-z0-9 &'(),.!?:/-]*)$")
 _DUP_SUFFIX_RE = re.compile(r"^(?P<base>.+?)(?:\s*\((?P<paren>\d+)\)|_(?P<underscore>\d+))$")
 
@@ -33,8 +34,12 @@ def normalize_suno_name_for_lookup(value: str) -> str:
 
 def suno_name_lookup_candidates(name: str) -> tuple[str, ...]:
     """Return full and derived aliases in most-specific-first order."""
-    prefix_match = _SUNO_TRACK_PREFIX_RE.match(name.strip())
-    base = prefix_match.group(1).strip() if prefix_match is not None else name.strip()
+    stripped_name = name.strip()
+    prefix_match = _SUNO_TRACK_PREFIX_RE.match(stripped_name)
+    if prefix_match is not None:
+        base = prefix_match.group(1).strip()
+    else:
+        base, _ = split_suno_studio_track_prefix(stripped_name)
     candidates = [base]
     dash_positions = [index for index, char in enumerate(base) if unicodedata.category(char) == "Pd"]
     candidates.extend(base[index + 1 :].strip() for index in dash_positions)
@@ -42,6 +47,15 @@ def suno_name_lookup_candidates(name: str) -> tuple[str, ...]:
     if tail_match is not None:
         candidates.append(tail_match.group(1).strip())
     return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
+def split_suno_studio_track_prefix(stem: str) -> tuple[str, int | None]:
+    """Split Studio Multitrack's ``<track number> <title>`` prefix."""
+    stripped_stem = stem.strip()
+    match = _SUNO_STUDIO_TRACK_PREFIX_RE.match(stripped_stem)
+    if match is None:
+        return stripped_stem, None
+    return match.group("title").strip(), int(match.group("track_number"))
 
 
 def split_suno_duplicate_stem(stem: str) -> tuple[str, int]:

--- a/src/youtube_automation/domains/suno/name_matching.py
+++ b/src/youtube_automation/domains/suno/name_matching.py
@@ -33,13 +33,16 @@ def normalize_suno_name_for_lookup(value: str) -> str:
 
 
 def suno_name_lookup_candidates(name: str) -> tuple[str, ...]:
-    """Return full and derived aliases in most-specific-first order."""
+    """Return full and derived aliases in most-specific-first order.
+
+    Both prompt names and downloaded filename stems flow through here, so this
+    only strips conventions that never occur inside a real song title.  Filename
+    conventions that a title could legitimately start with belong to
+    :func:`suno_filename_lookup_candidates`.
+    """
     stripped_name = name.strip()
     prefix_match = _SUNO_TRACK_PREFIX_RE.match(stripped_name)
-    if prefix_match is not None:
-        base = prefix_match.group(1).strip()
-    else:
-        base, _ = split_suno_studio_track_prefix(stripped_name)
+    base = prefix_match.group(1).strip() if prefix_match is not None else stripped_name
     candidates = [base]
     dash_positions = [index for index, char in enumerate(base) if unicodedata.category(char) == "Pd"]
     candidates.extend(base[index + 1 :].strip() for index in dash_positions)
@@ -49,8 +52,27 @@ def suno_name_lookup_candidates(name: str) -> tuple[str, ...]:
     return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 
+def suno_filename_lookup_candidates(stem: str) -> tuple[str, ...]:
+    """Return lookup candidates for a downloaded audio filename stem.
+
+    Studio Multitrack members carry a ``<track number> `` prefix that is not part
+    of the prompt name.  The unstripped stem stays first so a title that itself
+    begins with a number (``3 AM``) keeps matching its own entry, and the
+    stripped aliases only act as a fallback.
+    """
+    candidates = list(suno_name_lookup_candidates(stem))
+    base, track_number = split_suno_studio_track_prefix(stem)
+    if track_number is not None:
+        candidates.extend(suno_name_lookup_candidates(base))
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
 def split_suno_studio_track_prefix(stem: str) -> tuple[str, int | None]:
-    """Split Studio Multitrack's ``<track number> <title>`` prefix."""
+    """Split a filename stem's Studio Multitrack ``<track number> <title>`` prefix.
+
+    Only ever call this on filename stems: prompt names may legitimately start
+    with ``<number> `` and must keep their prefix.
+    """
     stripped_stem = stem.strip()
     match = _SUNO_STUDIO_TRACK_PREFIX_RE.match(stripped_stem)
     if match is None:

--- a/src/youtube_automation/domains/suno/name_matching.py
+++ b/src/youtube_automation/domains/suno/name_matching.py
@@ -60,10 +60,13 @@ def suno_filename_lookup_candidates(stem: str) -> tuple[str, ...]:
     begins with a number (``3 AM``) keeps matching its own entry, and the
     stripped aliases only act as a fallback.
     """
-    candidates = list(suno_name_lookup_candidates(stem))
+    stem_candidates = suno_name_lookup_candidates(stem)
     base, track_number = split_suno_studio_track_prefix(stem)
-    if track_number is not None:
-        candidates.extend(suno_name_lookup_candidates(base))
+    if track_number is None:
+        return stem_candidates
+
+    base_candidates = suno_name_lookup_candidates(base)
+    candidates = [stem_candidates[0], *base_candidates, *stem_candidates[1:]]
     return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
 
 

--- a/tests/domains/suno/downloaded/test_archive.py
+++ b/tests/domains/suno/downloaded/test_archive.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import zipfile
 from pathlib import Path
 
+import pytest
+
 from youtube_automation.domains.suno.downloaded.archive import extract_and_rename_music
+from youtube_automation.domains.suno.downloaded.models import DownloadedArtifactError
 
 
 def test_extract_reconciles_suno_zip_name_variations(tmp_path: Path) -> None:
@@ -46,3 +49,86 @@ def test_extract_reconciles_suno_zip_name_variations(tmp_path: Path) -> None:
         "03a-Ordinary Light.mp3": b"plain-a",
         "03b-Ordinary Light.mp3": b"parenthesized-b",
     }
+
+
+def test_extract_matches_studio_track_number_prefixes(tmp_path: Path) -> None:
+    """Given Studio Multitrack ZIP の数字 prefix 付き WAV
+    When prompts と照合して展開する
+    Then 数字 prefix を除いた曲名で entry へ配置する。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [
+        {"name": "灰色のまま五時"},
+        {"name": "朝の目覚め — bgm-wakeup"},
+    ]
+    archive = tmp_path / "studio.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("0 灰色のまま五時.wav", b"japanese")
+        zipped.writestr("1 bgm-wakeup.wav", b"latin")
+
+    placed_count = extract_and_rename_music(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=lambda _collection_dir: entries,
+    )
+
+    music_dir = tmp_path / "02-Individual-music"
+    assert placed_count == 2
+    assert {path.name: path.read_bytes() for path in music_dir.iterdir()} == {
+        "01a-灰色のまま五時.wav": b"japanese",
+        "02a-bgm-wakeup.wav": b"latin",
+    }
+
+
+def test_extract_assigns_same_entry_studio_tracks_to_variants_in_order(tmp_path: Path) -> None:
+    """Given 同一曲名を持つ Studio の 2 トラック
+    When prompts と照合して展開する
+    Then トラック順に a / b variant へ配置する。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [{"name": "灰色のまま五時"}]
+    archive = tmp_path / "studio.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("2 灰色のまま五時.wav", b"first-track")
+        zipped.writestr("3 灰色のまま五時.wav", b"second-track")
+
+    placed_count = extract_and_rename_music(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=lambda _collection_dir: entries,
+    )
+
+    music_dir = tmp_path / "02-Individual-music"
+    assert placed_count == 2
+    assert {path.name: path.read_bytes() for path in music_dir.iterdir()} == {
+        "01a-灰色のまま五時.wav": b"first-track",
+        "01b-灰色のまま五時.wav": b"second-track",
+    }
+
+
+def test_extract_rejects_studio_tracks_exceeding_entry_variants_without_partial_placement(tmp_path: Path) -> None:
+    """Given 同一曲名を持つ Studio の 3 トラック
+    When prompts と照合して展開する
+    Then variant 上限エラーになり music dir を部分更新しない。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [{"name": "灰色のまま五時"}]
+    archive = tmp_path / "studio.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        for track_number in range(3):
+            zipped.writestr(f"{track_number} 灰色のまま五時.wav", str(track_number).encode())
+
+    with pytest.raises(DownloadedArtifactError, match=r"more files than variants \(a/b\)"):
+        extract_and_rename_music(
+            tmp_path,
+            str(archive),
+            prompt_entries_reader=lambda _collection_dir: entries,
+        )
+
+    assert not (tmp_path / "02-Individual-music").exists()

--- a/tests/domains/suno/downloaded/test_archive.py
+++ b/tests/domains/suno/downloaded/test_archive.py
@@ -132,3 +132,59 @@ def test_extract_rejects_studio_tracks_exceeding_entry_variants_without_partial_
         )
 
     assert not (tmp_path / "02-Individual-music").exists()
+
+
+def test_extract_keeps_numeric_leading_titles_matching_their_own_entry(tmp_path: Path) -> None:
+    """Given 数字始まりの曲名 entry と、その残りに一致する別 entry がある Download all ZIP
+    When prompts と照合して展開する
+    Then 数字 prefix を Studio トラック番号と誤認せず、各ファイルを自分の entry へ配置する。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [{"name": "3 AM"}, {"name": "AM"}]
+    archive = tmp_path / "download.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("3 AM.mp3", b"three-am")
+        zipped.writestr("AM.mp3", b"am")
+
+    placed_count = extract_and_rename_music(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=lambda _collection_dir: entries,
+    )
+
+    music_dir = tmp_path / "02-Individual-music"
+    assert placed_count == 2
+    assert {path.name: path.read_bytes() for path in music_dir.iterdir()} == {
+        "01a-3 AM.mp3": b"three-am",
+        "02a-AM.mp3": b"am",
+    }
+
+
+def test_extract_orders_studio_tracks_by_numeric_track_number(tmp_path: Path) -> None:
+    """Given 同一曲名を持つ Studio のトラック 2 と 10
+    When prompts と照合して展開する
+    Then ファイル名の辞書順ではなくトラック番号の昇順で a / b variant へ配置する。
+    """
+    prompts_dir = tmp_path / "20-documentation"
+    prompts_dir.mkdir()
+    (prompts_dir / "suno-prompts.json").write_text("[]", encoding="utf-8")
+    entries = [{"name": "灰色のまま五時"}]
+    archive = tmp_path / "studio.zip"
+    with zipfile.ZipFile(archive, "w") as zipped:
+        zipped.writestr("10 灰色のまま五時.wav", b"track-10")
+        zipped.writestr("2 灰色のまま五時.wav", b"track-2")
+
+    placed_count = extract_and_rename_music(
+        tmp_path,
+        str(archive),
+        prompt_entries_reader=lambda _collection_dir: entries,
+    )
+
+    music_dir = tmp_path / "02-Individual-music"
+    assert placed_count == 2
+    assert {path.name: path.read_bytes() for path in music_dir.iterdir()} == {
+        "01a-灰色のまま五時.wav": b"track-2",
+        "01b-灰色のまま五時.wav": b"track-10",
+    }

--- a/tests/domains/suno/test_suno_playlist_verification.py
+++ b/tests/domains/suno/test_suno_playlist_verification.py
@@ -749,6 +749,45 @@ def test_cli_renames_studio_track_number_prefix_before_verification(tmp_path, mo
     assert f"RENAMED: 0 {entry}.wav -> 01a-{entry}.wav" in err
 
 
+def test_cli_orders_studio_track_number_prefixes_numerically(tmp_path, monkeypatch, capsys):
+    """Given 同一 entry の Studio トラック 2 と 10 が music directory にある
+    When --music-dir で CLI main を実行する
+    Then ファイル名の辞書順ではなくトラック番号の昇順で a / b variant へリネームする。
+    """
+    entry = "灰色のまま五時"
+    _write_prompts_json(tmp_path, [entry])
+    music_dir = tmp_path / "02-Individual-music"
+    music_dir.mkdir()
+    (music_dir / f"10 {entry}.wav").touch()
+    (music_dir / f"2 {entry}.wav").touch()
+
+    code, out, err = _run_cli(monkeypatch, capsys, [str(tmp_path), "--music-dir", str(music_dir)])
+
+    assert code == 0
+    assert f"{entry}: 2 clip(s)" in out
+    assert f"RENAMED: 2 {entry}.wav -> 01a-{entry}.wav" in err
+    assert f"RENAMED: 10 {entry}.wav -> 01b-{entry}.wav" in err
+
+
+def test_cli_keeps_numeric_leading_title_intact(tmp_path, monkeypatch, capsys):
+    """Given 数字始まりの曲名 entry と、その 2 clip の非正準形ファイルがある
+    When --music-dir で CLI main を実行する
+    Then 数字 prefix を Studio トラック番号と誤認せず曲名を保ったままリネームする。
+    """
+    _write_prompts_json(tmp_path, ["3 AM"])
+    music_dir = tmp_path / "02-Individual-music"
+    music_dir.mkdir()
+    (music_dir / "3 AM.mp3").touch()
+    (music_dir / "3 AM (1).mp3").touch()
+
+    code, out, err = _run_cli(monkeypatch, capsys, [str(tmp_path), "--music-dir", str(music_dir)])
+
+    assert code == 0
+    assert "3 AM: 2 clip(s)" in out
+    assert "RENAMED: 3 AM.mp3 -> 01a-3 AM.mp3" in err
+    assert "RENAMED: 3 AM (1).mp3 -> 01b-3 AM.mp3" in err
+
+
 def test_cli_renames_noncanonical_file_into_free_variant_next_to_canonical_clip(tmp_path, monkeypatch, capsys):
     """Given 正準形 a variant が既にあり、同一 entry の非正準形ファイルが 1 件ある
     When --music-dir で CLI main を実行する

--- a/tests/domains/suno/test_suno_playlist_verification.py
+++ b/tests/domains/suno/test_suno_playlist_verification.py
@@ -729,6 +729,26 @@ def test_cli_renames_noncanonical_duplicate_basenames_before_verification(
     assert f"RENAMED: {duplicate_name} -> 01b-Dim the Lights.mp3" in err
 
 
+def test_cli_renames_studio_track_number_prefix_before_verification(tmp_path, monkeypatch, capsys):
+    """Given Studio 由来の数字 prefix 付きファイルが music directory にある
+    When --music-dir で CLI main を実行する
+    Then 数字 prefix を除いた曲名で照合し空いている正準 variant へリネームする。
+    """
+    entry = "灰色のまま五時"
+    _write_prompts_json(tmp_path, [entry])
+    music_dir = tmp_path / "02-Individual-music"
+    music_dir.mkdir()
+    (music_dir / f"01b-{entry}.wav").touch()
+    (music_dir / f"0 {entry}.wav").touch()
+
+    code, out, err = _run_cli(monkeypatch, capsys, [str(tmp_path), "--music-dir", str(music_dir)])
+
+    assert code == 0
+    assert f"{entry}: 2 clip(s)" in out
+    assert (music_dir / f"01a-{entry}.wav").is_file()
+    assert f"RENAMED: 0 {entry}.wav -> 01a-{entry}.wav" in err
+
+
 def test_cli_renames_noncanonical_file_into_free_variant_next_to_canonical_clip(tmp_path, monkeypatch, capsys):
     """Given 正準形 a variant が既にあり、同一 entry の非正準形ファイルが 1 件ある
     When --music-dir で CLI main を実行する


### PR DESCRIPTION
## 変更内容

- Studio Multitrack の `<トラック番号> <曲名>.wav` を曲名へ照合する
- 同一 entry の Studio トラックをトラック番号順に variant a / b へ配置する
- variant 超過時は部分配置せず `DownloadedArtifactError` にする
- 手動配置経路でも数字 prefix を正準名へ変換する

Closes #4922