### PR TITLE
feat: ダウンロード省略トグルを追加する (#4924)

### DIFF
--- a/.claude/skills/music/references/generate.md
+++ b/.claude/skills/music/references/generate.md
@@ -117,8 +117,9 @@ Chrome DevTools MCP は必須ではない。通常運用は browser use を prim
 6. `[data-suno-control="collection-select"]` で対象 collection を選ぶ。選択後、Playlist 名が表示されること、`data-suno-collection-id` が対象 id になることを確認する。
 7. 配信元または collection の選択後に自動取得が完了し、`role="status"` の live region が `N パターンを取得しました。` になること、`data-suno-entry-count` が 1 以上で `[data-suno-entry-list]` に entry 行が並ぶことを確認する。配信元候補は selector を開き、候補更新後に表示された対象を選択する。実行前に overlay 自体が更新されない場合だけページを再読み込みし、手順 3 からやり直す。
 8. 必要な entry だけを checkbox で残す。各行は `data-suno-entry-index` / `data-suno-entry-state` / `data-suno-entry-selected` を持つ。通常は全選択のままにする。
-9. preset を確認し、`[data-suno-control="run"]`（表示文言: 全パターンを連続実行 / 選択したN件を連続実行）を押す。
-10. 実行中は Suno タブを reload / close せず、overlay の `data-suno-phase` と `role="status"` を監視する。agent は `finished` / `stopped` / `error` の終端 phase まで待つ。非終端 phase が変化しない場合は下記「無限待機を避ける監視ルール」で判断する。
+9. `[data-suno-control="download-enabled"]` を確認する。既定 ON は Suno Studio・Premier が必要。Premier でない場合は OFF にし、playlist 追加で完了した後に Suno から手動取得して `02-Individual-music/` へ配置する。
+10. preset を確認し、`[data-suno-control="run"]`（表示文言: 全パターンを連続実行 / 選択したN件を連続実行）を押す。
+11. 実行中は Suno タブを reload / close せず、overlay の `data-suno-phase` と `role="status"` を監視する。agent は `finished` / `stopped` / `error` の終端 phase まで待つ。非終端 phase が変化しない場合は下記「無限待機を避ける監視ルール」で判断する。
 
 Chrome 拡張 popup が別ウィンドウとして開く環境でも、操作対象と確認項目は同じ。Suno タブ上に overlay が出る場合は overlay を優先し、popup しか使えない場合だけ同じラベル・ボタン文言で操作する。
 
@@ -132,9 +133,9 @@ uv run yt-suno-unattended-request \
   --collection-id <collection-id>
 ```
 
-必要な場合だけ `--entry-index`（0-based、複数可）、`--max-entries`、`--max-concurrent-generations`、`--max-retries` を上書きする。同じ collection の resume state があれば未完了 entry / playlist / download から再開し、1 run の上限を超えた entry は次回へ繰り越す。既存 playlist の clip ID が失われている場合は新規生成しない。
+必要な場合だけ `--entry-index`（0-based、複数可）、`--max-entries`、`--max-concurrent-generations`、`--max-retries` を上書きする。Premier でないアカウントでは `--skip-download` を付け、playlist URL の checkpoint で `completed` とした後に音源を手動取得・配置する。同じ collection の resume state があれば未完了 entry / playlist / download から再開し、1 run の上限を超えた entry は次回へ繰り越す。既存 playlist の clip ID が失われている場合は新規生成しない。
 
-ログイン、CAPTCHA、料金・credit 確認、Suno UI 非互換では `manual-intervention` を保存して停止する。Suno ページ root の `data-suno-unattended-collection-id` が対象と一致することを確認し、`data-suno-unattended-status` / `data-suno-unattended-checkpoint` / `data-suno-unattended-stop-reason` / `data-suno-unattended-required-action` を監視する。`manual-intervention` を検知した agent は自動クリックや追加購入で突破せず、人へ handoff する。完了判定は手動 flow と同じ Step 6 の 6 点であり、extension storage の `completed` だけでは `/music --master` へ進めない。
+ログイン、CAPTCHA、料金・credit 確認、Suno UI 非互換では `manual-intervention` を保存して停止する。Suno ページ root の `data-suno-unattended-collection-id` が対象と一致することを確認し、`data-suno-unattended-status` / `data-suno-unattended-checkpoint` / `data-suno-unattended-stop-reason` / `data-suno-unattended-required-action` を監視する。`manual-intervention` を検知した agent は自動クリックや追加購入で突破せず、人へ handoff する。通常の完了判定は手動 flow と同じ Step 6 の 6 点であり、extension storage の `completed` だけでは `/music --master` へ進めない。`--skip-download` の場合は playlist URL の checkpoint を完了条件とし、手動取得した音源を配置してから `/music --master` へ進む。
 
 ### Step 2. overlay / popup を開く
 
@@ -149,6 +150,7 @@ browser use で Suno タブを前面にし、拡張アイコンをクリック�
 | 自動取得 | 初回表示・配信元選択・collection 選択 | サーバーから prompts JSON を fetch。配信元候補は selector を開く操作で再検出し、更新完了後に選択肢を表示 |
 | 連続実行 | 実行時 | 開始 |
 | 停止 | 実行中のみ有効 | 任意中断 |
+| ダウンロードまで実行する | 任意 | 既定 ON。OFF は playlist 追加で完了し、Download から再開は表示しない |
 
 agent が優先して使う DOM signal:
 

--- a/.claude/skills/music/references/generate.md
+++ b/.claude/skills/music/references/generate.md
@@ -117,7 +117,7 @@ Chrome DevTools MCP は必須ではない。通常運用は browser use を prim
 6. `[data-suno-control="collection-select"]` で対象 collection を選ぶ。選択後、Playlist 名が表示されること、`data-suno-collection-id` が対象 id になることを確認する。
 7. 配信元または collection の選択後に自動取得が完了し、`role="status"` の live region が `N パターンを取得しました。` になること、`data-suno-entry-count` が 1 以上で `[data-suno-entry-list]` に entry 行が並ぶことを確認する。配信元候補は selector を開き、候補更新後に表示された対象を選択する。実行前に overlay 自体が更新されない場合だけページを再読み込みし、手順 3 からやり直す。
 8. 必要な entry だけを checkbox で残す。各行は `data-suno-entry-index` / `data-suno-entry-state` / `data-suno-entry-selected` を持つ。通常は全選択のままにする。
-9. `[data-suno-control="download-enabled"]` を確認する。既定 ON は Suno Studio・Premier が必要。Premier でない場合は OFF にし、playlist 追加で完了した後に Suno から手動取得して `02-Individual-music/` へ配置する。
+9. `[data-suno-control="download-enabled"]` を確認する。既定 ON は Suno Studio・Premier が必要。Premier でない場合は OFF にし、playlist 追加で完了した後に Suno から手動取得して `02-Individual-music/` へ配置する。この Switch は連続実行と再開に適用され、`[data-suno-control="download-only"]` の明示操作には適用されない。
 10. preset を確認し、`[data-suno-control="run"]`（表示文言: 全パターンを連続実行 / 選択したN件を連続実行）を押す。
 11. 実行中は Suno タブを reload / close せず、overlay の `data-suno-phase` と `role="status"` を監視する。agent は `finished` / `stopped` / `error` の終端 phase まで待つ。非終端 phase が変化しない場合は下記「無限待機を避ける監視ルール」で判断する。
 
@@ -151,6 +151,7 @@ browser use で Suno タブを前面にし、拡張アイコンをクリック�
 | 連続実行 | 実行時 | 開始 |
 | 停止 | 実行中のみ有効 | 任意中断 |
 | ダウンロードまで実行する | 任意 | 既定 ON。OFF は playlist 追加で完了し、Download から再開は表示しない |
+| ダウンロードのみ実行 | 任意 | Suno 上の選択中 clip を採用し、生成・playlist 追加をやり直さず Studio download を開始する。Switch が OFF でも実行可能 |
 
 agent が優先して使う DOM signal:
 

--- a/changelog.d/4924-download-toggle.added.md
+++ b/changelog.d/4924-download-toggle.added.md
@@ -1,0 +1,1 @@
+- suno-helper にダウンロード実行 Switch と unattended の `--skip-download` を追加し、Premier でないアカウントでも playlist 追加で完了できるようにした（#4924）。

--- a/changelog.d/4924-download-toggle.added.md
+++ b/changelog.d/4924-download-toggle.added.md
@@ -1,1 +1,1 @@
-- suno-helper にダウンロード実行 Switch と unattended の `--skip-download` を追加し、Premier でないアカウントでも playlist 追加で完了できるようにした（#4924）。
+- suno-helper にダウンロード実行 Switch、選択中 clip から Studio export だけを行うボタン、unattended の `--skip-download` を追加し、Premier でないアカウントでも playlist 追加で完了できるようにした（#4924）。

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -44,7 +44,8 @@ browser use から overlay を安定して観測できるよう、操作 panel �
 | `[data-suno-control="collection-queue-dismiss"]`                                                   | 停止・完了した collection queue の破棄操作                                                                |
 | `[data-suno-control="collection-queue-discard-confirmation"]`                                      | 停止中 queue のインライン破棄確認                                                                          |
 | `[data-suno-control="run"]` / `[data-suno-control="stop"]`                                         | 主要操作ボタン                                                                                            |
-| `[data-suno-control="notification-enabled"]`                                                     | OS 通知と固定音をまとめて切り替える shadcn Switch                                                        |
+| `[data-suno-control="notification-enabled"]`                                                       | OS 通知と固定音をまとめて切り替える shadcn Switch                                                        |
+| `[data-suno-control="download-enabled"]`                                                           | Suno Studio からの download 実行を切り替える shadcn Switch（既定 ON）                                    |
 | `[data-suno-control="resume"]` / `[data-suno-control="dismiss-resume"]`                            | 前回中断 resume バナーの再開 / 閉じる                                                                     |
 | `[data-suno-control="adopt-selected-clips"]`                                                       | Suno 上の選択中 clip を採用                                                                               |
 | `[data-suno-control="retry-playlist"]` / `[data-suno-control="retry-download"]`                    | playlist / download phase から再開                                                                        |
@@ -92,16 +93,16 @@ build 後は `.output/chrome-mv3/manifest.json`、zip 後は `.output/suno-helpe
    ```
 2. Chrome で Suno の **Advanced → More options を開く → Lyrics mode → Write** の順に選ぶ。prompt entry の `lyrics` が非空なら、`[Instrumental]` だけのインスト曲でも suno-helper が Lyrics 欄へ値を注入するため Write が必須。Lyrics 欄を隠す Instrumental mode のままでは実行できない。`lyrics` が真に空の entry だけは Instrumental mode を使える。
 3. 拡張アイコンからポップアップを開き、**ローカル配信元** で動的検出されたチャンネル名つき候補を選ぶ。初回表示・配信元選択・collection 選択の各タイミングで一覧と prompts が自動取得される。
-4. `ready` な collection を checkbox で 1 件以上選び、prompts の自動取得後に **異常値の曲を再生成する** を選んでから実行する。1 件なら従来どおり現在の entry 選択を使い、2 件以上なら server 一覧順で各 collection の全 pattern を直列実行する。既定の ON は duration guard NG の entry を最大 2 回再生成する。OFF は追加生成せず、NG を警告表示したうえで生成済み全 clip を playlist / download 候補に残す。
+4. `ready` な collection を checkbox で 1 件以上選び、prompts の自動取得後に **異常値の曲を再生成する** と **ダウンロードまで実行する** を選んでから実行する。1 件なら従来どおり現在の entry 選択を使い、2 件以上なら server 一覧順で各 collection の全 pattern を直列実行する。download Switch は既定 ON で再読み込み後も保持され、Suno Studio を利用できる Premier プラン向けに playlist 追加後の download まで行う。OFF は playlist 追加で完了し、Suno から手動取得した音源を `02-Individual-music/` へ配置する。
 5. 各パターンで Style/Lyrics を注入 → Generate 押下 → 生成完了検知 → 次へ、を自動で繰り返す。
-6. 全件完了後、対象 clip を playlist へ追加し、Suno Studio に collection id 名の project を作る。各 clip を別 track の位置 0 に配置して件数を検証し、**Export → Multitrack** の WAV ZIP を監視して `POST /collections/<id>/downloaded` へ通知する。Studio 用に開いたタブは ZIP 完了・失敗・中断のいずれでも自動で閉じる（project 自体は Studio に残す）。Studio は Premier プランが必要で、利用できない場合は理由を表示して停止する。
+6. 全件完了後、対象 clip を playlist へ追加する。download Switch が ON なら Suno Studio に collection id 名の project を作り、各 clip を別 track の位置 0 に配置して件数を検証し、**Export → Multitrack** の WAV ZIP を監視して `POST /collections/<id>/downloaded` へ通知する。Studio 用に開いたタブは ZIP 完了・失敗・中断のいずれでも自動で閉じる（project 自体は Studio に残す）。Studio は Premier プランが必要で、利用できない場合は理由を表示して停止する。OFF なら Studio 操作と `/downloaded` 通知を行わず `FINISHED` になる。
 7. captcha challenge は waiting-captcha 表示で解消（多くは自動 verify）を待って続行する。entry 単位の一時的な失敗は Balanced 固定の上限で自動リトライし、上限超過分はスキップして完走する（#948）。スキップされた entry は一覧表示され、**失敗分のみ再実行** で再投入できる。
 
 prompt entry に `duration_sec` がある場合は、各 Generate 前に Duration の **Custom** を選択し、Suno UI の slider が公開する最小値・最大値の範囲内で指定秒数を注入する。selector 不在、範囲外、操作不受理、読戻し不一致は entry をエラー停止し、overlay に原因を表示する。`duration_sec` がない entry では Auto / Custom と slider の現在状態を変更しない。
 
 通知は初期状態で ON。最終 `FINISHED` は OS 通知と明るい3音上昇音、`ERROR` はエラー概要付き OS 通知と短い2音下降ベルで知らせる。手動 `STOPPED` と collection queue の途中完了では通知しない。Switch の設定は再読み込み後も維持され、旧 preset 設定は enabled を保ったまま自動移行される。OS 通知と Web Audio は独立して試行するため、一方の失敗は run 結果へ影響しない。
 
-複数 collection queue は各 collection の `/downloaded` 完了または失敗結果を extension storage へ保存してから Suno タブを再読み込みする。この境界処理が clip tracker と Suno 内部 multi-select を collection 間で破棄し、次の collection は保存済み index から自動開始する。タブ再読み込みや Stop で中断した queue は同じ current collection から再開でき、全件終了後は summary の **失敗したコレクションだけ再実行** を使う。
+複数 collection queue は各 collection の `/downloaded` 完了（download Switch OFF では playlist 追加完了）または失敗結果を extension storage へ保存してから Suno タブを再読み込みする。この境界処理が clip tracker と Suno 内部 multi-select を collection 間で破棄し、次の collection は保存済み index から自動開始する。タブ再読み込みや Stop で中断した queue は同じ current collection から再開でき、全件終了後は summary の **失敗したコレクションだけ再実行** を使う。
 
 **異常値の曲を再生成する** を OFF にした run は、duration guard の閾値外 clip も歯抜けにせず playlist と ZIP に含める。overlay の status / console warning で NG を確認し、完了後に対象 playlist を試聴して採否を手動判断する。overlay を閉じて再表示した場合も選択は復元される。entry phase の ERROR / STOPPED は resume バナー、playlist / download phase の中断は **Playlist から再開** / **Download から再開** を使い、いずれも元 run の選択と警告を引き継ぐ。
 
@@ -117,7 +118,9 @@ uv run yt-suno-unattended-request \
   --max-concurrent-generations 3 --max-retries 2
 ```
 
-既ログイン Chrome で出力 URL を開くと、download 済みは no-op、途中 state は未完了 entry または playlist/download から再開する。collection 単位の background lease は別タブ・別要求の重複生成を防ぎ、タブ crash 後は期限切れ lease を回収する。playlist URL と browser download 完了は不可逆操作の直後に checkpoint されるため、再開時に同名 playlist や ZIP を作り直さない。上限を超えた entry は checkpoint に残し、次回 URL 起動で続行する。既存 playlist があるのに clip ID が復元できない場合は重複生成せず停止する。ログイン、可視 CAPTCHA、料金・credit 確認、互換性のない UI も自動突破せず `local:sunoUnattendedRunState` に `manual-intervention` と必要操作を記録する。`completed` は localhost readback で音源、playlist URL、downloaded 状態をすべて確認した場合だけ通知する。同じ情報を Suno ページ root の `data-suno-unattended-request-id` / `-collection-id` / `-status` / `-checkpoint` / `-stop-reason` / `-required-action` に通知し、完了 reload 後も storage から復元するため、scheduler agent は storage API なしで観測できる。手動 overlay からの run はこの契約を付けないため従来挙動のまま。
+Premier でないアカウントでは `--skip-download` を付ける。request は playlist URL の checkpoint で `completed` になり、localhost の downloaded 状態を要求せず、`POST /collections/<id>/downloaded` も行わない。
+
+既ログイン Chrome で出力 URL を開くと、download 済みは no-op、途中 state は未完了 entry または playlist/download から再開する。collection 単位の background lease は別タブ・別要求の重複生成を防ぎ、タブ crash 後は期限切れ lease を回収する。playlist URL と browser download 完了は不可逆操作の直後に checkpoint されるため、再開時に同名 playlist や ZIP を作り直さない。上限を超えた entry は checkpoint に残し、次回 URL 起動で続行する。既存 playlist があるのに clip ID が復元できない場合は重複生成せず停止する。ログイン、可視 CAPTCHA、料金・credit 確認、互換性のない UI も自動突破せず `local:sunoUnattendedRunState` に `manual-intervention` と必要操作を記録する。通常の `completed` は localhost readback で音源、playlist URL、downloaded 状態をすべて確認した場合だけ通知し、`--skip-download` では playlist URL の確認だけを要求する。同じ情報を Suno ページ root の `data-suno-unattended-request-id` / `-collection-id` / `-status` / `-checkpoint` / `-stop-reason` / `-required-action` に通知し、完了 reload 後も storage から復元するため、scheduler agent は storage API なしで観測できる。手動 overlay からの run はこの契約を付けないため従来挙動のまま。
 
 ### in-flight 検知と停止判断（#948）
 

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -48,6 +48,7 @@ browser use から overlay を安定して観測できるよう、操作 panel �
 | `[data-suno-control="download-enabled"]`                                                           | Suno Studio からの download 実行を切り替える shadcn Switch（既定 ON）                                    |
 | `[data-suno-control="resume"]` / `[data-suno-control="dismiss-resume"]`                            | 前回中断 resume バナーの再開 / 閉じる                                                                     |
 | `[data-suno-control="adopt-selected-clips"]`                                                       | Suno 上の選択中 clip を採用                                                                               |
+| `[data-suno-control="download-only"]`                                                             | Suno 上の選択中 clip を採用し、生成・playlist 追加を行わず Studio download だけを実行                    |
 | `[data-suno-control="retry-playlist"]` / `[data-suno-control="retry-download"]`                    | playlist / download phase から再開                                                                        |
 | `role="status"` + `data-suno-status`                                                               | live status。`data-suno-status="error"` は handoff / retry 判断の入口                                     |
 | `[data-suno-entry-list]` / `[data-suno-entry-index]`                                               | entry 一覧。各行に `data-suno-entry-state` と `data-suno-entry-selected` が付く                           |
@@ -97,6 +98,8 @@ build 後は `.output/chrome-mv3/manifest.json`、zip 後は `.output/suno-helpe
 5. 各パターンで Style/Lyrics を注入 → Generate 押下 → 生成完了検知 → 次へ、を自動で繰り返す。
 6. 全件完了後、対象 clip を playlist へ追加する。download Switch が ON なら Suno Studio に collection id 名の project を作り、各 clip を別 track の位置 0 に配置して件数を検証し、**Export → Multitrack** の WAV ZIP を監視して `POST /collections/<id>/downloaded` へ通知する。Studio 用に開いたタブは ZIP 完了・失敗・中断のいずれでも自動で閉じる（project 自体は Studio に残す）。Studio は Premier プランが必要で、利用できない場合は理由を表示して停止する。OFF なら Studio 操作と `/downloaded` 通知を行わず `FINISHED` になる。
 7. captcha challenge は waiting-captcha 表示で解消（多くは自動 verify）を待って続行する。entry 単位の一時的な失敗は Balanced 固定の上限で自動リトライし、上限超過分はスキップして完走する（#948）。スキップされた entry は一覧表示され、**失敗分のみ再実行** で再投入できる。
+
+生成と playlist 追加をやり直さず Studio export だけを試す場合は、Suno 上で対象 clip を選択して **ダウンロードのみ実行** を押す。この明示操作は「ダウンロードまで実行する」Switch が OFF でも利用でき、選択 clip を resume state に保存してから Studio Multitrack download へ進む。
 
 prompt entry に `duration_sec` がある場合は、各 Generate 前に Duration の **Custom** を選択し、Suno UI の slider が公開する最小値・最大値の範囲内で指定秒数を注入する。selector 不在、範囲外、操作不受理、読戻し不一致は entry をエラー停止し、overlay に原因を表示する。`duration_sec` がない entry では Auto / Custom と slider の現在状態を変更しない。
 

--- a/extensions/suno-helper/README.md
+++ b/extensions/suno-helper/README.md
@@ -45,10 +45,10 @@ browser use から overlay を安定して観測できるよう、操作 panel �
 | `[data-suno-control="collection-queue-discard-confirmation"]`                                      | 停止中 queue のインライン破棄確認                                                                          |
 | `[data-suno-control="run"]` / `[data-suno-control="stop"]`                                         | 主要操作ボタン                                                                                            |
 | `[data-suno-control="notification-enabled"]`                                                       | OS 通知と固定音をまとめて切り替える shadcn Switch                                                        |
-| `[data-suno-control="download-enabled"]`                                                           | Suno Studio からの download 実行を切り替える shadcn Switch（既定 ON）                                    |
+| `[data-suno-control="download-enabled"]`                                                           | 連続実行と Playlist / Download からの再開で Studio download を行うかを切り替える shadcn Switch（既定 ON）。`download-only` の明示操作には適用されない |
 | `[data-suno-control="resume"]` / `[data-suno-control="dismiss-resume"]`                            | 前回中断 resume バナーの再開 / 閉じる                                                                     |
 | `[data-suno-control="adopt-selected-clips"]`                                                       | Suno 上の選択中 clip を採用                                                                               |
-| `[data-suno-control="download-only"]`                                                             | Suno 上の選択中 clip を採用し、生成・playlist 追加を行わず Studio download だけを実行                    |
+| `[data-suno-control="download-only"]`                                                             | Suno 上の選択中 clip を採用し、生成・playlist 追加を行わず Studio download だけを実行（`download-enabled` が OFF でも表示・実行できる明示操作） |
 | `[data-suno-control="retry-playlist"]` / `[data-suno-control="retry-download"]`                    | playlist / download phase から再開                                                                        |
 | `role="status"` + `data-suno-status`                                                               | live status。`data-suno-status="error"` は handoff / retry 判断の入口                                     |
 | `[data-suno-entry-list]` / `[data-suno-entry-index]`                                               | entry 一覧。各行に `data-suno-entry-state` と `data-suno-entry-selected` が付く                           |

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -27,7 +27,6 @@ import {
   RadioGroupItem,
   ScrollArea,
   ServerSourceField,
-  Switch,
 } from "@youtube-automation/ui";
 import { useEffect, useRef, useState } from "react";
 
@@ -39,6 +38,7 @@ import {
 } from "../lib/pattern-selection";
 import { buildSelectedEntriesRunOverrides } from "../lib/run-overrides";
 import { CompletionSoundControls } from "./CompletionSoundControls";
+import { DownloadControls } from "./DownloadControls";
 import { PatternList } from "./PatternList";
 import { ReloadRequiredNotice } from "./ReloadRequiredNotice";
 import { RunTimingPanel } from "./RunTimingPanel";
@@ -608,23 +608,11 @@ export function App() {
         onEnabledChange={setCompletionSoundEnabled}
       />
 
-      <section
-        className="flex flex-col gap-1 text-sm"
-        aria-label="ダウンロード設定"
-      >
-        <label className="flex items-center gap-2">
-          <Switch
-            checked={downloadEnabled}
-            disabled={!downloadEnabledLoaded || controlsLocked}
-            data-suno-control="download-enabled"
-            onCheckedChange={(checked) => setDownloadEnabled(checked === true)}
-          />
-          <span className="font-medium">ダウンロードまで実行する</span>
-        </label>
-        <p className="text-xs text-muted-foreground">
-          Suno Studio・Premier 必須
-        </p>
-      </section>
+      <DownloadControls
+        enabled={downloadEnabled}
+        disabled={!downloadEnabledLoaded || controlsLocked}
+        onEnabledChange={setDownloadEnabled}
+      />
 
       <div className="flex gap-2">
         <Button

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -27,6 +27,7 @@ import {
   RadioGroupItem,
   ScrollArea,
   ServerSourceField,
+  Switch,
 } from "@youtube-automation/ui";
 import { useEffect, useRef, useState } from "react";
 
@@ -72,6 +73,9 @@ export function App() {
     completionSoundSettings,
     completionSoundSettingsLoaded,
     setCompletionSoundEnabled,
+    downloadEnabled,
+    downloadEnabledLoaded,
+    setDownloadEnabled,
     playlistName,
     runModeId,
     setRunMode,
@@ -603,6 +607,24 @@ export function App() {
         onEnabledChange={setCompletionSoundEnabled}
       />
 
+      <section
+        className="flex flex-col gap-1 text-sm"
+        aria-label="ダウンロード設定"
+      >
+        <label className="flex items-center gap-2">
+          <Switch
+            checked={downloadEnabled}
+            disabled={!downloadEnabledLoaded || controlsLocked}
+            data-suno-control="download-enabled"
+            onCheckedChange={(checked) => setDownloadEnabled(checked === true)}
+          />
+          <span className="font-medium">ダウンロードまで実行する</span>
+        </label>
+        <p className="text-xs text-muted-foreground">
+          Suno Studio・Premier 必須
+        </p>
+      </section>
+
       <div className="flex gap-2">
         <Button
           type="button"
@@ -651,17 +673,19 @@ export function App() {
                 Playlist から再開
               </Button>
             )}
-            <Button
-              type="button"
-              onClick={() => void retryDownload()}
-              disabled={!selectedCollectionId}
-              data-suno-control="retry-download"
-              variant="success"
-              size="sm"
-              className="flex-1"
-            >
-              Download から再開
-            </Button>
+            {downloadEnabled && (
+              <Button
+                type="button"
+                onClick={() => void retryDownload()}
+                disabled={!selectedCollectionId}
+                data-suno-control="retry-download"
+                variant="success"
+                size="sm"
+                className="flex-1"
+              >
+                Download から再開
+              </Button>
+            )}
           </div>
         </div>
       )}

--- a/extensions/suno-helper/components/App.tsx
+++ b/extensions/suno-helper/components/App.tsx
@@ -89,6 +89,7 @@ export function App() {
     retryPlaylist,
     retryDownload,
     adoptSelectedClips,
+    downloadOnly,
     run,
     stop,
     timingReceipt,
@@ -659,6 +660,15 @@ export function App() {
             size="sm"
           >
             選択中の曲を採用
+          </Button>
+          <Button
+            type="button"
+            onClick={() => void downloadOnly()}
+            data-suno-control="download-only"
+            variant="success"
+            size="sm"
+          >
+            ダウンロードのみ実行
           </Button>
           <div className="flex gap-2">
             {playlistName && (

--- a/extensions/suno-helper/components/DownloadControls.tsx
+++ b/extensions/suno-helper/components/DownloadControls.tsx
@@ -1,0 +1,31 @@
+import { Switch } from "@youtube-automation/ui";
+
+interface DownloadControlsProps {
+  enabled: boolean;
+  disabled: boolean;
+  onEnabledChange: (enabled: boolean) => void;
+}
+
+export function DownloadControls({
+  enabled,
+  disabled,
+  onEnabledChange,
+}: DownloadControlsProps) {
+  return (
+    <section
+      className="flex flex-col gap-1 text-sm"
+      aria-label="ダウンロード設定"
+    >
+      <label className="flex items-center gap-2">
+        <Switch
+          checked={enabled}
+          disabled={disabled}
+          data-suno-control="download-enabled"
+          onCheckedChange={(checked) => onEnabledChange(checked === true)}
+        />
+        <span className="font-medium">ダウンロードまで実行する</span>
+      </label>
+      <p className="text-xs text-muted-foreground">Suno Studio・Premier 必須</p>
+    </section>
+  );
+}

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -60,7 +60,11 @@ import {
   type RunOverrides,
 } from "../lib/run-overrides";
 import { isTerminalPhase, nextItemStates } from "../lib/snapshot";
-import { migrateServerSourcesStorage, serverUrlItem } from "../lib/storage";
+import {
+  downloadEnabledItem,
+  migrateServerSourcesStorage,
+  serverUrlItem,
+} from "../lib/storage";
 import { shouldReportLiveProgressStatus } from "./live-progress-status";
 import {
   buildRestoreState,
@@ -95,6 +99,9 @@ interface RunnerState {
   completionSoundSettings: CompletionSoundSettings;
   completionSoundSettingsLoaded: boolean;
   setCompletionSoundEnabled: (enabled: boolean) => void;
+  downloadEnabled: boolean;
+  downloadEnabledLoaded: boolean;
+  setDownloadEnabled: (enabled: boolean) => void;
   // collection 選択時の playlist 名 (#854)。display only。
   playlistName: string | undefined;
   runModeId: RunModeId;
@@ -267,6 +274,8 @@ export function useSunoRunner(): RunnerState {
   const [regenerateDurationOutliers, setRegenerateDurationOutliers] = useState(
     DEFAULT_REGENERATE_DURATION_OUTLIERS
   );
+  const [downloadEnabled, setDownloadEnabledState] = useState(true);
+  const [downloadEnabledLoaded, setDownloadEnabledLoaded] = useState(false);
   const [
     restoredRegenerateDurationOutliers,
     setRestoredRegenerateDurationOutliers,
@@ -697,6 +706,22 @@ export function useSunoRunner(): RunnerState {
     [reportStorageFailure]
   );
 
+  useEffect(() => {
+    void downloadEnabledItem
+      .getValue()
+      .then(setDownloadEnabledState)
+      .catch(reportStorageFailure)
+      .finally(() => setDownloadEnabledLoaded(true));
+  }, [reportStorageFailure]);
+
+  const setDownloadEnabled = useCallback(
+    (enabled: boolean) => {
+      setDownloadEnabledState(enabled);
+      void downloadEnabledItem.setValue(enabled).catch(reportStorageFailure);
+    },
+    [reportStorageFailure]
+  );
+
   const dismissResume = useCallback(() => {
     setResumeDismissed(true);
   }, []);
@@ -883,6 +908,7 @@ export function useSunoRunner(): RunnerState {
             collectionQueueId: queue.queueId,
             runMode: queue.runMode,
             regenerateDurationOutliers: queue.regenerateDurationOutliers,
+            downloadEnabled,
             durationOutlierWarnings: overrides?.durationOutlierWarnings,
             overrides,
           })
@@ -912,6 +938,7 @@ export function useSunoRunner(): RunnerState {
       setRunning,
       settleRejectedCollectionQueueStart,
       writePausedCollectionQueue,
+      downloadEnabled,
     ]
   );
 
@@ -1222,6 +1249,7 @@ export function useSunoRunner(): RunnerState {
     if (
       resumeCheckedAt === null ||
       !collectionQueueChecked ||
+      !downloadEnabledLoaded ||
       initialFetchStartedRef.current
     ) {
       return;
@@ -1254,6 +1282,7 @@ export function useSunoRunner(): RunnerState {
     discoverSources,
     fetchData,
     collectionQueueChecked,
+    downloadEnabledLoaded,
     reportStorageFailure,
     resumableCollectionId,
     resumeCheckedAt,
@@ -1387,6 +1416,7 @@ export function useSunoRunner(): RunnerState {
             collectionId: selectedCollectionId,
             runMode: runModeId,
             regenerateDurationOutliers,
+            downloadEnabled,
             durationOutlierWarnings: overrides?.durationOutlierWarnings,
             overrides,
           })
@@ -1404,6 +1434,7 @@ export function useSunoRunner(): RunnerState {
       selectedCollectionId,
       runModeId,
       regenerateDurationOutliers,
+      downloadEnabled,
       report,
       reportRunDispatchFailure,
       setRunning,
@@ -1432,6 +1463,7 @@ export function useSunoRunner(): RunnerState {
     const expectedClipCount =
       playlistExpectedClipCountForResume ?? submittedClipIdsForResume.length;
     const shouldDownload =
+      downloadEnabled &&
       resumeBanner !== null &&
       resumeBanner.failedIndex >= resumeBanner.total &&
       !resumeBanner.remainingIndices?.length;
@@ -1460,6 +1492,7 @@ export function useSunoRunner(): RunnerState {
         submittedClipIdsAreDurationFiltered:
           submittedClipIdsAreDurationFilteredForResume,
         shouldDownload,
+        downloadEnabled,
         timingReceipt: persistedResume?.timingReceipt,
       });
       setResumeDismissed(true);
@@ -1486,6 +1519,7 @@ export function useSunoRunner(): RunnerState {
     report,
     setRunning,
     persistedResume?.timingReceipt,
+    downloadEnabled,
   ]);
 
   // バナー承認 = 1-click 自動再開 (#892 要件6)。failedIndex === total（全 entry 投入済み）のときは
@@ -1754,6 +1788,9 @@ export function useSunoRunner(): RunnerState {
     completionSoundSettings,
     completionSoundSettingsLoaded,
     setCompletionSoundEnabled,
+    downloadEnabled,
+    downloadEnabledLoaded,
+    setDownloadEnabled,
     playlistName,
     runModeId,
     setRunMode,

--- a/extensions/suno-helper/components/useSunoRunner.ts
+++ b/extensions/suno-helper/components/useSunoRunner.ts
@@ -118,8 +118,9 @@ interface RunnerState {
   rerunFailed: () => void;
   // playlist / download 単独再実行 (#1251)。失敗フォールバック用。
   retryPlaylist: () => Promise<void>;
-  retryDownload: () => Promise<void>;
-  adoptSelectedClips: () => Promise<void>;
+  retryDownload: (clipIdsOverride?: string[]) => Promise<void>;
+  adoptSelectedClips: () => Promise<string[] | undefined>;
+  downloadOnly: () => Promise<void>;
   // overrides.range があればそれを使う (#892 要件6)。
   // overrides.indices はチェック選択や失敗分再実行の部分実行対象。指定時は range より優先される。
   run: (overrides?: RunOverrides) => Promise<void>;
@@ -1572,48 +1573,53 @@ export function useSunoRunner(): RunnerState {
   ]);
 
   // ダウンロードのみ再実行 (#1251)。保存済み clip を Studio export へ渡す。
-  const retryDownload = useCallback(async () => {
-    if (isRunning) {
-      return;
-    }
-    if (!selectedCollectionId) {
-      report(
-        "コレクションを選択してから、ダウンロードを再開してください。",
-        true
-      );
-      return;
-    }
-    if (submittedClipIdsForResume.length === 0) {
-      report(
-        "ダウンロード再開に必要な clip ID がありません。Suno 上で対象曲を選択し、「選択中の曲を採用」を押してから「Download から再開」を再試行してください。",
-        true
-      );
-      return;
-    }
-    setRunning(true);
-    setPhase("downloading");
-    try {
-      const payload = {
-        collectionId: selectedCollectionId,
-        submittedClipIds: submittedClipIdsForResume,
-        expectedClipCount: expectedClipCountForDownloadResume,
-        timingReceipt: persistedResume?.timingReceipt,
-      };
-      await sendMessage("retryDownload", payload);
-      report("ダウンロードを再実行しています…");
-    } catch (err) {
-      reportRunDispatchFailure(err);
-    }
-  }, [
-    isRunning,
-    selectedCollectionId,
-    submittedClipIdsForResume,
-    expectedClipCountForDownloadResume,
-    persistedResume?.timingReceipt,
-    report,
-    reportRunDispatchFailure,
-    setRunning,
-  ]);
+  const retryDownload = useCallback(
+    async (clipIdsOverride?: string[]) => {
+      if (isRunning) {
+        return;
+      }
+      if (!selectedCollectionId) {
+        report(
+          "コレクションを選択してから、ダウンロードを再開してください。",
+          true
+        );
+        return;
+      }
+      const clipIds = clipIdsOverride ?? submittedClipIdsForResume;
+      if (clipIds.length === 0) {
+        report(
+          "ダウンロード再開に必要な clip ID がありません。Suno 上で対象曲を選択し、「選択中の曲を採用」を押してから「Download から再開」を再試行してください。",
+          true
+        );
+        return;
+      }
+      setRunning(true);
+      setPhase("downloading");
+      try {
+        const payload = {
+          collectionId: selectedCollectionId,
+          submittedClipIds: clipIds,
+          expectedClipCount:
+            clipIdsOverride?.length ?? expectedClipCountForDownloadResume,
+          timingReceipt: persistedResume?.timingReceipt,
+        };
+        await sendMessage("retryDownload", payload);
+        report("ダウンロードを再実行しています…");
+      } catch (err) {
+        reportRunDispatchFailure(err);
+      }
+    },
+    [
+      isRunning,
+      selectedCollectionId,
+      submittedClipIdsForResume,
+      expectedClipCountForDownloadResume,
+      persistedResume?.timingReceipt,
+      report,
+      reportRunDispatchFailure,
+      setRunning,
+    ]
+  );
 
   const adoptSelectedClips = useCallback(async () => {
     if (isRunning) {
@@ -1690,6 +1696,7 @@ export function useSunoRunner(): RunnerState {
       report(
         `選択中の曲 ${result.clipIds.length} 件を採用しました。Playlist / Download から再開できます。`
       );
+      return result.clipIds;
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       setPhase("error");
@@ -1712,6 +1719,12 @@ export function useSunoRunner(): RunnerState {
     report,
     setRunning,
   ]);
+
+  const downloadOnly = useCallback(async () => {
+    const clipIds = await adoptSelectedClips();
+    if (!clipIds) return;
+    await retryDownload(clipIds);
+  }, [adoptSelectedClips, retryDownload]);
 
   // 失敗分のみ再実行 (#948)。failedEntries を indices として run へ渡す。
   // 完走すると content 側が playlist 追加まで実行し resume state を消す。
@@ -1804,6 +1817,7 @@ export function useSunoRunner(): RunnerState {
     retryPlaylist,
     retryDownload,
     adoptSelectedClips,
+    downloadOnly,
     run,
     stop,
     timingReceipt,

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -366,7 +366,9 @@ function assertOptionalIndices(
 }
 
 // fallow-ignore-next-line complexity
-function assertRunPayload(value: unknown): RunPayload {
+function assertRunPayload(value: unknown): RunPayload & {
+  downloadEnabled: boolean;
+} {
   const record = assertRecord(value, "run payload");
   if (!Array.isArray(record.entries)) {
     throw new Error("run.entries must be array");
@@ -402,6 +404,9 @@ function assertRunPayload(value: unknown): RunPayload {
         record.regenerateDurationOutliers,
         "run.regenerateDurationOutliers"
       ) ?? DEFAULT_REGENERATE_DURATION_OUTLIERS,
+    downloadEnabled:
+      assertOptionalBoolean(record.downloadEnabled, "run.downloadEnabled") ??
+      true,
     durationFilter: assertOptionalDurationFilter(
       record.durationFilter,
       "run.durationFilter"
@@ -468,7 +473,9 @@ function assertOptionalDurationOutlierWarnings(
   );
 }
 
-function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload {
+function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload & {
+  downloadEnabled: boolean;
+} {
   const record = assertRecord(value, "retryPlaylist payload");
   const unattendedRecord =
     record.unattended === undefined
@@ -534,6 +541,11 @@ function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload {
       record.shouldDownload,
       "retryPlaylist.shouldDownload"
     ),
+    downloadEnabled:
+      assertOptionalBoolean(
+        record.downloadEnabled,
+        "retryPlaylist.downloadEnabled"
+      ) ?? true,
     unattended,
   };
 }
@@ -995,6 +1007,17 @@ export default defineContentScript({
       const collection = collections.find(
         (candidate) => candidate.id === unattended.request.collectionId
       );
+      if (unattended.request.skipDownload === true) {
+        if (
+          !collection ||
+          typeof collection.suno_playlist_url !== "string" ||
+          collection.suno_playlist_url.length === 0
+        ) {
+          throw new Error("server readback で playlist URL を確認できません。");
+        }
+        verifiedUnattendedRequests.add(unattended.request.requestId);
+        return;
+      }
       const promptResponse = await sendMessage(
         "fetchCollectionPromptResponse",
         {
@@ -1656,6 +1679,7 @@ export default defineContentScript({
       durationOutlierPolicy: DurationOutlierPolicy;
       collectionQueueId?: string;
       unattended?: RunPayload["unattended"];
+      downloadEnabled: boolean;
     }
 
     // fallow-ignore-next-line complexity
@@ -1724,6 +1748,7 @@ export default defineContentScript({
           : new Set(previousSubmittedClipIds).size +
             order.length * CLIPS_PER_REQUEST;
       const shouldRunDownloadAfterPlaylist =
+        options.downloadEnabled &&
         expectedRawPlaylistClipCount >= total * CLIPS_PER_REQUEST;
       // リトライ上限まで失敗しスキップした entry の 0-based index (#948)。終了時に resume state へ
       // 永続化し、popup の「失敗分のみ再実行」導線が消費する。
@@ -2661,6 +2686,12 @@ export default defineContentScript({
         phase: PHASE.FINISHED,
         total,
         ...(downloadSummary === undefined ? {} : { downloadSummary }),
+        ...(!options.downloadEnabled
+          ? {
+              message:
+                "ダウンロード未実行。Suno から手動で取得して 02-Individual-music/ へ配置してください。",
+            }
+          : {}),
       });
       // run 一式完了時リロード (#1411 要件2)。playlist 追加で作った multi-select 状態は
       // Suno 内部 state に残り、同一タブの次 run の Cmd+P に混入するためページごと破棄する。
@@ -2697,6 +2728,7 @@ export default defineContentScript({
         playlistExpectedClipCount,
         collectionQueueId,
         unattended,
+        downloadEnabled,
       } = assertRunPayload(data);
       // 手動 run では過去の定期実行 state を更新しない。定期実行だけが明示的に
       // active context を設定し、以降の progress を checkpoint へ反映する。
@@ -2764,6 +2796,7 @@ export default defineContentScript({
         playlistExpectedClipCount,
         collectionQueueId,
         unattended,
+        downloadEnabled,
       }).finally(async () => {
         running = false;
         // queue failure で resume state を消す場合、最後の checkpoint write より後に
@@ -2809,6 +2842,7 @@ export default defineContentScript({
         durationOutlierWarnings,
         submittedClipIdsAreDurationFiltered,
         shouldDownload,
+        downloadEnabled,
         unattended,
         timingReceipt,
       } = assertRetryPlaylistPayload(data);
@@ -2894,7 +2928,7 @@ export default defineContentScript({
             emitProgress({ phase: PHASE.STOPPED, total: 0 });
             return;
           }
-          if (shouldDownload) {
+          if (shouldDownload && downloadEnabled) {
             const downloadContext = await resolveDownloadContext();
             assertUnattendedUiIsSafe();
             if (studioClipIds === null) {
@@ -2929,7 +2963,16 @@ export default defineContentScript({
               err
             );
           }
-          emitProgress({ phase: PHASE.FINISHED, total: 0 });
+          emitProgress({
+            phase: PHASE.FINISHED,
+            total: 0,
+            ...(!downloadEnabled
+              ? {
+                  message:
+                    "ダウンロード未実行。Suno から手動で取得して 02-Individual-music/ へ配置してください。",
+                }
+              : {}),
+          });
           // retryPlaylist も playlist 追加で multi-select 状態を作るため完了時にページごと破棄する (#1411)。
           // リロード前に FINISHED snapshot を退避する（runAll の完了経路と同じ）。
           if (
@@ -3232,7 +3275,10 @@ export default defineContentScript({
               progress: {
                 phase: PHASE.FINISHED,
                 total: promptResponse.entries.length,
-                message: "音源は既に download 済みです。",
+                message:
+                  plan.reason === "playlist-created"
+                    ? "playlist 追加済みです。ダウンロードは実行しません。"
+                    : "音源は既に download 済みです。",
               },
               deferredIndices: [],
               now: Date.now(),
@@ -3271,6 +3317,7 @@ export default defineContentScript({
             submittedClipIdsAreDurationFiltered:
               resumeState?.submittedClipIdsAreDurationFiltered,
             shouldDownload: true,
+            downloadEnabled: request.skipDownload !== true,
             unattended: { request, deferredIndices: [], leaseToken },
           });
           if (!result.ok) throw new Error("suno-helper runner is busy");
@@ -3352,6 +3399,7 @@ export default defineContentScript({
           runMode: resumeState?.runMode ?? "queue",
           regenerateDurationOutliers:
             resumeState?.regenerateDurationOutliers ?? true,
+          downloadEnabled: request.skipDownload !== true,
           durationOutlierWarnings: resumeState?.durationOutlierWarnings,
           indices: plan.indices,
           submittedClipIds: plan.previousSubmittedClipIds,

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -3329,7 +3329,7 @@ export default defineContentScript({
             durationOutlierWarnings: resumeState?.durationOutlierWarnings,
             submittedClipIdsAreDurationFiltered:
               resumeState?.submittedClipIdsAreDurationFiltered,
-            shouldDownload: true,
+            shouldDownload: request.skipDownload !== true,
             downloadEnabled: request.skipDownload !== true,
             unattended: { request, deferredIndices: [], leaseToken },
           });

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -2648,8 +2648,8 @@ export default defineContentScript({
         emitProgress({ phase: PHASE.STOPPED, total });
         return;
       }
-      // 生成物を得られなかった entry が残る partial complete。完了分の playlist 追加・download は
-      // 実行済み。失敗 entry を再実行導線へ渡すため resume state を保持する。
+      // 生成物を得られなかった entry が残る partial complete。完了分の playlist 追加と、
+      // 設定に応じた download 処理は完了済み。失敗 entry を再実行導線へ渡すため resume state を保持する。
       if (
         stalledEntryIndices.length > 0 ||
         generationFailedEntryIndices.length > 0
@@ -2670,7 +2670,10 @@ export default defineContentScript({
         emitProgress({
           phase: PHASE.FINISHED,
           total,
-          message: `${details.join(" / ")}。完了分の playlist 追加とダウンロードは実行済みです。「失敗分のみ再実行」で残りを生成できます。`,
+          message: `${details.join(" / ")}。完了分の playlist 追加は実行済みです。${
+            downloadCompletionMessage(options.downloadEnabled).message ??
+            "ダウンロードは実行済みです。"
+          }「失敗分のみ再実行」で残りを生成できます。`,
         });
         return;
       }

--- a/extensions/suno-helper/entrypoints/content.ts
+++ b/extensions/suno-helper/entrypoints/content.ts
@@ -149,6 +149,15 @@ import {
   type DurationOutlierPolicy,
 } from "../lib/yield-guard";
 
+const DOWNLOAD_SKIPPED_MESSAGE =
+  "ダウンロード未実行。Suno から手動で取得して 02-Individual-music/ へ配置してください。";
+
+function downloadCompletionMessage(
+  downloadEnabled: boolean
+): Pick<ProgressPayload, "message"> {
+  return downloadEnabled ? {} : { message: DOWNLOAD_SKIPPED_MESSAGE };
+}
+
 function advanceRunTimingReceipt(
   receipt: RunTimingReceipt,
   payload: ProgressPayload,
@@ -473,6 +482,25 @@ function assertOptionalDurationOutlierWarnings(
   );
 }
 
+function assertRetryDownloadSettings(record: Record<string, unknown>): {
+  downloadEnabled: boolean;
+  shouldDownload: boolean;
+} {
+  const shouldDownload = assertOptionalBoolean(
+    record.shouldDownload,
+    "retryPlaylist.shouldDownload"
+  );
+  const downloadEnabled =
+    assertOptionalBoolean(
+      record.downloadEnabled,
+      "retryPlaylist.downloadEnabled"
+    ) ?? true;
+  return {
+    downloadEnabled,
+    shouldDownload: shouldDownload === true && downloadEnabled,
+  };
+}
+
 function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload & {
   downloadEnabled: boolean;
 } {
@@ -537,15 +565,7 @@ function assertRetryPlaylistPayload(value: unknown): RetryPlaylistPayload & {
       record.submittedClipIdsAreDurationFiltered,
       "retryPlaylist.submittedClipIdsAreDurationFiltered"
     ),
-    shouldDownload: assertOptionalBoolean(
-      record.shouldDownload,
-      "retryPlaylist.shouldDownload"
-    ),
-    downloadEnabled:
-      assertOptionalBoolean(
-        record.downloadEnabled,
-        "retryPlaylist.downloadEnabled"
-      ) ?? true,
+    ...assertRetryDownloadSettings(record),
     unattended,
   };
 }
@@ -2686,12 +2706,7 @@ export default defineContentScript({
         phase: PHASE.FINISHED,
         total,
         ...(downloadSummary === undefined ? {} : { downloadSummary }),
-        ...(!options.downloadEnabled
-          ? {
-              message:
-                "ダウンロード未実行。Suno から手動で取得して 02-Individual-music/ へ配置してください。",
-            }
-          : {}),
+        ...downloadCompletionMessage(options.downloadEnabled),
       });
       // run 一式完了時リロード (#1411 要件2)。playlist 追加で作った multi-select 状態は
       // Suno 内部 state に残り、同一タブの次 run の Cmd+P に混入するためページごと破棄する。
@@ -2928,7 +2943,7 @@ export default defineContentScript({
             emitProgress({ phase: PHASE.STOPPED, total: 0 });
             return;
           }
-          if (shouldDownload && downloadEnabled) {
+          if (shouldDownload) {
             const downloadContext = await resolveDownloadContext();
             assertUnattendedUiIsSafe();
             if (studioClipIds === null) {
@@ -2966,12 +2981,7 @@ export default defineContentScript({
           emitProgress({
             phase: PHASE.FINISHED,
             total: 0,
-            ...(!downloadEnabled
-              ? {
-                  message:
-                    "ダウンロード未実行。Suno から手動で取得して 02-Individual-music/ へ配置してください。",
-                }
-              : {}),
+            ...downloadCompletionMessage(downloadEnabled),
           });
           // retryPlaylist も playlist 追加で multi-select 状態を作るため完了時にページごと破棄する (#1411)。
           // リロード前に FINISHED snapshot を退避する（runAll の完了経路と同じ）。

--- a/extensions/suno-helper/lib/messaging.ts
+++ b/extensions/suno-helper/lib/messaging.ts
@@ -42,6 +42,7 @@ export interface RunPayload {
   /** 生成完了待ちの方式。serial は従来挙動、queue は ACK 後に次 entry を投入する。 */
   runMode: RunModeId;
   regenerateDurationOutliers: boolean;
+  downloadEnabled?: boolean;
   durationOutlierWarnings?: Record<number, string>;
   timingReceipt?: RunTimingReceipt;
   /** 任意の部分実行対象の 0-based index 列。チェック選択や失敗分再実行で使う。指定時は range より優先。 */
@@ -75,6 +76,7 @@ export interface RetryPlaylistPayload {
   /** true のとき submittedClipIds は resume 保存時点で OK clip IDs に正規化済み。 */
   submittedClipIdsAreDurationFiltered?: boolean;
   shouldDownload?: boolean;
+  downloadEnabled?: boolean;
   /** 定期実行の playlist/download 再開時だけ付与する checkpoint 契約。 */
   unattended?: {
     request: UnattendedRunRequest;

--- a/extensions/suno-helper/lib/run-overrides.ts
+++ b/extensions/suno-helper/lib/run-overrides.ts
@@ -45,6 +45,7 @@ export interface RunPayloadInput {
   collectionQueueId?: string;
   runMode: RunModeId;
   regenerateDurationOutliers?: boolean;
+  downloadEnabled: boolean;
   durationOutlierWarnings?: Record<number, string>;
   overrides: RunOverrides | undefined;
 }
@@ -64,6 +65,7 @@ export function buildRunPayload(input: RunPayloadInput): RunPayload {
       input.overrides?.regenerateDurationOutliers ??
       input.regenerateDurationOutliers ??
       DEFAULT_REGENERATE_DURATION_OUTLIERS,
+    downloadEnabled: input.downloadEnabled,
     indices: input.overrides?.indices,
     submittedClipIds: input.overrides?.submittedClipIds,
     submittedClipIdsAreDurationFiltered:

--- a/extensions/suno-helper/lib/storage.ts
+++ b/extensions/suno-helper/lib/storage.ts
@@ -21,6 +21,11 @@ export const serverUrlItem = storage.defineItem<string>(
   { fallback: DEFAULT_URL }
 );
 
+export const downloadEnabledItem = storage.defineItem<boolean>(
+  "local:sunoDownloadEnabled",
+  { fallback: true }
+);
+
 const legacyServerSourcesItem = storage.defineItem(
   `local:${SERVER_SOURCES_STORAGE_KEY}`
 );

--- a/extensions/suno-helper/lib/unattended-run.ts
+++ b/extensions/suno-helper/lib/unattended-run.ts
@@ -23,6 +23,7 @@ export interface UnattendedRunRequest {
   baseUrl: string;
   collectionId: string;
   entryIndices?: number[];
+  skipDownload?: boolean;
   limits: UnattendedRunLimits;
 }
 
@@ -59,7 +60,7 @@ export interface UnattendedRunState {
 }
 
 export type UnattendedRunPlan =
-  | { kind: "complete"; reason: "already-downloaded" }
+  | { kind: "complete"; reason: "already-downloaded" | "playlist-created" }
   | {
       kind: "manual-intervention";
       reason: UnattendedStopReason;
@@ -150,6 +151,14 @@ function normalizeIndices(value: unknown): number[] | undefined {
   });
 }
 
+function optionalBoolean(value: unknown, field: string): boolean {
+  if (value === undefined) return false;
+  if (typeof value !== "boolean") {
+    throw new Error(`${field} must be boolean`);
+  }
+  return value;
+}
+
 function assertLoopbackBaseUrl(value: unknown): string {
   const raw = nonEmptyString(value, "baseUrl");
   let url: URL;
@@ -219,6 +228,7 @@ export function assertUnattendedRunRequest(
     baseUrl: assertLoopbackBaseUrl(record.baseUrl),
     collectionId: nonEmptyString(record.collectionId, "collectionId"),
     entryIndices: normalizeIndices(record.entryIndices),
+    skipDownload: optionalBoolean(record.skipDownload, "skipDownload"),
     limits: {
       maxEntries: boundedInteger(
         limits.maxEntries,
@@ -271,6 +281,14 @@ export function planUnattendedRun(options: {
     (resume?.failedIndices?.length ?? 0) > 0 ||
     (resume?.remainingIndices?.length ?? 0) > 0 ||
     (resume !== null && resume.failedIndex < entryCount);
+  if (
+    request.skipDownload === true &&
+    typeof collection.suno_playlist_url === "string" &&
+    collection.suno_playlist_url.length > 0 &&
+    !hasPendingResumeEntries
+  ) {
+    return { kind: "complete", reason: "playlist-created" };
+  }
   if (
     hasCompleteUnattendedArtifacts(
       collection,

--- a/extensions/suno-helper/lib/unattended-run.ts
+++ b/extensions/suno-helper/lib/unattended-run.ts
@@ -285,6 +285,8 @@ export function planUnattendedRun(options: {
     request.skipDownload === true &&
     typeof collection.suno_playlist_url === "string" &&
     collection.suno_playlist_url.length > 0 &&
+    typeof collection.expected_file_count === "number" &&
+    collection.expected_file_count >= entryCount * CLIPS_PER_REQUEST &&
     !hasPendingResumeEntries
   ) {
     return { kind: "complete", reason: "playlist-created" };

--- a/extensions/suno-helper/tests/collection-queue-state.test.ts
+++ b/extensions/suno-helper/tests/collection-queue-state.test.ts
@@ -192,6 +192,7 @@ describe("collection queue state (#2029)", () => {
       collectionQueueId: "queue-1",
       runMode: "queue",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       overrides: undefined,
     });
 

--- a/extensions/suno-helper/tests/content-finished-snapshot.test.ts
+++ b/extensions/suno-helper/tests/content-finished-snapshot.test.ts
@@ -39,6 +39,7 @@ async function loadContentScript(
 
   const handlers = new Map<string, Handler>();
   const progressMessages: ProgressMessage[] = [];
+  const sentMessages: Array<{ type: string; payload: unknown }> = [];
   let lastMultiSelectIds: string[] = [];
 
   const writeFinishedSnapshotMock = overrides?.writeFinishedSnapshotError
@@ -56,6 +57,7 @@ async function loadContentScript(
       handlers.set(type, handler);
     }),
     sendMessage: vi.fn((type: string, payload?: unknown) => {
+      sentMessages.push({ type, payload });
       if (type === "progress") {
         progressMessages.push(payload as ProgressMessage);
       }
@@ -208,6 +210,7 @@ async function loadContentScript(
     handlers,
     runHandler,
     progressMessages,
+    sentMessages,
     writeFinishedSnapshotMock,
     readFreshFinishedSnapshotMock,
     clearFinishedSnapshotMock,
@@ -294,6 +297,42 @@ describe("content.ts 完了時リロード前の FINISHED snapshot 退避", () =
       }),
       timestamp: expect.any(Number),
     });
+  });
+
+  it("Given download Switch OFF When 全 entry 完走 Then playlist 完了で FINISHED になり download/post を行わない", async () => {
+    const autoRunClipIds = ["clip-1", "clip-2", "clip-3", "clip-4"];
+    const {
+      runHandler,
+      progressMessages,
+      sentMessages,
+      clearResumeStateForCollectionMock,
+    } = await loadContentScript(autoRunClipIds);
+
+    runHandler({
+      data: {
+        ...partialRunPayload(),
+        range: undefined,
+        downloadEnabled: false,
+      },
+    });
+
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({
+          phase: PHASE.FINISHED,
+          message: expect.stringContaining("ダウンロード未実行"),
+        })
+      )
+    );
+    expect(clearResumeStateForCollectionMock).toHaveBeenCalledWith("coll-1");
+    expect(
+      sentMessages.filter(({ type }) =>
+        ["startDownload", "startStudioExport", "postDownloaded"].includes(type)
+      )
+    ).toHaveLength(0);
+    expect(
+      progressMessages.some(({ phase }) => phase === PHASE.DOWNLOADING)
+    ).toBe(false);
   });
 
   it("Given snapshot 退避が失敗 When FINISHED Then リロードを見送る（in-memory snapshot を生かして復元性を守る）", async () => {

--- a/extensions/suno-helper/tests/content-queue-stall.test.ts
+++ b/extensions/suno-helper/tests/content-queue-stall.test.ts
@@ -13,6 +13,7 @@ interface RunPayload {
   playlistName: string;
   runMode?: "serial" | "queue";
   regenerateDurationOutliers?: boolean;
+  downloadEnabled?: boolean;
   collectionId: string;
 }
 

--- a/extensions/suno-helper/tests/content-queue-stall.test.ts
+++ b/extensions/suno-helper/tests/content-queue-stall.test.ts
@@ -292,7 +292,8 @@ const allClipIds = Array.from(clipIdsByEntry.values()).flat();
 
 function runQueue(
   runHandler: RunHandler,
-  runMode: "serial" | "queue" = "queue"
+  runMode: "serial" | "queue" = "queue",
+  downloadEnabled = true
 ): void {
   runHandler({
     data: {
@@ -301,6 +302,7 @@ function runQueue(
       collectionId: "collection-stall",
       runMode,
       regenerateDurationOutliers: false,
+      downloadEnabled,
     },
   });
 }
@@ -359,6 +361,38 @@ describe("content.ts queue mode stall graceful degradation (#1994)", () => {
     );
     expect(clearResumeStateForCollectionMock).not.toHaveBeenCalled();
     expect(scheduleRunCompleteReloadMock).not.toHaveBeenCalled();
+  });
+
+  it("Given download OFF で一部 entry の clip が stall When queue run Then 手動配置の案内を表示する", async () => {
+    const { progressMessages, sentMessages, runHandler } =
+      await loadContentScriptWithStalledCompletion({
+        initialSubmittedIds: allClipIds,
+        clipIdsByEntry: new Map(clipIdsByEntry),
+        completionResult: {
+          timedOut: true,
+          submittedIds: allClipIds,
+          stalledClipIds: ["clip-1b"],
+          message:
+            "生成完了待ちがタイムアウトしました: submitted=6/6, pending=1, 最後の進捗からの経過時間=600000ms",
+        },
+      });
+
+    runQueue(runHandler, "queue", false);
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({ phase: PHASE.FINISHED })
+      )
+    );
+
+    expect(sentMessages).not.toContainEqual(
+      expect.objectContaining({ type: "startDownload" })
+    );
+    const finished = progressMessages.find(
+      (message) => message.phase === PHASE.FINISHED
+    );
+    expect(finished?.message).toContain("ダウンロード未実行");
+    expect(finished?.message).toContain("02-Individual-music/");
+    expect(finished?.message).not.toContain("ダウンロードは実行済み");
   });
 
   it("Given 全 entry の clip が stall When queue run Then playlist 追加せず失敗保留の FINISHED で再実行導線へ委ねる", async () => {

--- a/extensions/suno-helper/tests/content-retry-handlers.test.ts
+++ b/extensions/suno-helper/tests/content-retry-handlers.test.ts
@@ -472,6 +472,34 @@ describe('content onMessage("retryPlaylist"): 正常完了', () => {
     ).toHaveLength(0);
   });
 
+  it("Given download Switch OFF When retryPlaylist Then playlist 完了で FINISHED になり download/post を行わない", async () => {
+    const { handlers, progressMessages, sentMessages, studioExportMock } =
+      await loadContentScript();
+
+    handlers.get("retryPlaylist")!(
+      retryPlaylistMessage({
+        submittedClipIds: ["clip-1", "clip-2"],
+        expectedClipCount: 2,
+        shouldDownload: true,
+        downloadEnabled: false,
+      })
+    );
+
+    await vi.waitFor(() =>
+      expect(progressMessages).toContainEqual(
+        expect.objectContaining({
+          phase: PHASE.FINISHED,
+          message: expect.stringContaining("ダウンロード未実行"),
+        })
+      )
+    );
+    expect(studioExportMock).not.toHaveBeenCalled();
+    expect(
+      sentMessages.filter((message) => message.type === "postDownloaded")
+    ).toHaveLength(0);
+    expect(clearResumeStateMock).toHaveBeenCalledWith("coll-1");
+  });
+
   it("Given retryPlaylist に duration NG clip が混在 When 未正規化 payload Then OK clip IDs のみを multi-select する", async () => {
     const { handlers, progressMessages, scrollAndMultiSelectByIdsMock } =
       await loadContentScript({

--- a/extensions/suno-helper/tests/content-run-preflight.test.ts
+++ b/extensions/suno-helper/tests/content-run-preflight.test.ts
@@ -724,6 +724,59 @@ describe("content unattended launch", () => {
     expect(location.hash).toBe("");
   });
 
+  it("Given skip-download の playlist checkpoint When unattended resume Then retryPlaylist も download を行わない", async () => {
+    setUnattendedLaunchHash({ skipDownload: true });
+    const entries = makePromptEntries(1);
+    harness.readResumeState.mockResolvedValue({
+      collectionId: "20260718-rjn-night-drive-collection",
+      failedIndex: 1,
+      total: 1,
+      timestamp: Date.now(),
+      submittedClipIds: ["clip-1", "clip-2"],
+      playlistExpectedClipCount: 2,
+      playlistUrlsBeforeCreate: [],
+    });
+    harness.sendMessage.mockImplementation((type: string) => {
+      if (type === "consumeUnattendedRequest") {
+        return Promise.resolve(harness.unattendedRequest);
+      }
+      if (type === "acquireUnattendedLease") {
+        return Promise.resolve({ acquired: true, token: "lease-token" });
+      }
+      if (type === "extensionVersionHandshake") {
+        return Promise.resolve({ version: "0.2.5", matches: true });
+      }
+      if (type === "fetchCollections") {
+        return Promise.resolve([
+          {
+            id: "20260718-rjn-night-drive-collection",
+            name: "night-drive",
+            theme: "night-drive",
+            status: "ready",
+            pattern_count: 1,
+            downloaded_count: 0,
+          },
+        ]);
+      }
+      if (type === "fetchCollectionPromptResponse") {
+        return Promise.resolve({ entries });
+      }
+      return Promise.resolve({ ok: true });
+    });
+
+    await loadContentScript();
+
+    await vi.waitFor(() =>
+      expect(harness.sendMessage).toHaveBeenCalledWith(
+        "retryPlaylist",
+        expect.objectContaining({
+          shouldDownload: false,
+          downloadEnabled: false,
+        })
+      )
+    );
+  });
+
   it("stops before generation when an existing playlist has no recovery clip ids", async () => {
     setUnattendedLaunchHash();
     harness.sendMessage.mockImplementation((type: string) => {

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -88,6 +88,7 @@ const runner = vi.hoisted(() => ({
   retryPlaylist: vi.fn(),
   retryDownload: vi.fn(),
   adoptSelectedClips: vi.fn(),
+  downloadOnly: vi.fn(),
   run: vi.fn(),
   stop: vi.fn(),
 }));
@@ -286,6 +287,9 @@ describe("Overlay shell", () => {
     expect(
       container.querySelector('[data-suno-control="retry-download"]')
     ).toBeNull();
+    expect(
+      container.querySelector('[data-suno-control="download-only"]')
+    ).not.toBeNull();
   });
 
   it("challenge履歴を総件数と直近5件で表示する", async () => {

--- a/extensions/suno-helper/tests/overlay-component.test.tsx
+++ b/extensions/suno-helper/tests/overlay-component.test.tsx
@@ -70,7 +70,11 @@ const runner = vi.hoisted(() => ({
   canRun: false,
   isRunning: false,
   completionSoundSettings: { enabled: true },
+  completionSoundSettingsLoaded: true,
   setCompletionSoundEnabled: vi.fn(),
+  downloadEnabled: true,
+  downloadEnabledLoaded: true,
+  setDownloadEnabled: vi.fn(),
   playlistName: "",
   runModeId: "serial",
   setRunMode: vi.fn(),
@@ -161,7 +165,10 @@ describe("Overlay shell", () => {
       itemStates: [],
       canRun: false,
       collectionQueue: null,
+      downloadEnabled: true,
+      downloadEnabledLoaded: true,
     });
+    runner.setDownloadEnabled.mockClear();
     runner.runCollectionQueue.mockClear();
     runner.resumeCollectionQueue.mockClear();
     runner.discardCollectionQueue.mockClear();
@@ -253,6 +260,32 @@ describe("Overlay shell", () => {
       minimized: false,
       hidden: false,
     });
+  });
+
+  it("download Switch は既定 ON で、OFF を永続化し Download 再開を隠す", async () => {
+    Object.assign(runner, {
+      selectedCollectionId: "collection",
+      playlistName: "playlist",
+      downloadEnabled: true,
+    });
+    await act(async () => root.render(createElement(Overlay)));
+
+    const toggle = container.querySelector<HTMLElement>(
+      '[data-suno-control="download-enabled"]'
+    )!;
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    expect(
+      container.querySelector('[data-suno-control="retry-download"]')
+    ).not.toBeNull();
+
+    await act(async () => toggle.click());
+    expect(runner.setDownloadEnabled).toHaveBeenCalledWith(false);
+
+    runner.downloadEnabled = false;
+    await act(async () => root.render(createElement(Overlay)));
+    expect(
+      container.querySelector('[data-suno-control="retry-download"]')
+    ).toBeNull();
   });
 
   it("challenge履歴を総件数と直近5件で表示する", async () => {

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -933,6 +933,7 @@ describe("Suno popup compatibility check", () => {
     expect(entriesTrigger.getAttribute("aria-expanded")).toBe("false");
     for (const control of [
       "adopt-selected-clips",
+      "download-only",
       "retry-playlist",
       "retry-download",
     ]) {
@@ -942,6 +943,7 @@ describe("Suno popup compatibility check", () => {
       expectControl(container, "adopt-selected-clips"),
       "outline"
     );
+    expectShadcnControl(expectControl(container, "download-only"), "success");
     expectShadcnControl(expectControl(container, "retry-playlist"), "warning");
     expectShadcnControl(expectControl(container, "retry-download"), "success");
     const collectionCheckbox = expectControl(container, "collection-checkbox");
@@ -2664,7 +2666,7 @@ describe("Suno popup compatibility check", () => {
     );
   });
 
-  it("選択中 clip 採用後に Download から再開すると retryDownload payload を送る", async () => {
+  it("ダウンロードのみ実行は選択中 clip を採用して retryDownload へ直行する", async () => {
     const entries = [{ name: "p1", style: "lofi", lyrics: "" }];
     const downloadResponse = deferred<unknown>();
     fetchMock
@@ -2707,20 +2709,15 @@ describe("Suno popup compatibility check", () => {
       expect(container.textContent).toContain("1 パターンを取得しました。");
     });
 
-    await act(async () => {
-      buttonByText(container, "選択中の曲を採用").click();
-    });
+    const downloadToggle = expectControl(container, "download-enabled");
+    await act(async () => downloadToggle.click());
     await waitFor(() => {
-      expect(container.textContent).toContain(
-        "選択中の曲 2 件を採用しました。"
-      );
+      expect(downloadToggle.getAttribute("aria-checked")).toBe("false");
+      expectControl(container, "download-only");
     });
-    expectShadcnControl(expectControl(container, "retry-playlist"), "warning");
-    expectShadcnControl(expectControl(container, "retry-download"), "success");
 
-    messagingMocks.sendMessage.mockClear();
     await act(async () => {
-      buttonByText(container, "Download から再開").click();
+      buttonByText(container, "ダウンロードのみ実行").click();
     });
 
     await waitFor(() => {
@@ -2730,6 +2727,10 @@ describe("Suno popup compatibility check", () => {
       expect(panel?.dataset.sunoPhase).toBe("downloading");
       expect(panel?.dataset.sunoRunning).toBe("true");
     });
+    expect(messagingMocks.sendMessage).toHaveBeenCalledWith(
+      "adoptSelectedClips",
+      { expectedClipCount: 2 }
+    );
     expect(messagingMocks.sendMessage).toHaveBeenCalledWith("retryDownload", {
       collectionId: "20260601-clm-theme-a-collection",
       submittedClipIds: ["clip-a", "clip-b"],

--- a/extensions/suno-helper/tests/popup-compatibility.test.ts
+++ b/extensions/suno-helper/tests/popup-compatibility.test.ts
@@ -47,6 +47,11 @@ const serverSourcesMocks = vi.hoisted(() => ({
   migrateServerSourcesStorage: vi.fn(async () => undefined),
 }));
 
+const downloadEnabledMocks = vi.hoisted(() => ({
+  getValue: vi.fn(async () => true),
+  setValue: vi.fn(async () => undefined),
+}));
+
 const legacySourceState = vi.hoisted(() => ({ present: true }));
 
 const resumeStateMocks = vi.hoisted(() => ({
@@ -80,6 +85,7 @@ vi.mock("wxt/browser", () => ({
 
 vi.mock("../lib/storage", () => ({
   serverUrlItem: storageMocks,
+  downloadEnabledItem: downloadEnabledMocks,
   completionSoundSettingsItem: completionSoundMocks,
   readCompletionSoundSettings: vi.fn(() => completionSoundMocks.getValue()),
   migrateServerSourcesStorage: serverSourcesMocks.migrateServerSourcesStorage,
@@ -388,6 +394,8 @@ describe("Suno popup compatibility check", () => {
     fetchMock = vi.fn();
     storageMocks.getValue.mockResolvedValue("");
     storageMocks.setValue.mockResolvedValue(undefined);
+    downloadEnabledMocks.getValue.mockResolvedValue(true);
+    downloadEnabledMocks.setValue.mockResolvedValue(undefined);
     completionSoundMocks.getValue.mockResolvedValue({
       enabled: true,
     });
@@ -798,6 +806,25 @@ describe("Suno popup compatibility check", () => {
     );
   });
 
+  it("download Switch は既定 ON で保存し、再表示時に OFF を復元する", async () => {
+    const enabled = expectControl(container, "download-enabled");
+    expect(enabled.dataset.slot).toBe("switch");
+    expect(enabled.getAttribute("aria-checked")).toBe("true");
+
+    await act(async () => enabled.click());
+    expect(downloadEnabledMocks.setValue).toHaveBeenCalledWith(false);
+
+    downloadEnabledMocks.getValue.mockResolvedValueOnce(false);
+    await rerenderApp();
+    await waitFor(() =>
+      expect(
+        expectControl(container, "download-enabled").getAttribute(
+          "aria-checked"
+        )
+      ).toBe("false")
+    );
+  });
+
   it("agent 操作用の root 状態属性と主要 control selector を実 DOM に公開する", async () => {
     const entries = [
       { name: "p1", style: "lofi", lyrics: "" },
@@ -1204,6 +1231,7 @@ describe("Suno popup compatibility check", () => {
       collectionId: "20260601-clm-theme-a-collection",
       runMode: "serial",
       regenerateDurationOutliers: false,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: undefined,
       submittedClipIdsAreDurationFiltered: undefined,
@@ -1328,6 +1356,7 @@ describe("Suno popup compatibility check", () => {
       collectionId: "20260601-clm-theme-a-collection",
       runMode: "queue",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: undefined,
       submittedClipIdsAreDurationFiltered: undefined,
@@ -1645,6 +1674,7 @@ describe("Suno popup compatibility check", () => {
       collectionId: "20260601-clm-theme-a-collection",
       runMode: "queue",
       regenerateDurationOutliers: false,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: [],
       submittedClipIdsAreDurationFiltered: false,
@@ -1742,6 +1772,7 @@ describe("Suno popup compatibility check", () => {
       regenerateDurationOutliers: false,
       indices: [1],
       submittedClipIds: ["clip-a", "clip-short"],
+      downloadEnabled: true,
       submittedClipIdsAreDurationFiltered: false,
       playlistExpectedClipCount: 4,
       durationOutlierWarnings: { 0: warning },
@@ -1908,6 +1939,7 @@ describe("Suno popup compatibility check", () => {
       regenerateDurationOutliers: true,
       indices: [0, 2],
       submittedClipIds: undefined,
+      downloadEnabled: true,
       submittedClipIdsAreDurationFiltered: undefined,
       playlistExpectedClipCount: undefined,
     });
@@ -2088,6 +2120,7 @@ describe("Suno popup compatibility check", () => {
       collectionId: "20260602-clm-snapshot-collection",
       runMode: "serial",
       regenerateDurationOutliers: false,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: [],
       submittedClipIdsAreDurationFiltered: false,
@@ -2174,6 +2207,7 @@ describe("Suno popup compatibility check", () => {
       collectionId: "20260603-clm-fresh-collection",
       runMode: "serial",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: undefined,
       submittedClipIdsAreDurationFiltered: undefined,
@@ -3103,6 +3137,7 @@ describe("Suno popup compatibility check", () => {
       regenerateDurationOutliers: true,
       durationOutlierWarnings: undefined,
       shouldDownload: true,
+      downloadEnabled: true,
     });
     await act(async () => {
       playlistResponse.resolve({ ok: true });
@@ -3187,6 +3222,7 @@ describe("Suno popup compatibility check", () => {
         0: "duration guard NG (75-180s): clip-b; 再生成 OFF のため全 clip を採用候補として保持します",
       },
       shouldDownload: true,
+      downloadEnabled: true,
     });
 
     await act(async () => {

--- a/extensions/suno-helper/tests/queue-runner.test.ts
+++ b/extensions/suno-helper/tests/queue-runner.test.ts
@@ -105,6 +105,7 @@ describe("queue-runner: production ロジック (#1586)", () => {
       range: undefined,
       collectionId: "queue-smoke",
       runMode: "queue",
+      downloadEnabled: true,
       overrides: undefined,
     });
     const submittedIndexes: number[] = [];

--- a/extensions/suno-helper/tests/storage.test.ts
+++ b/extensions/suno-helper/tests/storage.test.ts
@@ -11,18 +11,34 @@ const storageItems = vi.hoisted(() => {
     setValue: vi.fn(),
     removeValue: vi.fn(),
   };
-  return { serverUrl, legacySources, defineItem: vi.fn() };
+  const downloadEnabled = {
+    getValue: vi.fn(),
+    setValue: vi.fn(),
+    removeValue: vi.fn(),
+    fallback: undefined as unknown,
+  };
+  return { serverUrl, legacySources, downloadEnabled, defineItem: vi.fn() };
 });
 
 vi.mock("wxt/utils/storage", () => {
-  storageItems.defineItem.mockImplementation((key: string) => {
-    if (key === "local:sunoServerUrl") return storageItems.serverUrl;
-    return storageItems.legacySources;
-  });
+  storageItems.defineItem.mockImplementation(
+    (key: string, options?: { fallback?: unknown }) => {
+      if (key === "local:sunoServerUrl") return storageItems.serverUrl;
+      if (key === "local:sunoDownloadEnabled") {
+        storageItems.downloadEnabled.fallback = options?.fallback;
+        return storageItems.downloadEnabled;
+      }
+      return storageItems.legacySources;
+    }
+  );
   return { storage: { defineItem: storageItems.defineItem } };
 });
 
-import { migrateServerSourcesStorage, serverUrlItem } from "../lib/storage";
+import {
+  downloadEnabledItem,
+  migrateServerSourcesStorage,
+  serverUrlItem,
+} from "../lib/storage";
 
 describe("Suno server source storage migration", () => {
   beforeEach(() => {
@@ -65,5 +81,12 @@ describe("Suno server source storage migration", () => {
     await expect(migrateServerSourcesStorage()).rejects.toThrow(
       "storage unavailable"
     );
+  });
+});
+
+describe("download preference storage", () => {
+  it("defaults the local download preference to enabled", () => {
+    expect(storageItems.downloadEnabled.fallback).toBe(true);
+    expect(downloadEnabledItem).toBe(storageItems.downloadEnabled);
   });
 });

--- a/extensions/suno-helper/tests/unattended-run.test.ts
+++ b/extensions/suno-helper/tests/unattended-run.test.ts
@@ -27,6 +27,7 @@ const REQUEST: UnattendedRunRequest = {
   baseUrl: "http://rjn.localhost:7873",
   collectionId: COLLECTION.id,
   entryIndices: [0, 1, 2, 3, 4],
+  skipDownload: false,
   limits: {
     maxEntries: 2,
     maxConcurrentGenerations: 3,
@@ -75,9 +76,41 @@ describe("assertUnattendedRunRequest", () => {
       assertUnattendedRunRequest({ ...REQUEST, downloadFormat: "mp3" })
     ).toEqual(REQUEST);
   });
+
+  it("treats an omitted skipDownload as false and accepts an explicit skip", () => {
+    expect(assertUnattendedRunRequest(REQUEST).skipDownload).toBe(false);
+    expect(
+      assertUnattendedRunRequest({ ...REQUEST, skipDownload: true })
+        .skipDownload
+    ).toBe(true);
+  });
 });
 
 describe("planUnattendedRun", () => {
+  it("completes a skip-download request from the durable playlist checkpoint", () => {
+    expect(
+      planUnattendedRun({
+        request: { ...REQUEST, skipDownload: true },
+        collection: {
+          ...COLLECTION,
+          suno_playlist_url: "https://suno.com/playlist/known",
+        },
+        entryCount: 5,
+        resumeState: {
+          collectionId: COLLECTION.id,
+          failedIndex: 5,
+          total: 5,
+          timestamp: Date.now(),
+          submittedClipIds: Array.from(
+            { length: 10 },
+            (_, index) => `clip-${index}`
+          ),
+          playlistExpectedClipCount: 10,
+        },
+      })
+    ).toEqual({ kind: "complete", reason: "playlist-created" });
+  });
+
   it("caps work and carries the remaining entries to the next scheduled run", () => {
     expect(
       planUnattendedRun({

--- a/extensions/suno-helper/tests/unattended-run.test.ts
+++ b/extensions/suno-helper/tests/unattended-run.test.ts
@@ -94,6 +94,7 @@ describe("planUnattendedRun", () => {
         collection: {
           ...COLLECTION,
           suno_playlist_url: "https://suno.com/playlist/known",
+          expected_file_count: 10,
         },
         entryCount: 5,
         resumeState: {
@@ -109,6 +110,26 @@ describe("planUnattendedRun", () => {
         },
       })
     ).toEqual({ kind: "complete", reason: "playlist-created" });
+  });
+
+  it("does not complete skip-download when entries were added after the playlist checkpoint", () => {
+    expect(
+      planUnattendedRun({
+        request: {
+          ...REQUEST,
+          entryIndices: undefined,
+          skipDownload: true,
+        },
+        collection: {
+          ...COLLECTION,
+          pattern_count: 8,
+          suno_playlist_url: "https://suno.com/playlist/known",
+          expected_file_count: 10,
+        },
+        entryCount: 8,
+        resumeState: null,
+      })
+    ).not.toMatchObject({ kind: "complete" });
   });
 
   it("caps work and carries the remaining entries to the next scheduled run", () => {

--- a/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
+++ b/extensions/suno-helper/tests/use-suno-runner-resume.test.ts
@@ -131,6 +131,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       collectionId: "collection-a",
       runMode: "queue",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       overrides,
     });
 
@@ -141,6 +142,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       collectionId: "collection-a",
       runMode: "queue",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       indices: undefined,
       submittedClipIds: ["clip-a", "clip-b"],
       submittedClipIdsAreDurationFiltered: true,
@@ -183,6 +185,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       collectionId: "collection-a",
       runMode: "serial",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       overrides,
     });
 
@@ -193,6 +196,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       collectionId: "collection-a",
       runMode: "serial",
       regenerateDurationOutliers: true,
+      downloadEnabled: true,
       indices: [0, 2],
       submittedClipIds: ["clip-a", "clip-c"],
       submittedClipIdsAreDurationFiltered: true,
@@ -252,6 +256,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       range: undefined,
       collectionId: "collection-a",
       runMode: "queue",
+      downloadEnabled: true,
       overrides: undefined,
     });
 
@@ -273,6 +278,7 @@ describe("submitted clip ID resume wiring: failed-only rerun / playlist-only res
       range: undefined,
       collectionId: "collection-a",
       runMode: "serial" as const,
+      downloadEnabled: true,
     };
 
     expect(

--- a/src/youtube_automation/commands/suno/suno_unattended_request.py
+++ b/src/youtube_automation/commands/suno/suno_unattended_request.py
@@ -47,6 +47,7 @@ def build_unattended_request(
     max_entries: int,
     max_concurrent_generations: int,
     max_retries: int,
+    skip_download: bool,
     request_id: str | None = None,
 ) -> dict[str, object]:
     collection_id = collection_id.strip()
@@ -72,6 +73,7 @@ def build_unattended_request(
         "requestId": resolved_request_id,
         "baseUrl": _loopback_base_url(base_url),
         "collectionId": collection_id,
+        "skipDownload": skip_download,
         "limits": {
             "maxEntries": _bounded_integer(max_entries, "--max-entries", 1, 100),
             "maxConcurrentGenerations": _bounded_integer(
@@ -138,6 +140,11 @@ def _parser() -> argparse.ArgumentParser:
         help=fallback.format(key="max_concurrent_generations"),
     )
     parser.add_argument("--max-retries", type=int, help=fallback.format(key="max_retries"))
+    parser.add_argument(
+        "--skip-download",
+        action="store_true",
+        help="playlist 追加で完了し、Suno Studio からのダウンロードを行わない",
+    )
     parser.add_argument("--request-id", help="監査用 ID。省略時は UTC 時刻と乱数から生成")
     return parser
 
@@ -166,6 +173,7 @@ def main(argv: list[str] | None = None) -> int:
         max_entries=args.max_entries,
         max_concurrent_generations=args.max_concurrent_generations,
         max_retries=args.max_retries,
+        skip_download=args.skip_download,
         request_id=args.request_id,
     )
     nonce = register_unattended_request(args.base_url, request)

--- a/tests/commands/suno/test_suno_unattended_request.py
+++ b/tests/commands/suno/test_suno_unattended_request.py
@@ -31,6 +31,7 @@ def test_build_request_matches_extension_wire_contract() -> None:
         max_entries=2,
         max_concurrent_generations=3,
         max_retries=1,
+        skip_download=True,
         request_id="scheduled-test",
     )
     assert request == {
@@ -39,6 +40,7 @@ def test_build_request_matches_extension_wire_contract() -> None:
         "baseUrl": "http://rjn.localhost:7873/path",
         "collectionId": "20260718-rjn-night-drive-collection",
         "entryIndices": [0, 2],
+        "skipDownload": True,
         "limits": {
             "maxEntries": 2,
             "maxConcurrentGenerations": 3,
@@ -75,6 +77,7 @@ def test_rejects_unsafe_or_unbounded_requests(override: dict[str, object], messa
         "max_entries": 1,
         "max_concurrent_generations": 1,
         "max_retries": 0,
+        "skip_download": False,
         "request_id": "request",
     }
     arguments.update(override)
@@ -159,8 +162,39 @@ def test_cli_uses_skill_config_defaults(capsys: pytest.CaptureFixture[str], monk
     assert envelope["nonce"] == "abcdefghijklmnopqrstuvwxyzABCDEFGH_1234567890"
     request = captured[0]
     assert "downloadFormat" not in request
+    assert request["skipDownload"] is False
     assert request["limits"] == {
         "maxEntries": 10,
         "maxConcurrentGenerations": 3,
         "maxRetries": 2,
     }
+
+
+def test_cli_skip_download_sets_wire_contract(
+    capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        suno_unattended_request,
+        "register_unattended_request",
+        lambda _base_url, request: captured.append(request)
+        or "abcdefghijklmnopqrstuvwxyzABCDEFGH_1234567890",
+    )
+
+    assert (
+        main(
+            [
+                "--base-url",
+                "http://localhost:7873",
+                "--collection-id",
+                "collection",
+                "--request-id",
+                "scheduled-test",
+                "--skip-download",
+            ]
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    assert captured[0]["skipDownload"] is True

--- a/tests/commands/suno/test_suno_unattended_request.py
+++ b/tests/commands/suno/test_suno_unattended_request.py
@@ -177,8 +177,7 @@ def test_cli_skip_download_sets_wire_contract(
     monkeypatch.setattr(
         suno_unattended_request,
         "register_unattended_request",
-        lambda _base_url, request: captured.append(request)
-        or "abcdefghijklmnopqrstuvwxyzABCDEFGH_1234567890",
+        lambda _base_url, request: captured.append(request) or "abcdefghijklmnopqrstuvwxyzABCDEFGH_1234567890",
     )
 
     assert (


### PR DESCRIPTION
## 変更内容

- overlay に「ダウンロードまで実行する」Switchを既定ONで追加し永続化する
- OFF時はplaylist追加を完了地点としてStudio exportと`/downloaded` POSTを省略する
- unattended request に `--skip-download` と再開時の設定維持を追加する
- queue／retry／popup互換／skill文書を新しい契約へ追従する

Closes #4924