### PR TITLE
chore(suno-helper): ext-v0.4.0

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "description": "/suno が生成した Style/Lyrics を Suno の Advanced タブに順次注入し Generate を連続実行する補助拡張 (WXT + React + TS)。",
   "type": "module",


### PR DESCRIPTION
## Summary

suno-helper の Chrome 拡張リリース準備。

- `extensions/suno-helper/package.json` を `0.3.0` から `0.4.0` へ更新
- Python 本体・他の拡張・lockfile は変更なし

## Local verification

- `bash .claude/skills/automation-release/references/verify-extensions.sh suno-helper`: PASS
- Nix extensions shell: Node 24 / pnpm 11.15.1
- frozen install / build / zip: PASS
- `suno-helper-0.4.0-chrome.zip`: 生成確認
- 差分ガード: `package.json::version` の1行のみ