### PR TITLE
feat: 末尾のパディング無音を除去する (#4955)

### DIFF
--- a/.claude/skills/music/config.default.yaml
+++ b/.claude/skills/music/config.default.yaml
@@ -591,7 +591,8 @@ master:
       bitrate: "192k"             # libmp3lame 出力ビットレート (未指定なら audio.bitrate)
       codec: "libmp3lame"
       trim_silence:
-        enabled: true             # 冒頭無音を silenceremove でカット
+        enabled: true             # 冒頭・末尾無音を silenceremove でカット
+        trailing: true            # false で末尾カットだけを無効化
         threshold_db: -50
       eq:
         enabled: true             # 350Hz のもやつき / 8kHz 以上のシャリつきを軽く抑える

--- a/.claude/skills/music/references/master.md
+++ b/.claude/skills/music/references/master.md
@@ -75,6 +75,7 @@ TS CLI `uv run yt-generate-master` は `audio` の実行時既定値を組み込
 | `post_processing.rain_layers.output_codec` / `.output_sample_rate` | `pcm_s16le` / `44100` | 出力 WAV の ffmpeg コーデックとサンプリングレート（ステレオ固定）。後段の外部 DAW でミキシング+マスタリングする運用想定 |
 | `post_processing.suno_audio_cleanup.enabled` | `true` | Suno ダウンロード直後の個別音源に、無音カット / EQ / dynaudnorm / limiter / LUFS 正規化 / 末尾 fade guard を適用する。従来挙動へ戻す場合はチャンネル側で `false` にする |
 | `post_processing.suno_audio_cleanup.max_workers` | `2` | `apply` の曲単位最大並列数（1〜8）。CLI `--jobs` が優先し、`--jobs 1` で従来どおり main thread の直列実行を選ぶ。範囲外は処理開始前に失敗する |
+| `post_processing.suno_audio_cleanup.trim_silence.trailing` | `true` | 冒頭カットは維持したまま末尾無音カットだけを止める場合は `false`。冒頭・末尾とも `threshold_db` を共用する |
 | `post_processing.suno_audio_cleanup.loudnorm.I` | `-14` | YouTube 向け LUFS 正規化の目標値。チャンネル側 `config/skills/masterup.json` 優先、既存 `masterup.yaml` fallback で調整可能 |
 | `validation.loudness_deviation.max_lu` | `2.0` | マスター結合前に許容するコレクション内 integrated LUFS の最大差（LU）。0 より大きい数値のみ |
 | `pair_selection.mode` | `auto` | `suno-prompts.json` の `lyrics` から歌詞あり/なしを判定し、歌詞ありならペアから 1 曲、歌詞なしなら 2 clip 両方を採用する。`never` で整理をスキップ |
@@ -338,7 +339,7 @@ Audio Studio で調整した値が `20-documentation/audio-adjustments.json::tra
 
 適用内容:
 
-- 冒頭無音カット (`silenceremove`)
+- 冒頭・末尾無音カット (`silenceremove`。末尾は `areverse` で本当の末尾だけを対象にする)
 - 350Hz 付近のもやつき / 8kHz 付近のシャリつきを軽く抑える EQ
 - 曲中の音量ムラを `dynaudnorm` で緩和
 - `alimiter` による瞬間ピーク抑制

--- a/changelog.d/4955-trim-trailing-silence.added.md
+++ b/changelog.d/4955-trim-trailing-silence.added.md
@@ -1,0 +1,1 @@
+- `yt-suno-audio-cleanup` が既定で末尾のパディング無音も除去し、トリム後の実尺を基準に fade-out guard を適用するようにした

--- a/src/youtube_automation/commands/suno/suno_audio_cleanup.py
+++ b/src/youtube_automation/commands/suno/suno_audio_cleanup.py
@@ -36,6 +36,7 @@ class CleanupConfig:
     enabled: bool = False
     backup_originals: bool = True
     trim_silence: bool = True
+    trim_silence_trailing: bool = True
     silence_threshold_db: float = -50.0
     adaptive_eq: bool = True
     muddiness_freq_hz: int = 350
@@ -77,6 +78,7 @@ def resolve_cleanup_config(skill_cfg: Mapping[str, object]) -> CleanupConfig:
         enabled=bool(raw.get("enabled", False)),
         backup_originals=bool(raw.get("backup_originals", True)),
         trim_silence=bool(trim.get("enabled", True)),
+        trim_silence_trailing=bool(trim.get("trailing", True)),
         silence_threshold_db=float(trim.get("threshold_db", -50.0)),
         adaptive_eq=bool(eq.get("enabled", True)),
         muddiness_freq_hz=int(eq.get("muddiness_freq_hz", 350)),
@@ -114,7 +116,11 @@ def cleanup_config_settings(cfg: CleanupConfig) -> dict[str, object]:
             "TP": cfg.true_peak,
         },
         "limiter": {"enabled": cfg.limiter, "limit": cfg.limiter_limit},
-        "trim_silence": {"enabled": cfg.trim_silence, "threshold_db": cfg.silence_threshold_db},
+        "trim_silence": {
+            "enabled": cfg.trim_silence,
+            "trailing": cfg.trim_silence_trailing,
+            "threshold_db": cfg.silence_threshold_db,
+        },
         "tail_fade_guard": {"enabled": cfg.tail_fade_guard, "fade_sec": cfg.tail_fade_sec},
         "volume_smoothing": cfg.volume_smoothing,
     }
@@ -142,6 +148,7 @@ def apply_cleanup_overrides(cfg: CleanupConfig, overrides: object) -> CleanupCon
         limiter=cast(bool, limiter.get("enabled", cfg.limiter)),
         limiter_limit=cast(float, limiter.get("limit", cfg.limiter_limit)),
         trim_silence=cast(bool, trim.get("enabled", cfg.trim_silence)),
+        trim_silence_trailing=cast(bool, trim.get("trailing", cfg.trim_silence_trailing)),
         silence_threshold_db=cast(float, trim.get("threshold_db", cfg.silence_threshold_db)),
         tail_fade_guard=cast(bool, tail.get("enabled", cfg.tail_fade_guard)),
         tail_fade_sec=cast(float, tail.get("fade_sec", cfg.tail_fade_sec)),
@@ -202,6 +209,17 @@ def build_filter(cfg: CleanupConfig, *, duration_sec: float | None = None) -> st
         filters.append(
             f"silenceremove=start_periods=1:start_duration=0.2:start_threshold={cfg.silence_threshold_db:g}dB"
         )
+        if cfg.trim_silence_trailing:
+            filters.extend(
+                [
+                    "areverse",
+                    (
+                        "silenceremove=start_periods=1:start_duration=0.2:"
+                        f"start_threshold={cfg.silence_threshold_db:g}dB"
+                    ),
+                    "areverse",
+                ]
+            )
     if cfg.adaptive_eq:
         filters.append(f"equalizer=f={cfg.muddiness_freq_hz}:t=q:w=1:g={cfg.muddiness_gain_db:g}")
         filters.append(f"equalizer=f={cfg.harshness_freq_hz}:t=q:w=1:g={cfg.harshness_gain_db:g}")
@@ -215,6 +233,43 @@ def build_filter(cfg: CleanupConfig, *, duration_sec: float | None = None) -> st
         start = max(0.0, duration_sec - cfg.tail_fade_sec)
         filters.append(f"afade=t=out:st={start:g}:d={cfg.tail_fade_sec:g}")
     return ",".join(filters) if filters else "anull"
+
+
+def probe_trimmed_duration(path: Path, cfg: CleanupConfig) -> float:
+    """Measure the duration after the same leading/trailing silence trim used by cleanup."""
+    trim_only = replace(
+        cfg,
+        adaptive_eq=False,
+        volume_smoothing=False,
+        limiter=False,
+        loudnorm=False,
+        tail_fade_guard=False,
+    )
+    cmd = [
+        "ffmpeg",
+        "-nostdin",
+        "-i",
+        str(path),
+        "-af",
+        build_filter(trim_only),
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        "-f",
+        "null",
+        "-",
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(f"ffmpeg trim duration probe failed ({path.name}, rc={proc.returncode}):\n{proc.stderr}")
+    durations = [
+        int(line.removeprefix("out_time_us=")) / 1_000_000
+        for line in proc.stdout.splitlines()
+        if line.startswith("out_time_us=") and line.removeprefix("out_time_us=").isdigit()
+    ]
+    if not durations:
+        raise RuntimeError(f"ffmpeg trim duration probe returned no duration: {path.name}")
+    return max(durations)
 
 
 def collect_audio_files(collection_dir: Path) -> list[Path]:
@@ -265,6 +320,8 @@ def process_file(path: Path, cfg: CleanupConfig, *, apply: bool, force: bool, qu
         return False
 
     duration = probe_duration(path)
+    if apply and cfg.trim_silence and cfg.trim_silence_trailing and cfg.tail_fade_guard:
+        duration = probe_trimmed_duration(path, cfg)
     tmp = _tmp_output_for(path)
     cmd = build_ffmpeg_cmd(path, tmp, cfg, duration_sec=duration)
 

--- a/src/youtube_automation/commands/suno/suno_audio_cleanup.py
+++ b/src/youtube_automation/commands/suno/suno_audio_cleanup.py
@@ -206,20 +206,13 @@ def _codec_uses_bitrate(codec: str) -> bool:
 def build_filter(cfg: CleanupConfig, *, duration_sec: float | None = None) -> str:
     filters: list[str] = []
     if cfg.trim_silence:
-        filters.append(
+        # 末尾は areverse で挟み、同じ silenceremove を「冒頭」として適用する
+        silence_step = (
             f"silenceremove=start_periods=1:start_duration=0.2:start_threshold={cfg.silence_threshold_db:g}dB"
         )
+        filters.append(silence_step)
         if cfg.trim_silence_trailing:
-            filters.extend(
-                [
-                    "areverse",
-                    (
-                        "silenceremove=start_periods=1:start_duration=0.2:"
-                        f"start_threshold={cfg.silence_threshold_db:g}dB"
-                    ),
-                    "areverse",
-                ]
-            )
+            filters.extend(["areverse", silence_step, "areverse"])
     if cfg.adaptive_eq:
         filters.append(f"equalizer=f={cfg.muddiness_freq_hz}:t=q:w=1:g={cfg.muddiness_gain_db:g}")
         filters.append(f"equalizer=f={cfg.harshness_freq_hz}:t=q:w=1:g={cfg.harshness_gain_db:g}")
@@ -319,9 +312,10 @@ def process_file(path: Path, cfg: CleanupConfig, *, apply: bool, force: bool, qu
             print(f"skip already cleaned: {path.name} (backup exists)")
         return False
 
-    duration = probe_duration(path)
     if apply and cfg.trim_silence and cfg.trim_silence_trailing and cfg.tail_fade_guard:
         duration = probe_trimmed_duration(path, cfg)
+    else:
+        duration = probe_duration(path)
     tmp = _tmp_output_for(path)
     cmd = build_ffmpeg_cmd(path, tmp, cfg, duration_sec=duration)
 

--- a/src/youtube_automation/domains/media/audio_adjustments.py
+++ b/src/youtube_automation/domains/media/audio_adjustments.py
@@ -31,7 +31,11 @@ _NESTED_FIELDS: dict[str, dict[str, tuple[type[object], float | None, float | No
         "TP": (float, -9, 0),
     },
     "limiter": {"enabled": (bool, None, None), "limit": (float, 0.01, 1)},
-    "trim_silence": {"enabled": (bool, None, None), "threshold_db": (float, -100, 0)},
+    "trim_silence": {
+        "enabled": (bool, None, None),
+        "trailing": (bool, None, None),
+        "threshold_db": (float, -100, 0),
+    },
     "tail_fade_guard": {"enabled": (bool, None, None), "fade_sec": (float, 0, 60)},
 }
 _BOOLEAN_FIELDS = frozenset({"volume_smoothing"})

--- a/tests/commands/suno/test_suno_audio_cleanup.py
+++ b/tests/commands/suno/test_suno_audio_cleanup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import threading
 from pathlib import Path
@@ -16,11 +17,17 @@ from youtube_automation.commands.suno.suno_audio_cleanup import (
     build_filter,
     cleanup_collection,
     collect_audio_files,
+    probe_trimmed_duration,
     process_file,
     resolve_cleanup_config,
     resolve_max_workers,
 )
 from youtube_automation.core.errors import ConfigError
+
+
+@pytest.fixture(autouse=True)
+def _reuse_input_duration_unless_duration_probe_is_under_test(monkeypatch) -> None:
+    monkeypatch.setattr(mod, "probe_trimmed_duration", lambda path, _cfg: mod.probe_duration(path))
 
 
 def _make_collection(tmp_path: Path, names: list[str]) -> Path:
@@ -37,6 +44,7 @@ def test_resolve_cleanup_config_defaults_disabled() -> None:
     assert cfg.enabled is False
     assert cfg.target_lufs == -14.0
     assert cfg.backup_originals is True
+    assert cfg.trim_silence_trailing is True
 
 
 def test_resolve_cleanup_config_accepts_overrides() -> None:
@@ -72,6 +80,15 @@ def test_apply_cleanup_overrides_changes_only_explicit_track_values() -> None:
     assert resolved.limiter is False
     assert resolved.harshness_gain_db == defaults.harshness_gain_db
     assert resolved.bitrate == defaults.bitrate
+
+
+def test_trailing_silence_can_be_disabled_per_track() -> None:
+    defaults = CleanupConfig(enabled=True)
+
+    resolved = apply_cleanup_overrides(defaults, {"trim_silence": {"trailing": False}})
+
+    assert resolved.trim_silence is True
+    assert resolved.trim_silence_trailing is False
 
 
 def test_resolve_cleanup_config_rejects_bad_shape() -> None:
@@ -172,13 +189,86 @@ def test_main_passes_jobs_to_cleanup_collection(monkeypatch) -> None:
 
 def test_build_filter_contains_expected_ffmpeg_steps() -> None:
     filt = build_filter(CleanupConfig(enabled=True), duration_sec=120)
-    assert "silenceremove" in filt
+    leading = "silenceremove=start_periods=1:start_duration=0.2:start_threshold=-50dB"
+    assert filt.startswith(f"{leading},areverse,{leading},areverse,")
     assert "equalizer=f=350" in filt
     assert "equalizer=f=8000" in filt
     assert "dynaudnorm" in filt
     assert "alimiter=limit=0.95" in filt
     assert "loudnorm=I=-14" in filt
     assert "afade=t=out:st=117:d=3" in filt
+
+
+def test_build_filter_trailing_opt_out_keeps_leading_trim() -> None:
+    filt = build_filter(CleanupConfig(trim_silence_trailing=False))
+
+    assert filt.startswith("silenceremove=start_periods=1:start_duration=0.2:start_threshold=-50dB,")
+    assert "areverse" not in filt
+
+
+def test_build_filter_disabled_trim_has_no_leading_or_trailing_trim() -> None:
+    filt = build_filter(CleanupConfig(trim_silence=False))
+
+    assert "silenceremove" not in filt
+    assert "areverse" not in filt
+
+
+def test_probe_trimmed_duration_reads_ffmpeg_progress(monkeypatch, tmp_path: Path) -> None:
+    source = tmp_path / "track.wav"
+    source.write_bytes(b"audio")
+
+    def fake_run(cmd, capture_output, text):
+        assert cmd[cmd.index("-af") + 1].count("areverse") == 2
+        assert ["-f", "null", "-"] == cmd[cmd.index("-f") : cmd.index("-f") + 3]
+        return subprocess.CompletedProcess(cmd, 0, stdout="out_time_us=57000000\nprogress=end\n", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    assert probe_trimmed_duration(source, CleanupConfig()) == 57.0
+
+
+@pytest.mark.skipif(shutil.which("ffmpeg") is None, reason="ffmpeg is required")
+def test_trailing_trim_preserves_mid_track_silence(tmp_path: Path) -> None:
+    source = tmp_path / "track.wav"
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=mono:d=3",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=frequency=440:duration=2",
+            "-f",
+            "lavfi",
+            "-i",
+            "anullsrc=r=44100:cl=mono:d=5",
+            "-filter_complex",
+            "[0:a][1:a][2:a][3:a]concat=n=4:v=0:a=1",
+            str(source),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    cfg = CleanupConfig(
+        backup_originals=False,
+        adaptive_eq=False,
+        volume_smoothing=False,
+        limiter=False,
+        loudnorm=False,
+        tail_fade_guard=False,
+    )
+
+    assert process_file(source, cfg, apply=True, force=False, quiet=True) is True
+    output_duration = mod.probe_duration(source)
+    assert 6.0 < output_duration < 8.0
 
 
 def test_collect_audio_files_uses_supported_extensions(tmp_path: Path) -> None:
@@ -562,6 +652,29 @@ def test_process_file_apply_backs_up_original_and_replaces(tmp_path: Path, monke
     assert changed is True
     assert backup.read_bytes() == b"audio"
     assert source.read_bytes() == b"cleaned"
+
+
+def test_process_file_positions_fade_from_trimmed_duration(tmp_path: Path, monkeypatch) -> None:
+    collection = _make_collection(tmp_path, ["01-a.mp3"])
+    source = collection / "02-Individual-music" / "01-a.mp3"
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(mod, "probe_duration", lambda _path: 120)
+    monkeypatch.setattr(mod, "probe_trimmed_duration", lambda _path, _cfg: 60)
+    monkeypatch.setattr(mod.shutil, "which", lambda _name: "/usr/bin/ffmpeg")
+
+    def fake_run(cmd, capture_output, text):
+        commands.append(cmd)
+        Path(cmd[-1]).write_bytes(b"cleaned")
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(mod.subprocess, "run", fake_run)
+
+    process_file(source, CleanupConfig(enabled=True), apply=True, force=False, quiet=True)
+
+    audio_filter = commands[0][commands[0].index("-af") + 1]
+    assert "afade=t=out:st=57:d=3" in audio_filter
+    assert "st=117" not in audio_filter
 
 
 @pytest.mark.parametrize(

--- a/tests/domains/media/test_audio_adjustments.py
+++ b/tests/domains/media/test_audio_adjustments.py
@@ -30,7 +30,7 @@ def _settings() -> dict[str, object]:
         },
         "loudnorm": {"enabled": True, "I": -14.0, "LRA": 11.0, "TP": -1.5},
         "limiter": {"enabled": True, "limit": 0.95},
-        "trim_silence": {"enabled": True, "threshold_db": -50.0},
+        "trim_silence": {"enabled": True, "trailing": True, "threshold_db": -50.0},
         "tail_fade_guard": {"enabled": True, "fade_sec": 3.0},
         "volume_smoothing": True,
     }


### PR DESCRIPTION
## Summary
- trim_silence に既定 ON の末尾無音カットを追加
- トリム後の実尺を解析して末尾 fade-out guard の開始位置を決定
- 曲単位 override、Audio Studio round trip、既定設定・ドキュメントを更新

Closes #4955