### PR TITLE
fix: canary 通知の channel 引数を保持する (#4888)

### DIFF
--- a/changelog.d/4888-codex-canary-channel.fixed.md
+++ b/changelog.d/4888-codex-canary-channel.fixed.md
@@ -1,0 +1,1 @@
+- `yt-codex-canary-notify` の通知 channel 引数が共通 workspace option に消費される問題を修正した（#4888）。

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -16,6 +16,7 @@ _CHANNEL_OPTION_CONFLICTS = {
     "youtube_automation.commands.analytics.benchmark_collector",
     "youtube_automation.commands.analytics.fetch_benchmark_comments",
     "youtube_automation.commands.analytics.video_analyze",
+    "youtube_automation.commands.system.codex_canary_notify",
     "youtube_automation.commands.thumbnail.compare_thumbnails",
 }
 

--- a/tests/commands/system/test_codex_canary_notify.py
+++ b/tests/commands/system/test_codex_canary_notify.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import sys
 from argparse import Namespace
 
 import pytest
 
+from youtube_automation import entrypoints
 from youtube_automation.commands.system import codex_canary_notify
 from youtube_automation.domains.notifications import NotificationEvent, NotificationEventKind
 
@@ -57,3 +59,22 @@ def test_cli_rejects_unknown_job_result_before_notification(monkeypatch) -> None
     with pytest.raises(SystemExit):
         codex_canary_notify.main(["--result", "pending", "--channel", "ambient-lab"])
     assert sink.events == []
+
+
+def test_console_entrypoint_preserves_notification_channel_option(monkeypatch) -> None:
+    sink = RecordingSink()
+    monkeypatch.setattr(codex_canary_notify, "create_discord_notification_sink", lambda: sink)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "yt-codex-canary-notify",
+            "--result",
+            "success",
+            "--channel",
+            "ambient-lab",
+        ],
+    )
+
+    assert entrypoints._run("youtube_automation.commands.system.codex_canary_notify") == 0
+    assert sink.events[0].channel == "ambient-lab"


### PR DESCRIPTION
## 変更内容
- `yt-codex-canary-notify` 固有の `--channel` を共通 option の前処理対象から除外
- console script 経路で通知先 channel が保持される回帰テストを追加
- changelog fragment を追加

Closes #4888