### PR TITLE
feat: fal.ai HTTP クライアントを追加する (#4946)

### DIFF
--- a/changelog.d/4946-fal-client.added.md
+++ b/changelog.d/4946-fal-client.added.md
@@ -1,2 +1,3 @@
-- fal.ai queue・storage API の安全な HTTP client と `FAL_KEY` の secret 解決を追加
-- fal の GET / download はリダイレクトを拒否し、HTTPS と host allowlist の境界を維持します。
+- fal.ai queue・storage API の安全な HTTP client と `FAL_KEY` の secret 解決を追加した（#4946）。
+- fal の GET / download が未検証のリダイレクトを拒否し、HTTPS と host allowlist の境界を維持するようにした（#4946）。
+- media client 共通の HTTP エラー変換・URL 検証を `infrastructure/media/_http_support.py` に集約し、fal / MiniMax の両 client から共有するようにした（#4946）。

--- a/changelog.d/4946-fal-client.added.md
+++ b/changelog.d/4946-fal-client.added.md
@@ -1,1 +1,2 @@
 - fal.ai queue・storage API の安全な HTTP client と `FAL_KEY` の secret 解決を追加
+- fal の GET / download はリダイレクトを拒否し、HTTPS と host allowlist の境界を維持します。

--- a/changelog.d/4946-fal-client.added.md
+++ b/changelog.d/4946-fal-client.added.md
@@ -1,0 +1,1 @@
+- fal.ai queue・storage API の安全な HTTP client と `FAL_KEY` の secret 解決を追加

--- a/src/youtube_automation/infrastructure/media/_http_support.py
+++ b/src/youtube_automation/infrastructure/media/_http_support.py
@@ -1,0 +1,51 @@
+"""``infrastructure/media`` の HTTP client が共有する低レベルヘルパー。
+
+media client 共通の流儀 — エラー文言に secret・payload・response body・下位例外の
+文言を含めない — をここに集約し、client ごとの再実装を防ぐ。
+"""
+
+from __future__ import annotations
+
+from typing import NoReturn
+from urllib.parse import SplitResult
+
+import requests
+
+from youtube_automation.core.errors import GeneratorError
+
+
+def http_status(response: requests.Response | None) -> int | None:
+    """response から int の status code だけを安全に取り出す。"""
+    if response is None:
+        return None
+    status_code = response.status_code
+    return status_code if isinstance(status_code, int) else None
+
+
+def raise_transport_error(operation: str, error: requests.RequestException) -> NoReturn:
+    """transport 例外を、secret や body を含まない ``GeneratorError`` へ変換する。"""
+    if isinstance(error, requests.Timeout):
+        raise GeneratorError(f"{operation} が timeout しました") from None
+    if isinstance(error, requests.HTTPError):
+        status = http_status(error.response)
+        detail = f" (status={status})" if status is not None else ""
+        raise GeneratorError(f"{operation} HTTP error{detail}") from None
+    raise GeneratorError(f"{operation} に失敗しました") from None
+
+
+def response_json(response: requests.Response, subject: str) -> dict[str, object]:
+    """response body を JSON object として解釈する。復号できない body は文言へ含めない。"""
+    try:
+        body = response.json()
+    except requests.exceptions.JSONDecodeError:
+        raise GeneratorError(f"{subject} response を JSON として解釈できません") from None
+    if not isinstance(body, dict):
+        raise GeneratorError(f"{subject} response は JSON object である必要があります")
+    return body
+
+
+def is_safe_https(parsed: SplitResult) -> bool:
+    """認証情報を埋め込んでいない HTTPS URL かを判定する（host allowlist は含まない）。"""
+    if parsed.scheme != "https" or not parsed.netloc:
+        return False
+    return parsed.username is None and parsed.password is None

--- a/src/youtube_automation/infrastructure/media/fal_client.py
+++ b/src/youtube_automation/infrastructure/media/fal_client.py
@@ -6,11 +6,17 @@ import json
 import mimetypes
 from collections.abc import Mapping
 from pathlib import Path
-from urllib.parse import urlsplit
+from urllib.parse import SplitResult, urlsplit
 
 import requests
 
 from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.media._http_support import (
+    http_status,
+    is_safe_https,
+    raise_transport_error,
+    response_json,
+)
 from youtube_automation.infrastructure.secrets import get_secret
 
 _QUEUE_BASE_URL = "https://queue.fal.run"
@@ -37,39 +43,16 @@ def _queue_url(path: str) -> str:
     return f"{_QUEUE_BASE_URL}/{path}"
 
 
+def _is_allowlisted_host(parsed: SplitResult) -> bool:
+    host = parsed.hostname
+    return host in _EXACT_HOSTS or (host is not None and host.endswith(".fal.media"))
+
+
 def _validated_url(url: str) -> str:
     parsed = urlsplit(url)
-    host = parsed.hostname
-    allowed = host in _EXACT_HOSTS or (host is not None and host.endswith(".fal.media"))
-    if parsed.scheme != "https" or not allowed or parsed.username is not None or parsed.password is not None:
+    if not is_safe_https(parsed) or not _is_allowlisted_host(parsed):
         raise GeneratorError("fal URL は許可された host の認証情報を含まない HTTPS URL である必要があります")
     return url
-
-
-def _status(response: requests.Response | None) -> int | None:
-    if response is None:
-        return None
-    return response.status_code if isinstance(response.status_code, int) else None
-
-
-def _raise_transport_error(operation: str, error: requests.RequestException) -> None:
-    if isinstance(error, requests.Timeout):
-        raise GeneratorError(f"fal {operation} が timeout しました") from None
-    if isinstance(error, requests.HTTPError):
-        status = _status(error.response)
-        detail = f" (status={status})" if status is not None else ""
-        raise GeneratorError(f"fal {operation} HTTP error{detail}") from None
-    raise GeneratorError(f"fal {operation} に失敗しました") from None
-
-
-def _response_json(response: requests.Response, operation: str) -> dict[str, object]:
-    try:
-        body = response.json()
-    except requests.exceptions.JSONDecodeError:
-        raise GeneratorError(f"fal {operation} response を JSON として解釈できません") from None
-    if not isinstance(body, dict):
-        raise GeneratorError(f"fal {operation} response は JSON object である必要があります")
-    return body
 
 
 def submit(path: str, payload: Mapping[str, object], *, timeout: float) -> dict[str, object]:
@@ -84,12 +67,12 @@ def submit(path: str, payload: Mapping[str, object], *, timeout: float) -> dict[
         )
         response.raise_for_status()
     except requests.RequestException as error:
-        _raise_transport_error("submit", error)
-    return _response_json(response, "submit")
+        raise_transport_error("fal submit", error)
+    return response_json(response, "fal submit")
 
 
 def _reject_redirect(response: requests.Response) -> None:
-    status = _status(response)
+    status = http_status(response)
     if status is not None and 300 <= status < 400:
         raise GeneratorError("fal redirect は許可されていません")
 
@@ -102,8 +85,8 @@ def get_url(url: str, *, timeout: float) -> dict[str, object]:
         _reject_redirect(response)
         response.raise_for_status()
     except requests.RequestException as error:
-        _raise_transport_error("GET", error)
-    return _response_json(response, "GET")
+        raise_transport_error("fal GET", error)
+    return response_json(response, "fal GET")
 
 
 def download(url: str, *, timeout: float) -> bytes:
@@ -114,7 +97,7 @@ def download(url: str, *, timeout: float) -> bytes:
         _reject_redirect(response)
         response.raise_for_status()
     except requests.RequestException as error:
-        _raise_transport_error("download", error)
+        raise_transport_error("fal download", error)
     return response.content
 
 
@@ -135,16 +118,18 @@ def upload_file(path: Path, *, timeout: float) -> str:
         )
         response.raise_for_status()
     except requests.RequestException as error:
-        _raise_transport_error("storage initiate", error)
+        raise_transport_error("fal storage initiate", error)
 
-    body = _response_json(response, "storage initiate")
+    body = response_json(response, "fal storage initiate")
     upload_url = body.get("upload_url")
     file_url = body.get("file_url")
     if not isinstance(upload_url, str) or not isinstance(file_url, str):
         raise GeneratorError("fal storage initiate response に必要な URL がありません")
     _validated_url(file_url)
-    parsed_upload = urlsplit(upload_url)
-    if parsed_upload.scheme != "https" or not parsed_upload.netloc or parsed_upload.username or parsed_upload.password:
+    # signed PUT 先は fal 側が採番する任意 host のため host allowlist の対象外とし、
+    # 認証済み initiate response（TLS 経由の rest.alpha.fal.ai）を信頼する。
+    # 認証情報なしの HTTPS であることだけは呼び出し前に必ず確認する。
+    if not is_safe_https(urlsplit(upload_url)):
         raise GeneratorError("fal storage upload URL が安全な HTTPS URL ではありません")
     try:
         data = path.read_bytes()
@@ -159,5 +144,5 @@ def upload_file(path: Path, *, timeout: float) -> str:
         )
         put_response.raise_for_status()
     except requests.RequestException as error:
-        _raise_transport_error("storage upload", error)
+        raise_transport_error("fal storage upload", error)
     return file_url

--- a/src/youtube_automation/infrastructure/media/fal_client.py
+++ b/src/youtube_automation/infrastructure/media/fal_client.py
@@ -1,0 +1,155 @@
+"""fal.ai queue / storage API の認証と HTTP 往復を所有する client。"""
+
+from __future__ import annotations
+
+import json
+import mimetypes
+from collections.abc import Mapping
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import requests
+
+from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.secrets import get_secret
+
+_QUEUE_BASE_URL = "https://queue.fal.run"
+_STORAGE_INITIATE_URL = "https://rest.alpha.fal.ai/storage/upload/initiate"
+_EXACT_HOSTS = frozenset({"queue.fal.run", "fal.run", "rest.alpha.fal.ai"})
+_LIFECYCLE_PREFERENCE = json.dumps({"expiration_duration_seconds": 86400})
+
+
+def get_api_key() -> str:
+    """既存の secret resolver から fal API key を解決する。"""
+    return get_secret("FAL_KEY")
+
+
+def _authorization_headers(*, json_content: bool = False) -> dict[str, str]:
+    headers = {"Authorization": f"Key {get_api_key()}"}
+    if json_content:
+        headers["Content-Type"] = "application/json"
+    return headers
+
+
+def _queue_url(path: str) -> str:
+    if not path or path.startswith("/") or "://" in path:
+        raise GeneratorError("fal API path は / を含まない相対 path である必要があります")
+    return f"{_QUEUE_BASE_URL}/{path}"
+
+
+def _validated_url(url: str) -> str:
+    parsed = urlsplit(url)
+    host = parsed.hostname
+    allowed = host in _EXACT_HOSTS or (host is not None and host.endswith(".fal.media"))
+    if parsed.scheme != "https" or not allowed or parsed.username is not None or parsed.password is not None:
+        raise GeneratorError("fal URL は許可された host の認証情報を含まない HTTPS URL である必要があります")
+    return url
+
+
+def _status(response: requests.Response | None) -> int | None:
+    if response is None:
+        return None
+    return response.status_code if isinstance(response.status_code, int) else None
+
+
+def _raise_transport_error(operation: str, error: requests.RequestException) -> None:
+    if isinstance(error, requests.Timeout):
+        raise GeneratorError(f"fal {operation} が timeout しました") from None
+    if isinstance(error, requests.HTTPError):
+        status = _status(error.response)
+        detail = f" (status={status})" if status is not None else ""
+        raise GeneratorError(f"fal {operation} HTTP error{detail}") from None
+    raise GeneratorError(f"fal {operation} に失敗しました") from None
+
+
+def _response_json(response: requests.Response, operation: str) -> dict[str, object]:
+    try:
+        body = response.json()
+    except requests.exceptions.JSONDecodeError:
+        raise GeneratorError(f"fal {operation} response を JSON として解釈できません") from None
+    if not isinstance(body, dict):
+        raise GeneratorError(f"fal {operation} response は JSON object である必要があります")
+    return body
+
+
+def submit(path: str, payload: Mapping[str, object], *, timeout: float) -> dict[str, object]:
+    """queue endpoint へ job を submit する。"""
+    url = _queue_url(path)
+    try:
+        response = requests.post(
+            url,
+            json=payload,
+            headers=_authorization_headers(json_content=True),
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.RequestException as error:
+        _raise_transport_error("submit", error)
+    return _response_json(response, "submit")
+
+
+def get_url(url: str, *, timeout: float) -> dict[str, object]:
+    """allowlist 済みの fal URL へ認証付き GET を送る。"""
+    safe_url = _validated_url(url)
+    try:
+        response = requests.get(safe_url, headers=_authorization_headers(), timeout=timeout)
+        response.raise_for_status()
+    except requests.RequestException as error:
+        _raise_transport_error("GET", error)
+    return _response_json(response, "GET")
+
+
+def download(url: str, *, timeout: float) -> bytes:
+    """allowlist 済みの fal media URL から認証情報なしで bytes を取得する。"""
+    safe_url = _validated_url(url)
+    try:
+        response = requests.get(safe_url, timeout=timeout)
+        response.raise_for_status()
+    except requests.RequestException as error:
+        _raise_transport_error("download", error)
+    return response.content
+
+
+def upload_file(path: Path, *, timeout: float) -> str:
+    """fal storage の initiate / signed PUT を実行し公開 ``file_url`` を返す。"""
+    content_type = mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+    headers = {
+        **_authorization_headers(json_content=True),
+        "X-Fal-Object-Lifecycle-Preference": _LIFECYCLE_PREFERENCE,
+    }
+    try:
+        response = requests.post(
+            _STORAGE_INITIATE_URL,
+            params={"storage_type": "fal-cdn-v3"},
+            json={"file_name": path.name, "content_type": content_type},
+            headers=headers,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.RequestException as error:
+        _raise_transport_error("storage initiate", error)
+
+    body = _response_json(response, "storage initiate")
+    upload_url = body.get("upload_url")
+    file_url = body.get("file_url")
+    if not isinstance(upload_url, str) or not isinstance(file_url, str):
+        raise GeneratorError("fal storage initiate response に必要な URL がありません")
+    _validated_url(file_url)
+    parsed_upload = urlsplit(upload_url)
+    if parsed_upload.scheme != "https" or not parsed_upload.netloc or parsed_upload.username or parsed_upload.password:
+        raise GeneratorError("fal storage upload URL が安全な HTTPS URL ではありません")
+    try:
+        data = path.read_bytes()
+    except OSError:
+        raise GeneratorError("fal upload file を読み込めません") from None
+    try:
+        put_response = requests.put(
+            upload_url,
+            data=data,
+            headers={"Content-Type": content_type},
+            timeout=timeout,
+        )
+        put_response.raise_for_status()
+    except requests.RequestException as error:
+        _raise_transport_error("storage upload", error)
+    return file_url

--- a/src/youtube_automation/infrastructure/media/fal_client.py
+++ b/src/youtube_automation/infrastructure/media/fal_client.py
@@ -88,11 +88,18 @@ def submit(path: str, payload: Mapping[str, object], *, timeout: float) -> dict[
     return _response_json(response, "submit")
 
 
+def _reject_redirect(response: requests.Response) -> None:
+    status = _status(response)
+    if status is not None and 300 <= status < 400:
+        raise GeneratorError("fal redirect は許可されていません")
+
+
 def get_url(url: str, *, timeout: float) -> dict[str, object]:
     """allowlist 済みの fal URL へ認証付き GET を送る。"""
     safe_url = _validated_url(url)
     try:
-        response = requests.get(safe_url, headers=_authorization_headers(), timeout=timeout)
+        response = requests.get(safe_url, headers=_authorization_headers(), timeout=timeout, allow_redirects=False)
+        _reject_redirect(response)
         response.raise_for_status()
     except requests.RequestException as error:
         _raise_transport_error("GET", error)
@@ -103,7 +110,8 @@ def download(url: str, *, timeout: float) -> bytes:
     """allowlist 済みの fal media URL から認証情報なしで bytes を取得する。"""
     safe_url = _validated_url(url)
     try:
-        response = requests.get(safe_url, timeout=timeout)
+        response = requests.get(safe_url, timeout=timeout, allow_redirects=False)
+        _reject_redirect(response)
         response.raise_for_status()
     except requests.RequestException as error:
         _raise_transport_error("download", error)

--- a/src/youtube_automation/infrastructure/media/minimax_client.py
+++ b/src/youtube_automation/infrastructure/media/minimax_client.py
@@ -8,6 +8,11 @@ from urllib.parse import urlsplit
 import requests
 
 from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.media._http_support import (
+    is_safe_https,
+    raise_transport_error,
+    response_json,
+)
 from youtube_automation.infrastructure.secrets import get_secret
 
 _BASE_URL = "https://api.minimax.io"
@@ -22,13 +27,6 @@ def _url_for_path(path: str) -> str:
     if not path.startswith("/") or path.startswith("//") or "://" in path:
         raise GeneratorError("MiniMax API path は / で始まる相対 path である必要があります")
     return f"{_BASE_URL}{path}"
-
-
-def _http_status(response: requests.Response | None) -> int | None:
-    if response is None:
-        return None
-    status_code = response.status_code
-    return status_code if isinstance(status_code, int) else None
 
 
 def request_json(
@@ -50,22 +48,9 @@ def request_json(
     try:
         response = requests.post(url, json=payload, headers=headers, timeout=timeout)
         response.raise_for_status()
-    except requests.Timeout:
-        raise GeneratorError("MiniMax API request が timeout しました") from None
-    except requests.HTTPError as error:
-        status = _http_status(error.response)
-        detail = f" (status={status})" if status is not None else ""
-        raise GeneratorError(f"MiniMax API HTTP error{detail}") from None
-    except requests.RequestException:
-        raise GeneratorError("MiniMax API request に失敗しました") from None
-
-    try:
-        body = response.json()
-    except requests.exceptions.JSONDecodeError:
-        raise GeneratorError("MiniMax API response を JSON として解釈できません") from None
-    if not isinstance(body, dict):
-        raise GeneratorError("MiniMax API response は JSON object である必要があります")
-    return body
+    except requests.RequestException as error:
+        raise_transport_error("MiniMax API request", error)
+    return response_json(response, "MiniMax API")
 
 
 def get_json(
@@ -85,38 +70,18 @@ def get_json(
             timeout=timeout,
         )
         response.raise_for_status()
-    except requests.Timeout:
-        raise GeneratorError("MiniMax API request が timeout しました") from None
-    except requests.HTTPError as error:
-        status = _http_status(error.response)
-        detail = f" (status={status})" if status is not None else ""
-        raise GeneratorError(f"MiniMax API HTTP error{detail}") from None
-    except requests.RequestException:
-        raise GeneratorError("MiniMax API request に失敗しました") from None
-
-    try:
-        body = response.json()
-    except requests.exceptions.JSONDecodeError:
-        raise GeneratorError("MiniMax API response を JSON として解釈できません") from None
-    if not isinstance(body, dict):
-        raise GeneratorError("MiniMax API response は JSON object である必要があります")
-    return body
+    except requests.RequestException as error:
+        raise_transport_error("MiniMax API request", error)
+    return response_json(response, "MiniMax API")
 
 
 def download_bytes(url: str, *, timeout: float) -> bytes:
     """MiniMax が返した HTTPS download URL から認証情報なしで bytes を取得する。"""
-    parsed = urlsplit(url)
-    if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password:
+    if not is_safe_https(urlsplit(url)):
         raise GeneratorError("MiniMax download URL は認証情報を含まない HTTPS URL である必要があります")
     try:
         response = requests.get(url, timeout=timeout)
         response.raise_for_status()
-    except requests.Timeout:
-        raise GeneratorError("MiniMax file download が timeout しました") from None
-    except requests.HTTPError as error:
-        status = _http_status(error.response)
-        detail = f" (status={status})" if status is not None else ""
-        raise GeneratorError(f"MiniMax file download HTTP error{detail}") from None
-    except requests.RequestException:
-        raise GeneratorError("MiniMax file download に失敗しました") from None
+    except requests.RequestException as error:
+        raise_transport_error("MiniMax file download", error)
     return response.content

--- a/src/youtube_automation/infrastructure/secrets.py
+++ b/src/youtube_automation/infrastructure/secrets.py
@@ -27,6 +27,7 @@ _SECRET_REFS: dict[str, str] = {
     "OPENAI_API_KEY": "op://Personal/OpenAI_API_Key/credential",
     "GEMINI_API_KEY": "op://Personal/Gemini_API_Key/credential",
     "MINIMAX_API_KEY": "op://Personal/MiniMax_API_Key/credential",
+    "FAL_KEY": "op://Personal/fal_API_Key/credential",
     "R2_API_TOKEN": "op://Personal/Cloudflare_R2_API_Token/credential",
     "YOUTUBE_STREAM_KEY": "op://Personal/YouTube/stream_key",
     "VULTR_API_KEY": "op://Personal/Vultr/api_key",

--- a/tests/infrastructure/media/test_fal_client.py
+++ b/tests/infrastructure/media/test_fal_client.py
@@ -19,6 +19,14 @@ def _json_response(body: object) -> Mock:
     return response
 
 
+def test_get_api_key_uses_registered_secret_resolver(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_secret = Mock(return_value="resolved-key")
+    monkeypatch.setattr(fal_client, "get_secret", get_secret)
+
+    assert fal_client.get_api_key() == "resolved-key"
+    get_secret.assert_called_once_with("FAL_KEY")
+
+
 def test_submit_uses_key_auth_and_queue_host(monkeypatch: pytest.MonkeyPatch) -> None:
     response = _json_response({"request_id": "request-1"})
     post = Mock(return_value=response)
@@ -55,10 +63,13 @@ def test_submit_rejects_non_relative_endpoint(path: str, monkeypatch: pytest.Mon
 @pytest.mark.parametrize("operation", ["get_url", "download"])
 def test_rejects_unsafe_url(url: str, operation: str, monkeypatch: pytest.MonkeyPatch) -> None:
     get = Mock()
+    get_api_key = Mock(side_effect=AssertionError("unsafe URL must not resolve a secret"))
+    monkeypatch.setattr(fal_client, "get_api_key", get_api_key)
     monkeypatch.setattr(fal_client.requests, "get", get)
     with pytest.raises(GeneratorError):
         getattr(fal_client, operation)(url, timeout=1)
     get.assert_not_called()
+    get_api_key.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -90,19 +101,36 @@ def test_download_returns_bytes_without_auth(monkeypatch: pytest.MonkeyPatch) ->
 
 def test_errors_do_not_expose_api_key_or_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     secret = "secret-must-not-leak"
+    body_text = "body-must-not-leak"
     response = Mock(spec=requests.Response)
-    response.status_code = 200
     response.status_code = 422
+    response.text = body_text
     response.raise_for_status.side_effect = requests.HTTPError(secret, response=response)
     monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value=secret))
     monkeypatch.setattr(fal_client.requests, "post", Mock(return_value=response))
     with pytest.raises(GeneratorError) as exc_info:
         fal_client.submit("model/run", {"prompt": secret}, timeout=1)
     assert secret not in str(exc_info.value)
+    assert body_text not in str(exc_info.value)
     assert "status=422" in str(exc_info.value)
 
 
+def test_json_decode_error_does_not_expose_response_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    body_text = "body-must-not-leak"
+    response = Mock(spec=requests.Response)
+    response.status_code = 200
+    response.text = body_text
+    response.json.side_effect = requests.exceptions.JSONDecodeError("invalid", body_text, 0)
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
+    monkeypatch.setattr(fal_client.requests, "post", Mock(return_value=response))
+    with pytest.raises(GeneratorError) as exc_info:
+        fal_client.submit("model/run", {"prompt": "loop"}, timeout=1)
+    assert "JSON" in str(exc_info.value)
+    assert body_text not in str(exc_info.value)
+
+
 def test_upload_file_initiates_then_puts_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """signed PUT 先は host allowlist の対象外（fal が採番する任意 host を許す）ことを固定する。"""
     source = tmp_path / "input.png"
     source.write_bytes(b"png-data")
     initiate = _json_response(
@@ -134,6 +162,48 @@ def test_upload_file_initiates_then_puts_bytes(tmp_path: Path, monkeypatch: pyte
         headers={"Content-Type": "image/png"},
         timeout=20,
     )
+
+
+@pytest.mark.parametrize(
+    "upload_url",
+    [
+        "http://signed-storage.example/put",
+        "https://user:pass@signed-storage.example/put",
+        "/put",
+    ],
+)
+def test_upload_file_rejects_unsafe_upload_url(
+    upload_url: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "input.png"
+    source.write_bytes(b"png-data")
+    initiate = _json_response({"upload_url": upload_url, "file_url": "https://cdn.fal.media/input.png"})
+    put = Mock()
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
+    monkeypatch.setattr(fal_client.requests, "post", Mock(return_value=initiate))
+    monkeypatch.setattr(fal_client.requests, "put", put)
+
+    with pytest.raises(GeneratorError, match="HTTPS"):
+        fal_client.upload_file(source, timeout=20)
+    put.assert_not_called()
+
+
+def test_upload_file_rejects_non_allowlisted_file_url(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "input.png"
+    source.write_bytes(b"png-data")
+    initiate = _json_response(
+        {"upload_url": "https://signed-storage.example/put", "file_url": "https://cdn.evil.example/input.png"}
+    )
+    put = Mock()
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
+    monkeypatch.setattr(fal_client.requests, "post", Mock(return_value=initiate))
+    monkeypatch.setattr(fal_client.requests, "put", put)
+
+    with pytest.raises(GeneratorError):
+        fal_client.upload_file(source, timeout=20)
+    put.assert_not_called()
 
 
 @pytest.mark.parametrize("operation", ["get_url", "download"])

--- a/tests/infrastructure/media/test_fal_client.py
+++ b/tests/infrastructure/media/test_fal_client.py
@@ -1,0 +1,133 @@
+"""fal.ai HTTP client の契約テスト。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from youtube_automation.core.errors import GeneratorError
+from youtube_automation.infrastructure.media import fal_client
+
+
+def _json_response(body: object) -> Mock:
+    response = Mock(spec=requests.Response)
+    response.json.return_value = body
+    return response
+
+
+def test_submit_uses_key_auth_and_queue_host(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = _json_response({"request_id": "request-1"})
+    post = Mock(return_value=response)
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
+    monkeypatch.setattr(fal_client.requests, "post", post)
+
+    assert fal_client.submit("minimax/h3/image-to-video", {"prompt": "loop"}, timeout=30) == {
+        "request_id": "request-1"
+    }
+    post.assert_called_once_with(
+        "https://queue.fal.run/minimax/h3/image-to-video",
+        json={"prompt": "loop"},
+        headers={"Authorization": "Key fal-secret", "Content-Type": "application/json"},
+        timeout=30,
+    )
+
+
+@pytest.mark.parametrize("path", ["/model", "https://example.com/model", "//example.com/model", ""])
+def test_submit_rejects_non_relative_endpoint(path: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    post = Mock()
+    monkeypatch.setattr(fal_client.requests, "post", post)
+    with pytest.raises(GeneratorError, match="path"):
+        fal_client.submit(path, {}, timeout=1)
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://queue.fal.run/request/1",
+        "https://example.com/request/1",
+        "https://queue.fal.run.evil.example/request/1",
+        "https://user:pass@fal.run/request/1",
+    ],
+)
+def test_get_url_rejects_unsafe_url(url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    get = Mock()
+    monkeypatch.setattr(fal_client.requests, "get", get)
+    with pytest.raises(GeneratorError):
+        fal_client.get_url(url, timeout=1)
+    get.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://queue.fal.run/requests/1/status",
+        "https://fal.run/model/requests/1",
+        "https://rest.alpha.fal.ai/requests/1",
+        "https://v3.fal.media/files/video.mp4",
+    ],
+)
+def test_get_url_accepts_allowlisted_hosts(url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+    get = Mock(return_value=_json_response({"status": "COMPLETED"}))
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="key"))
+    monkeypatch.setattr(fal_client.requests, "get", get)
+    assert fal_client.get_url(url, timeout=4) == {"status": "COMPLETED"}
+    get.assert_called_once_with(url, headers={"Authorization": "Key key"}, timeout=4)
+
+
+def test_download_returns_bytes_without_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    response = Mock(spec=requests.Response)
+    response.content = b"video"
+    get = Mock(return_value=response)
+    monkeypatch.setattr(fal_client.requests, "get", get)
+    assert fal_client.download("https://cdn.fal.media/video.mp4", timeout=8) == b"video"
+    get.assert_called_once_with("https://cdn.fal.media/video.mp4", timeout=8)
+
+
+def test_errors_do_not_expose_api_key_or_payload(monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "secret-must-not-leak"
+    response = Mock(spec=requests.Response)
+    response.status_code = 422
+    response.raise_for_status.side_effect = requests.HTTPError(secret, response=response)
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value=secret))
+    monkeypatch.setattr(fal_client.requests, "post", Mock(return_value=response))
+    with pytest.raises(GeneratorError) as exc_info:
+        fal_client.submit("model/run", {"prompt": secret}, timeout=1)
+    assert secret not in str(exc_info.value)
+    assert "status=422" in str(exc_info.value)
+
+
+def test_upload_file_initiates_then_puts_bytes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    source = tmp_path / "input.png"
+    source.write_bytes(b"png-data")
+    initiate = _json_response(
+        {"upload_url": "https://signed-storage.example/put", "file_url": "https://cdn.fal.media/input.png"}
+    )
+    put_response = Mock(spec=requests.Response)
+    post = Mock(return_value=initiate)
+    put = Mock(return_value=put_response)
+    monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
+    monkeypatch.setattr(fal_client.requests, "post", post)
+    monkeypatch.setattr(fal_client.requests, "put", put)
+
+    assert fal_client.upload_file(source, timeout=20) == "https://cdn.fal.media/input.png"
+    post.assert_called_once_with(
+        "https://rest.alpha.fal.ai/storage/upload/initiate",
+        params={"storage_type": "fal-cdn-v3"},
+        json={"file_name": "input.png", "content_type": "image/png"},
+        headers={
+            "Authorization": "Key fal-secret",
+            "Content-Type": "application/json",
+            "X-Fal-Object-Lifecycle-Preference": '{"expiration_duration_seconds": 86400}',
+        },
+        timeout=20,
+    )
+    put.assert_called_once_with(
+        "https://signed-storage.example/put",
+        data=b"png-data",
+        headers={"Content-Type": "image/png"},
+        timeout=20,
+    )

--- a/tests/infrastructure/media/test_fal_client.py
+++ b/tests/infrastructure/media/test_fal_client.py
@@ -14,6 +14,7 @@ from youtube_automation.infrastructure.media import fal_client
 
 def _json_response(body: object) -> Mock:
     response = Mock(spec=requests.Response)
+    response.status_code = 200
     response.json.return_value = body
     return response
 
@@ -73,21 +74,23 @@ def test_get_url_accepts_allowlisted_hosts(url: str, monkeypatch: pytest.MonkeyP
     monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="key"))
     monkeypatch.setattr(fal_client.requests, "get", get)
     assert fal_client.get_url(url, timeout=4) == {"status": "COMPLETED"}
-    get.assert_called_once_with(url, headers={"Authorization": "Key key"}, timeout=4)
+    get.assert_called_once_with(url, headers={"Authorization": "Key key"}, timeout=4, allow_redirects=False)
 
 
 def test_download_returns_bytes_without_auth(monkeypatch: pytest.MonkeyPatch) -> None:
     response = Mock(spec=requests.Response)
+    response.status_code = 200
     response.content = b"video"
     get = Mock(return_value=response)
     monkeypatch.setattr(fal_client.requests, "get", get)
     assert fal_client.download("https://cdn.fal.media/video.mp4", timeout=8) == b"video"
-    get.assert_called_once_with("https://cdn.fal.media/video.mp4", timeout=8)
+    get.assert_called_once_with("https://cdn.fal.media/video.mp4", timeout=8, allow_redirects=False)
 
 
 def test_errors_do_not_expose_api_key_or_payload(monkeypatch: pytest.MonkeyPatch) -> None:
     secret = "secret-must-not-leak"
     response = Mock(spec=requests.Response)
+    response.status_code = 200
     response.status_code = 422
     response.raise_for_status.side_effect = requests.HTTPError(secret, response=response)
     monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value=secret))
@@ -105,6 +108,7 @@ def test_upload_file_initiates_then_puts_bytes(tmp_path: Path, monkeypatch: pyte
         {"upload_url": "https://signed-storage.example/put", "file_url": "https://cdn.fal.media/input.png"}
     )
     put_response = Mock(spec=requests.Response)
+    put_response.status_code = 200
     post = Mock(return_value=initiate)
     put = Mock(return_value=put_response)
     monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
@@ -129,3 +133,35 @@ def test_upload_file_initiates_then_puts_bytes(tmp_path: Path, monkeypatch: pyte
         headers={"Content-Type": "image/png"},
         timeout=20,
     )
+
+
+@pytest.mark.parametrize("operation", ["get_url", "download"])
+@pytest.mark.parametrize("target", ["http://outside.invalid/private", "https://outside.invalid/private"])
+def test_redirect_is_rejected_without_following(monkeypatch: pytest.MonkeyPatch, operation: str, target: str) -> None:
+    class RedirectAdapter(requests.adapters.BaseAdapter):
+        def __init__(self) -> None:
+            self.urls: list[str] = []
+
+        def send(self, request, **kwargs):
+            self.urls.append(request.url)
+            response = requests.Response()
+            response.request = request
+            response.url = request.url
+            response.status_code = 302 if len(self.urls) == 1 else 200
+            response.headers["Location"] = target
+            response._content = b"{}"
+            return response
+
+        def close(self) -> None:
+            pass
+
+    adapter = RedirectAdapter()
+    with requests.Session() as session:
+        session.trust_env = False
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        monkeypatch.setattr(fal_client.requests, "get", session.get)
+        monkeypatch.setattr(fal_client, "get_api_key", lambda: "test-key")
+        with pytest.raises(GeneratorError, match="redirect"):
+            getattr(fal_client, operation)("https://v3.fal.media/output", timeout=1)
+    assert adapter.urls == ["https://v3.fal.media/output"]

--- a/tests/infrastructure/media/test_fal_client.py
+++ b/tests/infrastructure/media/test_fal_client.py
@@ -24,9 +24,7 @@ def test_submit_uses_key_auth_and_queue_host(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.setattr(fal_client, "get_api_key", Mock(return_value="fal-secret"))
     monkeypatch.setattr(fal_client.requests, "post", post)
 
-    assert fal_client.submit("minimax/h3/image-to-video", {"prompt": "loop"}, timeout=30) == {
-        "request_id": "request-1"
-    }
+    assert fal_client.submit("minimax/h3/image-to-video", {"prompt": "loop"}, timeout=30) == {"request_id": "request-1"}
     post.assert_called_once_with(
         "https://queue.fal.run/minimax/h3/image-to-video",
         json={"prompt": "loop"},

--- a/tests/infrastructure/media/test_fal_client.py
+++ b/tests/infrastructure/media/test_fal_client.py
@@ -52,11 +52,12 @@ def test_submit_rejects_non_relative_endpoint(path: str, monkeypatch: pytest.Mon
         "https://user:pass@fal.run/request/1",
     ],
 )
-def test_get_url_rejects_unsafe_url(url: str, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("operation", ["get_url", "download"])
+def test_rejects_unsafe_url(url: str, operation: str, monkeypatch: pytest.MonkeyPatch) -> None:
     get = Mock()
     monkeypatch.setattr(fal_client.requests, "get", get)
     with pytest.raises(GeneratorError):
-        fal_client.get_url(url, timeout=1)
+        getattr(fal_client, operation)(url, timeout=1)
     get.assert_not_called()
 
 

--- a/tests/infrastructure/test_secrets.py
+++ b/tests/infrastructure/test_secrets.py
@@ -298,6 +298,7 @@ class TestFalKeyRegistered:
             with pytest.raises(ConfigError, match="FAL_KEY"):
                 get_secret("FAL_KEY")
 
+
 # ---------- Issue #110: 帯域モニタリング用シークレット ----------
 
 

--- a/tests/infrastructure/test_secrets.py
+++ b/tests/infrastructure/test_secrets.py
@@ -34,6 +34,7 @@ _MANAGED_SECRETS = (
     "OPENAI_API_KEY",
     "GEMINI_API_KEY",
     "MINIMAX_API_KEY",
+    "FAL_KEY",
     "R2_API_TOKEN",
 )
 _OP_READ_DISABLED_ENV = secrets_module._OP_READ_DISABLED_ENV
@@ -263,6 +264,39 @@ class TestMiniMaxApiKeyRegistered:
             with pytest.raises(ConfigError, match="MINIMAX_API_KEY"):
                 get_secret("MINIMAX_API_KEY")
 
+
+class TestFalKeyRegistered:
+    def test_fal_key_uses_expected_op_reference(self):
+        assert _SECRET_REFS["FAL_KEY"] == "op://Personal/fal_API_Key/credential"
+
+    def test_fal_key_returns_from_environ_before_op(self):
+        os.environ["FAL_KEY"] = "fal-from-env"
+        with patch("youtube_automation.infrastructure.secrets.subprocess.run") as mock_run:
+            assert get_secret("FAL_KEY") == "fal-from-env"
+        mock_run.assert_not_called()
+
+    def test_fal_key_falls_back_to_op_read(self):
+        with (
+            patch.dict(os.environ, {_OP_READ_DISABLED_ENV: "0"}),
+            patch("youtube_automation.infrastructure.secrets.shutil.which", return_value="/usr/bin/op"),
+            patch("youtube_automation.infrastructure.secrets.subprocess.run") as mock_run,
+        ):
+            mock_run.return_value = subprocess.CompletedProcess(
+                args=["op", "read", _SECRET_REFS["FAL_KEY"]], returncode=0, stdout="fal-from-op\n", stderr=""
+            )
+            assert get_secret("FAL_KEY") == "fal-from-op"
+        mock_run.assert_called_once_with(
+            ["op", "read", "op://Personal/fal_API_Key/credential"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=secrets_module._OP_READ_TIMEOUT_SEC,
+        )
+
+    def test_fal_key_raises_config_error_when_unavailable(self):
+        with patch.dict(os.environ, {_OP_READ_DISABLED_ENV: "1"}):
+            with pytest.raises(ConfigError, match="FAL_KEY"):
+                get_secret("FAL_KEY")
 
 # ---------- Issue #110: 帯域モニタリング用シークレット ----------
 


### PR DESCRIPTION
fal.ai queue/storage API の安全な HTTP client と FAL_KEY secret 解決を追加します。

Closes #4946