### PR TITLE
feat: 廃止 workspace hook を同期時に除去する (#4908)

### DIFF
--- a/.claude/settings.template.json
+++ b/.claude/settings.template.json
@@ -20,10 +20,6 @@
           {
             "type": "command",
             "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in *auth/client_secrets.json|*auth/token.json|*.env) echo \"BLOCKED: $f は AI から直接編集禁止。専用ツール経由で更新してください\" >&2; exit 2;; esac; done"
-          },
-          {
-            "type": "command",
-            "command": "for f in $CLAUDE_FILE_PATHS; do case \"$f\" in channels|channels/*|*/channels|*/channels/*|collections|collections/*|*/collections|*/collections/*|config/channel|config/channel/*|*/config/channel|*/config/channel/*|assets|assets/*|*/assets|*/assets/*|data|data/*|*/data|*/data/*|auth|auth/*|*/auth|*/auth/*) uv run yt-workspace-guard check $CLAUDE_FILE_PATHS; exit $?;; esac; done; exit 0"
           }
         ]
       },
@@ -44,16 +40,6 @@
           {
             "type": "command",
             "command": "uv run --project \"$CLAUDE_PROJECT_DIR\" yt-progress-hook"
-          }
-        ]
-      }
-    ],
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "uv run yt-workspace-guard context"
           }
         ]
       }

--- a/changelog.d/4908-workspace-deprecated.deprecated.md
+++ b/changelog.d/4908-workspace-deprecated.deprecated.md
@@ -1,0 +1,1 @@
+- workspace 経路は次の major release で削除予定です。単一リポジトリへの移行には `yt-channel-export` を使用してください（#4908）。

--- a/src/youtube_automation/commands/system/skills_sync/_settings.py
+++ b/src/youtube_automation/commands/system/skills_sync/_settings.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 
 _KNOWN_REMOVED_HOOK_COMMANDS = frozenset(
@@ -121,51 +122,87 @@ def _prune_removed_hooks(target: dict[str, object]) -> None:
         target.pop("hooks", None)
 
 
-def sync_settings_asset(spec: dict[str, str], root: Path, target: Path, args: argparse.Namespace) -> int:
-    if args.symlink:
-        print("  [warn] settings は JSON merge のため --symlink を無視します", file=sys.stderr)
-    try:
-        template = read_json_object(root / spec["source_filename"])
-        merged = read_json_object(target, missing_ok=True)
-        missing_allow = merge_unique_strings(merged, template, "allow")
-        missing_deny = merge_unique_strings(merged, template, "deny")
-        hooks = missing_hooks(merged, template)
-        removals = removed_hooks(merged)
-    except (OSError, json.JSONDecodeError, ValueError) as exc:
-        print(f"  [error] settings をマージできません: {exc}", file=sys.stderr)
-        return 1
+@dataclass(frozen=True)
+class _SettingsChanges:
+    merged: dict[str, object]
+    missing_allow: list[str]
+    missing_deny: list[str]
+    hooks: list[tuple[str, dict[str, object]]]
+    removals: list[tuple[str, object, str]]
 
-    for event, group in hooks:
+
+def _settings_changes(template_path: Path, target: Path) -> _SettingsChanges:
+    template = read_json_object(template_path)
+    merged = read_json_object(target, missing_ok=True)
+    return _SettingsChanges(
+        merged=merged,
+        missing_allow=merge_unique_strings(merged, template, "allow"),
+        missing_deny=merge_unique_strings(merged, template, "deny"),
+        hooks=missing_hooks(merged, template),
+        removals=removed_hooks(merged),
+    )
+
+
+def _report_hook_candidates(changes: _SettingsChanges) -> None:
+    for event, group in changes.hooks:
         group_hooks = group["hooks"]
         assert isinstance(group_hooks, list)
         for hook in group_hooks:
             assert isinstance(hook, dict)
             print(f"  hook 追加候補: {event} / {group.get('matcher')} / {hook.get('type')} / {hook.get('command')}")
-    for event, matcher, command in removals:
+    for event, matcher, command in changes.removals:
         print(f"  hook 除去候補: {event} / {matcher} / command / {command}")
-    accept_hooks = bool(getattr(args, "accept_hooks", False))
-    hook_changes = bool(hooks or removals)
-    if hook_changes and not accept_hooks and getattr(sys.stdin, "isatty", lambda: False)():
-        accept_hooks = input("  hook の追加・除去を適用しますか? [y/N] ").strip().lower() in {"y", "yes"}
-    if removals and accept_hooks:
-        _prune_removed_hooks(merged)
-    if hooks and accept_hooks:
-        merged_hooks = merged.setdefault("hooks", {})
-        assert isinstance(merged_hooks, dict)
-        for event, group in hooks:
-            merged_hooks.setdefault(event, []).append(group)
-    elif hooks:
-        print("  [skip] hook 追加は未承認です (--accept-hooks で承認)")
-    if removals and not accept_hooks:
-        print("  [skip] hook 除去は未承認です (--accept-hooks で承認)")
 
-    changed = bool(missing_allow or missing_deny or (hook_changes and accept_hooks) or not target.exists())
+
+def _hooks_accepted(args: argparse.Namespace, *, has_changes: bool) -> bool:
+    accepted = bool(getattr(args, "accept_hooks", False))
+    if not has_changes or accepted or not getattr(sys.stdin, "isatty", lambda: False)():
+        return accepted
+    return input("  hook の追加・除去を適用しますか? [y/N] ").strip().lower() in {"y", "yes"}
+
+
+def _apply_hook_changes(changes: _SettingsChanges, *, accepted: bool) -> None:
+    if not accepted:
+        if changes.hooks:
+            print("  [skip] hook 追加は未承認です (--accept-hooks で承認)")
+        if changes.removals:
+            print("  [skip] hook 除去は未承認です (--accept-hooks で承認)")
+        return
+    if changes.removals:
+        _prune_removed_hooks(changes.merged)
+    if changes.hooks:
+        merged_hooks = changes.merged.setdefault("hooks", {})
+        assert isinstance(merged_hooks, dict)
+        for event, group in changes.hooks:
+            merged_hooks.setdefault(event, []).append(group)
+
+
+def _write_settings(target: Path, merged: dict[str, object]) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{target.name}.tmp")
+    tmp.write_text(json.dumps(merged, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(target)
+
+
+def sync_settings_asset(spec: dict[str, str], root: Path, target: Path, args: argparse.Namespace) -> int:
+    if args.symlink:
+        print("  [warn] settings は JSON merge のため --symlink を無視します", file=sys.stderr)
+    try:
+        changes = _settings_changes(root / spec["source_filename"], target)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(f"  [error] settings をマージできません: {exc}", file=sys.stderr)
+        return 1
+
+    _report_hook_candidates(changes)
+    hook_changes = bool(changes.hooks or changes.removals)
+    accept_hooks = _hooks_accepted(args, has_changes=hook_changes)
+    _apply_hook_changes(changes, accepted=accept_hooks)
+    changed = bool(
+        changes.missing_allow or changes.missing_deny or (hook_changes and accept_hooks) or not target.exists()
+    )
     result = "created" if not target.exists() else "updated" if changed else "unchanged"
     if changed and not args.dry_run:
-        target.parent.mkdir(parents=True, exist_ok=True)
-        tmp = target.with_name(f".{target.name}.tmp")
-        tmp.write_text(json.dumps(merged, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        tmp.replace(target)
+        _write_settings(target, changes.merged)
     prefix = "[dry-run] " if args.dry_run else ""
     print(f"  {prefix}{result:>8}: {target}")
     return 0

--- a/src/youtube_automation/commands/system/skills_sync/_settings.py
+++ b/src/youtube_automation/commands/system/skills_sync/_settings.py
@@ -7,6 +7,17 @@ import json
 import sys
 from pathlib import Path
 
+_KNOWN_REMOVED_HOOK_COMMANDS = frozenset(
+    {
+        'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
+        "channels|channels/*|*/channels|*/channels/*|collections|collections/*|*/collections|*/collections/*|"
+        "config/channel|config/channel/*|*/config/channel|*/config/channel/*|assets|assets/*|*/assets|*/assets/*|"
+        "data|data/*|*/data|*/data/*|auth|auth/*|*/auth|*/auth/*) "
+        "uv run yt-workspace-guard check $CLAUDE_FILE_PATHS; exit $?;; esac; done; exit 0",
+        "uv run yt-workspace-guard context",
+    }
+)
+
 
 def read_json_object(path: Path, *, missing_ok: bool = False) -> dict[str, object]:
     if missing_ok and not path.exists():
@@ -67,6 +78,49 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
     return missing
 
 
+def removed_hooks(target: dict[str, object]) -> list[tuple[str, object, str]]:
+    target_hooks = target.get("hooks", {})
+    if not isinstance(target_hooks, dict):
+        raise ValueError("hooks は object である必要があります")
+    removed: list[tuple[str, object, str]] = []
+    for event, groups in target_hooks.items():
+        if not isinstance(groups, list):
+            raise ValueError("hooks の event は配列である必要があります")
+        for group in groups:
+            if not isinstance(group, dict) or not isinstance(group.get("hooks", []), list):
+                raise ValueError("hook group の形式が不正です")
+            for hook in group["hooks"]:
+                if isinstance(hook, dict) and hook.get("command") in _KNOWN_REMOVED_HOOK_COMMANDS:
+                    removed.append((str(event), group.get("matcher"), str(hook["command"])))
+    return removed
+
+
+def _prune_removed_hooks(target: dict[str, object]) -> None:
+    target_hooks = target.get("hooks")
+    assert isinstance(target_hooks, dict)
+    for event in list(target_hooks):
+        groups = target_hooks[event]
+        assert isinstance(groups, list)
+        retained_groups: list[object] = []
+        for group in groups:
+            assert isinstance(group, dict)
+            hooks = group.get("hooks", [])
+            assert isinstance(hooks, list)
+            group["hooks"] = [
+                hook
+                for hook in hooks
+                if not (isinstance(hook, dict) and hook.get("command") in _KNOWN_REMOVED_HOOK_COMMANDS)
+            ]
+            if group["hooks"]:
+                retained_groups.append(group)
+        if retained_groups:
+            target_hooks[event] = retained_groups
+        else:
+            del target_hooks[event]
+    if not target_hooks:
+        target.pop("hooks", None)
+
+
 def sync_settings_asset(spec: dict[str, str], root: Path, target: Path, args: argparse.Namespace) -> int:
     if args.symlink:
         print("  [warn] settings は JSON merge のため --symlink を無視します", file=sys.stderr)
@@ -76,16 +130,25 @@ def sync_settings_asset(spec: dict[str, str], root: Path, target: Path, args: ar
         missing_allow = merge_unique_strings(merged, template, "allow")
         missing_deny = merge_unique_strings(merged, template, "deny")
         hooks = missing_hooks(merged, template)
+        removals = removed_hooks(merged)
     except (OSError, json.JSONDecodeError, ValueError) as exc:
         print(f"  [error] settings をマージできません: {exc}", file=sys.stderr)
         return 1
 
     for event, group in hooks:
-        for hook in group["hooks"]:
+        group_hooks = group["hooks"]
+        assert isinstance(group_hooks, list)
+        for hook in group_hooks:
+            assert isinstance(hook, dict)
             print(f"  hook 追加候補: {event} / {group.get('matcher')} / {hook.get('type')} / {hook.get('command')}")
+    for event, matcher, command in removals:
+        print(f"  hook 除去候補: {event} / {matcher} / command / {command}")
     accept_hooks = bool(getattr(args, "accept_hooks", False))
-    if hooks and not accept_hooks and getattr(sys.stdin, "isatty", lambda: False)():
-        accept_hooks = input("  hook を追加しますか? [y/N] ").strip().lower() in {"y", "yes"}
+    hook_changes = bool(hooks or removals)
+    if hook_changes and not accept_hooks and getattr(sys.stdin, "isatty", lambda: False)():
+        accept_hooks = input("  hook の追加・除去を適用しますか? [y/N] ").strip().lower() in {"y", "yes"}
+    if removals and accept_hooks:
+        _prune_removed_hooks(merged)
     if hooks and accept_hooks:
         merged_hooks = merged.setdefault("hooks", {})
         assert isinstance(merged_hooks, dict)
@@ -93,8 +156,10 @@ def sync_settings_asset(spec: dict[str, str], root: Path, target: Path, args: ar
             merged_hooks.setdefault(event, []).append(group)
     elif hooks:
         print("  [skip] hook 追加は未承認です (--accept-hooks で承認)")
+    if removals and not accept_hooks:
+        print("  [skip] hook 除去は未承認です (--accept-hooks で承認)")
 
-    changed = bool(missing_allow or missing_deny or (hooks and accept_hooks) or not target.exists())
+    changed = bool(missing_allow or missing_deny or (hook_changes and accept_hooks) or not target.exists())
     result = "created" if not target.exists() else "updated" if changed else "unchanged"
     if changed and not args.dry_run:
         target.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -9,6 +9,7 @@ import pytest
 
 from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.system import skills_sync
+from youtube_automation.commands.system.skills_sync import _settings
 
 
 def _template(root: Path) -> None:
@@ -35,26 +36,6 @@ def _template(root: Path) -> None:
 def _run(root: Path, target: Path, monkeypatch, *extra: str) -> int:
     monkeypatch.setattr(skills_sync, "_editable_root", lambda: root)
     return skills_sync.main(["sync", "--asset", "settings", "--target", str(target), *extra])
-
-
-def _workspace_guard_command(settings: dict[str, object]) -> str:
-    groups = settings["hooks"]["PreToolUse"]
-    commands = [
-        hook["command"]
-        for group in groups
-        if group["matcher"] == "Edit|Write"
-        for hook in group["hooks"]
-        if "yt-workspace-guard" in hook["command"]
-    ]
-    assert len(commands) == 1
-    return commands[0]
-
-
-def _session_context_command(settings: dict[str, object]) -> str:
-    groups = settings["hooks"]["SessionStart"]
-    commands = [hook["command"] for group in groups for hook in group["hooks"]]
-    assert commands == ["uv run yt-workspace-guard context"]
-    return commands[0]
 
 
 # hook は呼び出し元の cwd に依存しないよう Claude の project root を明示する（#4835）。
@@ -119,25 +100,78 @@ def test_settings_noninteractive_skips_hooks_but_merges_permissions(tmp_path, mo
     assert "hooks" not in merged
 
 
-def test_distributed_settings_include_workspace_guard_alongside_auth_hook(tmp_path, monkeypatch) -> None:
-    target = tmp_path / "downstream" / ".claude" / "settings.json"
+def test_settings_prunes_known_removed_hooks_and_preserves_other_hooks(tmp_path, monkeypatch) -> None:
+    _template(tmp_path)
+    target = tmp_path / "settings.json"
+    target.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Edit|Write",
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": next(
+                                        command
+                                        for command in _settings._KNOWN_REMOVED_HOOK_COMMANDS
+                                        if " check " in command
+                                    ),
+                                },
+                                {"type": "command", "command": "keep-pre"},
+                            ],
+                        }
+                    ],
+                    "SessionStart": [
+                        {"hooks": [{"type": "command", "command": "uv run yt-workspace-guard context"}]},
+                        {"hooks": [{"type": "command", "command": "keep-session"}]},
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
 
-    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
-
+    assert _run(tmp_path, target, monkeypatch, "--accept-hooks") == 0
     merged = json.loads(target.read_text(encoding="utf-8"))
-    command = _workspace_guard_command(merged)
-    assert "uv run yt-workspace-guard check $CLAUDE_FILE_PATHS" in command
-    all_commands = [hook["command"] for group in merged["hooks"]["PreToolUse"] for hook in group["hooks"]]
-    assert any("auth/client_secrets.json" in candidate for candidate in all_commands)
+    commands = [hook["command"] for groups in merged["hooks"].values() for group in groups for hook in group["hooks"]]
+    assert set(commands) == {"keep-pre", "keep-session", "block-secrets"}
+    assert all(group["hooks"] for groups in merged["hooks"].values() for group in groups)
 
 
-def test_distributed_settings_include_session_start_context_hook(tmp_path, monkeypatch) -> None:
-    target = tmp_path / "downstream" / ".claude" / "settings.json"
+def test_settings_noninteractive_reports_prune_without_writing(tmp_path, monkeypatch, capsys) -> None:
+    _template(tmp_path)
+    target = tmp_path / "settings.json"
+    target.write_text(
+        json.dumps(
+            {
+                "permissions": {
+                    "allow": ["Agent", "Bash(uv run yt-upload-auto*)"],
+                    "deny": ["Read(.env)"],
+                },
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Edit|Write",
+                            "hooks": [{"type": "command", "command": "block-secrets"}],
+                        }
+                    ],
+                    "SessionStart": [{"hooks": [{"type": "command", "command": "uv run yt-workspace-guard context"}]}],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    before = target.read_bytes()
 
-    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+    assert _run(tmp_path, target, monkeypatch) == 0
+    assert target.read_bytes() == before
+    assert "hook 除去候補" in capsys.readouterr().out
 
-    merged = json.loads(target.read_text(encoding="utf-8"))
-    assert _session_context_command(merged) == "uv run yt-workspace-guard context"
+
+def test_distributed_settings_template_excludes_workspace_guard() -> None:
+    assert "yt-workspace-guard" not in (REPO_ROOT / ".claude/settings.template.json").read_text(encoding="utf-8")
 
 
 def test_distributed_settings_include_background_progress_hook(tmp_path, monkeypatch) -> None:
@@ -203,37 +237,6 @@ def test_repository_ruff_hook_never_syncs_the_venv() -> None:
     assert "uv run --no-sync ruff format" in command
     assert "uv run --no-sync ruff check --fix" in command
     assert "uv run ruff" not in command
-
-
-def test_workspace_guard_hook_prefilters_unrelated_paths(tmp_path) -> None:
-    settings = json.loads((REPO_ROOT / ".claude" / "settings.template.json").read_text(encoding="utf-8"))
-    command = _workspace_guard_command(settings)
-    env = {**os.environ, "CLAUDE_FILE_PATHS": "README.md docs/guide.md", "PATH": str(tmp_path)}
-
-    result = subprocess.run(command, shell=True, env=env, capture_output=True, text=True, check=False)
-
-    assert result.returncode == 0
-    assert result.stderr == ""
-
-
-def test_workspace_guard_hook_propagates_block_and_paths(tmp_path) -> None:
-    settings = json.loads((REPO_ROOT / ".claude" / "settings.template.json").read_text(encoding="utf-8"))
-    command = _workspace_guard_command(settings)
-    invocation = tmp_path / "invocation"
-    fake_uv = tmp_path / "uv"
-    fake_uv.write_text(
-        f'#!/bin/sh\nprintf "%s\\n" "$*" > "{invocation}"\necho "channel mismatch" >&2\nexit 2\n',
-        encoding="utf-8",
-    )
-    fake_uv.chmod(0o755)
-    paths = "channels/beta/collections/new workspace/assets/cover.png"
-    env = {**os.environ, "CLAUDE_FILE_PATHS": paths, "PATH": str(tmp_path)}
-
-    result = subprocess.run(command, shell=True, env=env, capture_output=True, text=True, check=False)
-
-    assert result.returncode == 2
-    assert result.stderr == "channel mismatch\n"
-    assert invocation.read_text(encoding="utf-8") == f"run yt-workspace-guard check {paths}\n"
 
 
 def test_settings_invalid_target_is_not_overwritten(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## 変更内容
- settings 同期に既知の `yt-workspace-guard` hook 2 件の同意付き prune を追加
- 空になった hook group / event を除去
- 配布 template から両 guard hook を削除し、回帰テストと changelog fragment を追加

Closes #4908