### PR TITLE
feat: export 時に channel registry を置換する (#4907)

### DIFF
--- a/changelog.d/4907-registry-replace.added.md
+++ b/changelog.d/4907-registry-replace.added.md
@@ -1,0 +1,1 @@
+- `yt-channel-export` が channel registry の workspace entry を同位置で export 先へ置換するようにした（#4907）。

--- a/src/youtube_automation/commands/channel/channel_export.py
+++ b/src/youtube_automation/commands/channel/channel_export.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
-import json
 import os
 import shutil
 import subprocess
@@ -18,7 +17,6 @@ from youtube_automation.commands.channel.channel_import import SLUG_PATTERN, _va
 from youtube_automation.core.errors import ChannelRegistryError, ConfigError
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,
-    ChannelRegistryUpdate,
     plan_channel_registry_update,
 )
 from youtube_automation.infrastructure.auth.client_secrets import template_bytes
@@ -220,13 +218,9 @@ def export_channel(
     except OSError as error:
         print(f"[error] channel registry の書込に失敗しました（dest は残します）: {error}", file=sys.stderr)
         print("channel registry を次の内容へ手動更新してください:")
-        print(_registry_json(registry_update))
+        print(registry_update.as_json())
         return EXIT_VALIDATION
     return EXIT_OK
-
-
-def _registry_json(update: ChannelRegistryUpdate) -> str:
-    return json.dumps([str(channel) for channel in update.channels], ensure_ascii=False, indent=2)
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/youtube_automation/commands/channel/channel_export.py
+++ b/src/youtube_automation/commands/channel/channel_export.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import json
 import os
 import shutil
 import subprocess
@@ -13,7 +14,13 @@ from pathlib import Path
 
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.commands.channel.channel_import import SLUG_PATTERN, _validate_config, _workspace_root
-from youtube_automation.core.errors import ConfigError
+
+from youtube_automation.core.errors import ChannelRegistryError, ConfigError
+from youtube_automation.infrastructure.analytics.channel_registry import (
+    DEFAULT_CHANNEL_REGISTRY,
+    ChannelRegistryUpdate,
+    plan_channel_registry_update,
+)
 from youtube_automation.infrastructure.auth.client_secrets import template_bytes
 
 EXIT_OK = 0
@@ -132,6 +139,7 @@ def export_channel(
     workspace: Path,
     allow_dirty: bool = False,
     dry_run: bool = False,
+    registry: Path | None = None,
 ) -> int:
     workspace = workspace.expanduser().resolve()
     if not SLUG_PATTERN.fullmatch(slug):
@@ -167,6 +175,13 @@ def export_channel(
     print(f"export plan: {source} -> {destination} ({count} files, {size} bytes)")
     if (source / ".env").exists():
         print("[warning] .env は不要のはずなので copy しません")
+    registry_path = (registry or DEFAULT_CHANNEL_REGISTRY).expanduser().absolute()
+    try:
+        registry_update = plan_channel_registry_update(registry_path, source=source, destination=destination)
+    except ChannelRegistryError as error:
+        print(f"[error] channel registry を更新できません: {error}", file=sys.stderr)
+        return EXIT_VALIDATION
+    print(f"registry plan: {registry_update.action} index={registry_update.index} ({registry_path})")
     if dry_run:
         return EXIT_OK
 
@@ -200,7 +215,18 @@ def export_channel(
         "参考: uv init; uv add git+https://github.com/daiki-beppu/youtube-automation; uv run yt-skills sync; git init"
     )
     print("案内: bootstrap 後に `uv run yt-doctor` と workflow-state の path を確認してください。")
+    try:
+        registry_update.write()
+    except OSError as error:
+        print(f"[error] channel registry の書込に失敗しました（dest は残します）: {error}", file=sys.stderr)
+        print("channel registry を次の内容へ手動更新してください:")
+        print(_registry_json(registry_update))
+        return EXIT_VALIDATION
     return EXIT_OK
+
+
+def _registry_json(update: ChannelRegistryUpdate) -> str:
+    return json.dumps([str(channel) for channel in update.channels], ensure_ascii=False, indent=2)
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -209,6 +235,12 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("dest", type=Path, help="workspace 外の、存在しないか空の出力 directory")
     parser.add_argument("--allow-dirty", action="store_true", help="未 commit（untracked を含む）の source を許可する")
     parser.add_argument("--dry-run", action="store_true", help="copy せず対象ファイル数と総サイズだけ表示する")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=DEFAULT_CHANNEL_REGISTRY,
+        help=f"channel registry path（default: {DEFAULT_CHANNEL_REGISTRY}）",
+    )
     return parser
 
 
@@ -219,6 +251,7 @@ def run(args: argparse.Namespace) -> int:
         workspace=_workspace_root(Path.cwd()),
         allow_dirty=args.allow_dirty,
         dry_run=args.dry_run,
+        registry=args.registry,
     )
 
 

--- a/src/youtube_automation/commands/channel/channel_export.py
+++ b/src/youtube_automation/commands/channel/channel_export.py
@@ -13,7 +13,6 @@ from pathlib import Path
 
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.commands.channel.channel_import import SLUG_PATTERN, _validate_config, _workspace_root
-
 from youtube_automation.core.errors import ChannelRegistryError, ConfigError
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,

--- a/src/youtube_automation/infrastructure/analytics/channel_registry.py
+++ b/src/youtube_automation/infrastructure/analytics/channel_registry.py
@@ -1,14 +1,64 @@
-"""所有チャンネル registry の読み取り専用 loader。"""
+"""所有チャンネル registry の loader と原子的 writer。"""
 
 from __future__ import annotations
 
 import json
 import os
+import shutil
+import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 from youtube_automation.core.errors import ChannelRegistryError
 
 DEFAULT_CHANNEL_REGISTRY = Path.home() / ".config" / "tayk" / "channels.json"
+
+
+@dataclass(frozen=True)
+class ChannelRegistryUpdate:
+    path: Path
+    channels: tuple[Path, ...]
+    action: str
+    index: int
+
+    def write(self) -> None:
+        """変更があれば backup を残して registry を原子的に置換する。"""
+        if self.action == "noop":
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists():
+            shutil.copy2(self.path, self.path.with_name(f"{self.path.name}.bak"))
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{self.path.name}.", dir=self.path.parent)
+        temporary = Path(temporary_name)
+        try:
+            with os.fdopen(descriptor, "w", encoding="utf-8") as file:
+                json.dump([str(channel) for channel in self.channels], file, ensure_ascii=False, indent=2)
+                file.write("\n")
+            temporary.replace(self.path)
+        except OSError:
+            temporary.unlink(missing_ok=True)
+            raise
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    normalized_left = os.path.normcase(os.path.normpath(str(left)))
+    normalized_right = os.path.normcase(os.path.normpath(str(right)))
+    return normalized_left == normalized_right or left.resolve(strict=False) == right.resolve(strict=False)
+
+
+def plan_channel_registry_update(path: Path, *, source: Path, destination: Path) -> ChannelRegistryUpdate:
+    """source の同位置置換、destination の追加、または no-op を計画する。"""
+    destination = destination.absolute()
+    channels = load_channel_registry(path) if path.exists() else []
+    for index, channel in enumerate(channels):
+        if _same_path(channel, destination):
+            return ChannelRegistryUpdate(path, tuple(channels), "noop", index)
+    for index, channel in enumerate(channels):
+        if _same_path(channel, source):
+            updated = [*channels]
+            updated[index] = destination
+            return ChannelRegistryUpdate(path, tuple(updated), "replace", index)
+    return ChannelRegistryUpdate(path, (*channels, destination), "append", len(channels))
 
 
 def load_channel_registry(path: Path | None = None) -> list[Path]:

--- a/src/youtube_automation/infrastructure/analytics/channel_registry.py
+++ b/src/youtube_automation/infrastructure/analytics/channel_registry.py
@@ -21,6 +21,10 @@ class ChannelRegistryUpdate:
     action: str
     index: int
 
+    def as_json(self) -> str:
+        """registry へ書き込む JSON 本文（末尾改行なし）を返す。"""
+        return json.dumps([str(channel) for channel in self.channels], ensure_ascii=False, indent=2)
+
     def write(self) -> None:
         """変更があれば backup を残して registry を原子的に置換する。"""
         if self.action == "noop":
@@ -32,17 +36,20 @@ class ChannelRegistryUpdate:
         temporary = Path(temporary_name)
         try:
             with os.fdopen(descriptor, "w", encoding="utf-8") as file:
-                json.dump([str(channel) for channel in self.channels], file, ensure_ascii=False, indent=2)
-                file.write("\n")
+                file.write(f"{self.as_json()}\n")
             temporary.replace(self.path)
         except OSError:
             temporary.unlink(missing_ok=True)
             raise
 
 
+def _normalized(value: str) -> str:
+    return os.path.normcase(os.path.normpath(value))
+
+
 def _same_path(left: Path, right: Path) -> bool:
-    normalized_left = os.path.normcase(os.path.normpath(str(left)))
-    normalized_right = os.path.normcase(os.path.normpath(str(right)))
+    normalized_left = _normalized(str(left))
+    normalized_right = _normalized(str(right))
     return normalized_left == normalized_right or left.resolve(strict=False) == right.resolve(strict=False)
 
 
@@ -86,7 +93,7 @@ def load_channel_registry(path: Path | None = None) -> list[Path]:
         channel = Path(value)
         if not channel.is_absolute():
             raise ChannelRegistryError(f"channel registry index {index} は絶対 path でなければなりません: {value}")
-        normalized = os.path.normcase(os.path.normpath(value))
+        normalized = _normalized(value)
         if normalized in seen:
             raise ChannelRegistryError(f"channel registry index {index} の path が重複しています: {value}")
         seen.add(normalized)

--- a/tests/commands/channel/test_channel_export.py
+++ b/tests/commands/channel/test_channel_export.py
@@ -10,6 +10,11 @@ from youtube_automation.commands.channel import channel_export
 from youtube_automation.core.errors import ConfigError
 
 
+@pytest.fixture(autouse=True)
+def _isolated_registry(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(channel_export, "DEFAULT_CHANNEL_REGISTRY", tmp_path / "registry/channels.json")
+
+
 def _workspace(tmp_path: Path) -> tuple[Path, Path]:
     workspace = tmp_path / "workspace"
     source = workspace / "channels" / "demo"
@@ -167,3 +172,39 @@ def test_export_cli_finds_workspace_from_channel_subdirectory(tmp_path: Path, mo
     destination = tmp_path / "exported"
     assert channel_export.main(["demo", str(destination), "--dry-run"]) == 0
     assert not destination.exists()
+
+def test_export_replaces_workspace_registry_entry_and_dry_run_only_reports_plan(tmp_path: Path, capsys) -> None:
+    workspace, source = _workspace(tmp_path)
+    other = tmp_path / "other"
+    destination = tmp_path / "exported"
+    registry = tmp_path / "channels.json"
+    registry.write_text(json.dumps([str(other), str(source)]), encoding="utf-8")
+
+    assert (
+        channel_export.export_channel("demo", destination, workspace=workspace, registry=registry, dry_run=True)
+        == channel_export.EXIT_OK
+    )
+    assert json.loads(registry.read_text(encoding="utf-8")) == [str(other), str(source)]
+    assert "registry plan: replace index=1" in capsys.readouterr().out
+
+    assert channel_export.export_channel("demo", destination, workspace=workspace, registry=registry) == 0
+    assert json.loads(registry.read_text(encoding="utf-8")) == [str(other), str(destination)]
+
+
+def test_registry_write_failure_keeps_export_and_prints_manual_document(tmp_path: Path, monkeypatch, capsys) -> None:
+    workspace, _ = _workspace(tmp_path)
+    destination = tmp_path / "exported"
+    registry = tmp_path / "channels.json"
+
+    def fail_write(_update) -> None:
+        raise OSError("read only")
+
+    monkeypatch.setattr(channel_export.ChannelRegistryUpdate, "write", fail_write)
+    assert (
+        channel_export.export_channel("demo", destination, workspace=workspace, registry=registry)
+        == channel_export.EXIT_VALIDATION
+    )
+    assert destination.is_dir()
+    captured = capsys.readouterr()
+    assert "手動更新" in captured.out
+    assert str(destination) in captured.out

--- a/tests/commands/channel/test_channel_export.py
+++ b/tests/commands/channel/test_channel_export.py
@@ -8,6 +8,7 @@ import pytest
 
 from youtube_automation.commands.channel import channel_export
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.infrastructure.analytics.channel_registry import ChannelRegistryUpdate
 
 
 @pytest.fixture(autouse=True)
@@ -199,7 +200,7 @@ def test_registry_write_failure_keeps_export_and_prints_manual_document(tmp_path
     def fail_write(_update) -> None:
         raise OSError("read only")
 
-    monkeypatch.setattr(channel_export.ChannelRegistryUpdate, "write", fail_write)
+    monkeypatch.setattr(ChannelRegistryUpdate, "write", fail_write)
     assert (
         channel_export.export_channel("demo", destination, workspace=workspace, registry=registry)
         == channel_export.EXIT_VALIDATION

--- a/tests/commands/channel/test_channel_export.py
+++ b/tests/commands/channel/test_channel_export.py
@@ -174,6 +174,7 @@ def test_export_cli_finds_workspace_from_channel_subdirectory(tmp_path: Path, mo
     assert channel_export.main(["demo", str(destination), "--dry-run"]) == 0
     assert not destination.exists()
 
+
 def test_export_replaces_workspace_registry_entry_and_dry_run_only_reports_plan(tmp_path: Path, capsys) -> None:
     workspace, source = _workspace(tmp_path)
     other = tmp_path / "other"

--- a/tests/infrastructure/analytics/test_channel_registry.py
+++ b/tests/infrastructure/analytics/test_channel_registry.py
@@ -8,7 +8,10 @@ from pathlib import Path
 import pytest
 
 from youtube_automation.core.errors import ChannelRegistryError
-from youtube_automation.infrastructure.analytics.channel_registry import load_channel_registry
+from youtube_automation.infrastructure.analytics.channel_registry import (
+    load_channel_registry,
+    plan_channel_registry_update,
+)
 
 
 def test_registry_returns_absolute_paths_in_declared_order(tmp_path: Path) -> None:
@@ -50,3 +53,56 @@ def test_registry_rejects_duplicate_paths(tmp_path: Path) -> None:
 
     with pytest.raises(ChannelRegistryError, match="index 1.*重複"):
         load_channel_registry(registry)
+
+
+def test_registry_replaces_resolved_workspace_path_in_place_and_backs_up(tmp_path: Path) -> None:
+    real_workspace = tmp_path / "real-workspace"
+    source = real_workspace / "channels/demo"
+    source.mkdir(parents=True)
+    workspace_link = tmp_path / "workspace-link"
+    workspace_link.symlink_to(real_workspace, target_is_directory=True)
+    first = tmp_path / "first"
+    destination = tmp_path / "exported"
+    registry = tmp_path / "channels.json"
+    original = json.dumps([str(first), str(workspace_link / "channels/demo")])
+    registry.write_text(original, encoding="utf-8")
+
+    update = plan_channel_registry_update(registry, source=source, destination=destination)
+    assert update.action == "replace"
+    assert update.index == 1
+    update.write()
+
+    assert load_channel_registry(registry) == [first, destination]
+    assert registry.with_name("channels.json.bak").read_text(encoding="utf-8") == original
+
+
+def test_registry_appends_missing_destination_and_existing_destination_is_noop(tmp_path: Path) -> None:
+    existing = tmp_path / "existing"
+    destination = tmp_path / "exported"
+    registry = tmp_path / "channels.json"
+    registry.write_text(json.dumps([str(existing)]), encoding="utf-8")
+
+    update = plan_channel_registry_update(registry, source=tmp_path / "missing", destination=destination)
+    assert (update.action, update.index) == ("append", 1)
+    update.write()
+    before = registry.read_bytes()
+    backup_before = registry.with_name("channels.json.bak").read_bytes()
+
+    noop = plan_channel_registry_update(registry, source=tmp_path / "missing", destination=destination)
+    assert (noop.action, noop.index) == ("noop", 1)
+    noop.write()
+    assert registry.read_bytes() == before
+    assert registry.with_name("channels.json.bak").read_bytes() == backup_before
+
+
+def test_registry_missing_file_is_created_and_invalid_json_is_preserved(tmp_path: Path) -> None:
+    destination = tmp_path / "exported"
+    registry = tmp_path / "channels.json"
+    update = plan_channel_registry_update(registry, source=tmp_path / "missing", destination=destination)
+    update.write()
+    assert load_channel_registry(registry) == [destination]
+
+    registry.write_text("invalid", encoding="utf-8")
+    with pytest.raises(ChannelRegistryError, match="JSON"):
+        plan_channel_registry_update(registry, source=tmp_path / "missing", destination=tmp_path / "other")
+    assert registry.read_text(encoding="utf-8") == "invalid"


### PR DESCRIPTION
## 変更内容
- channel registry の置換・追加・no-op 計画と backup 付き原子書込を追加
- `yt-channel-export` に `--registry` と dry-run 計画表示を統合
- 書込失敗時に export 先を保持し手動更新 JSON を表示
- 回帰テストと changelog fragment を追加

Closes #4907