### PR TITLE
feat: fal ループ動画エンジンを CLI に配線する (#4950)

### DIFF
--- a/.claude/skills/thumbnail/config.default.yaml
+++ b/.claude/skills/thumbnail/config.default.yaml
@@ -6,6 +6,9 @@
 # テキストなし main.png/jpg からループ動画背景を生成する --loop mode。
 # 旧 config/skills/loop-video.yaml override は loader がこの節へ deep-merge する。
 loop:
+  # 既定は GCP に集約できる Veo。fal は低コストの opt-in。
+  engine: veo
+
   # 動画の構成タイプ。現行 generator は loop のみを実装する。
   video_type: loop
 
@@ -56,6 +59,24 @@ loop:
     # Veo API 制約で現状 8 秒固定。
     duration_seconds: 8
     crossfade_sec: 0.5
+
+  # fal.ai queue 経由の MiniMax H3 image-to-video。
+  fal:
+    model: "minimax/h3-max-turbo/image-to-video"
+    allowed_models:
+      - "minimax/h3-max-turbo/image-to-video"
+      - "minimax/h3-max/image-to-video"
+    duration_seconds: 8
+    aspect_ratio: "16:9"
+    resolution: "768P"
+    prompt_expansion_mode: balanced
+    upscale_to: [1920, 1080]
+    canvas:
+      "16:9": [1344, 768]
+      "9:16": [768, 1344]
+    timeout_seconds: 600
+    poll_interval_seconds: 2
+    max_poll_retries: 3
 
   # Gemini Developer API Interactions API の代替エンジン。
   omni:

--- a/.claude/skills/thumbnail/references/loop.md
+++ b/.claude/skills/thumbnail/references/loop.md
@@ -57,6 +57,8 @@ subagent は `workflow-state.json` へ書き込まず `AskUserQuestion` を実�
 
 ## 前提
 
+既定 engine は GCP に集約できる Veo とする。fal は低コストな opt-in として利用し、fal 生成物の承認が 3 本以上蓄積した場合、または Veo の値上げ・廃止が告知された場合に既定 engine を再評価する。
+
 `config/channel/` が存在すること（`load_config()` でロード可能）。
 
 存在しない場合、ユーザーに確認:

--- a/changelog.d/4950-fal-loop-cli.added.md
+++ b/changelog.d/4950-fal-loop-cli.added.md
@@ -1,0 +1,1 @@
+- `yt-generate-loop-video` に fal.ai のループ動画生成 engine と skill-config による既定 engine 選択を追加。

--- a/changelog.d/4950-fal-loop-cli.added.md
+++ b/changelog.d/4950-fal-loop-cli.added.md
@@ -1,1 +1,2 @@
 - `yt-generate-loop-video` に fal.ai のループ動画生成 engine と skill-config による既定 engine 選択を追加。
+- `loop.fal.max_poll_retries` を生成境界へ渡し、一時的な polling 障害の再試行回数を設定できます。

--- a/src/youtube_automation/commands/media/generate_loop_video.py
+++ b/src/youtube_automation/commands/media/generate_loop_video.py
@@ -416,7 +416,8 @@ def _run_generate(
             prompt_expansion_mode=str(fal_config.get("prompt_expansion_mode", DEFAULT_FAL_PROMPT_EXPANSION_MODE)),
             timeout_sec=float(fal_config.get("timeout_seconds", DEFAULT_FAL_TIMEOUT_SEC)),
             poll_interval_sec=float(fal_config.get("poll_interval_seconds", DEFAULT_FAL_POLL_INTERVAL_SEC)),
-            max_poll_retries=int(fal_config.get("max_poll_retries", DEFAULT_FAL_MAX_POLL_RETRIES)),
+            # 不正な型を丸めず、生成境界の整数検証へ渡す。
+            max_poll_retries=fal_config.get("max_poll_retries", DEFAULT_FAL_MAX_POLL_RETRIES),
             allowed_models=frozenset(fal_config.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
             canvas=canvas or DEFAULT_FAL_CANVAS,
             upscale_to=tuple(upscale) if upscale is not None else None,

--- a/src/youtube_automation/commands/media/generate_loop_video.py
+++ b/src/youtube_automation/commands/media/generate_loop_video.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""コレクション用ループ動画背景を Veo / Omni / MiniMax H3 で生成する。
+"""コレクション用ループ動画背景を Veo / fal / Omni / MiniMax H3 で生成する。
 
 main.png を開始・終了フレーム両方に指定し、微細なアニメーション付きの
 シームレスなループ動画を生成する。
@@ -25,15 +25,40 @@ import time
 from pathlib import Path
 
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.media.loop_engine import LoopEngineConfig
 from youtube_automation.domains.media.video_type import VideoType, VideoTypeConfig
 from youtube_automation.infrastructure.media.fal_video_generator import (
     DEFAULT_ALLOWED_MODELS as DEFAULT_FAL_ALLOWED_MODELS,
 )
 from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_ASPECT_RATIO as DEFAULT_FAL_ASPECT_RATIO,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
     DEFAULT_CANVAS as DEFAULT_FAL_CANVAS,
 )
 from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_DURATION_SECONDS as DEFAULT_FAL_DURATION_SECONDS,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_MAX_POLL_RETRIES as DEFAULT_FAL_MAX_POLL_RETRIES,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
     DEFAULT_MODEL as DEFAULT_FAL_MODEL,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_POLL_INTERVAL_SEC as DEFAULT_FAL_POLL_INTERVAL_SEC,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_PROMPT_EXPANSION_MODE as DEFAULT_FAL_PROMPT_EXPANSION_MODE,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_RESOLUTION as DEFAULT_FAL_RESOLUTION,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_TIMEOUT_SEC as DEFAULT_FAL_TIMEOUT_SEC,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_UPSCALE_TO as DEFAULT_FAL_UPSCALE_TO,
 )
 from youtube_automation.infrastructure.media.fal_video_generator import (
     generate_loop_video as generate_fal_loop_video,
@@ -223,7 +248,7 @@ def _build_parser() -> argparse.ArgumentParser:
     # RawTextHelpFormatter: help 文字列にハイフン入りモデル名が連なるため、
     # 80 桁折り返しで `veo-3.1-lite-` / `generate-preview` のように分断されないようにする。
     parser = argparse.ArgumentParser(
-        description="Veo 3.1 / Gemini Omni Flash / MiniMax H3 コレクションループ動画生成",
+        description="Veo 3.1 / fal.ai / Gemini Omni Flash / MiniMax H3 コレクションループ動画生成",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument("collection", nargs="?", help="コレクションパス")
@@ -379,19 +404,19 @@ def _run_generate(
         fal_config = engine_config or {}
         raw_canvas = fal_config.get("canvas", {})
         canvas = {str(key): tuple(value) for key, value in raw_canvas.items()}
-        upscale = fal_config.get("upscale_to", [1920, 1080])
+        upscale = fal_config.get("upscale_to", DEFAULT_FAL_UPSCALE_TO)
         success = generate_fal_loop_video(
             image_path,
             output_path,
             model,
             prompt,
-            duration_seconds=int(fal_config.get("duration_seconds", 8)),
-            aspect_ratio=str(fal_config.get("aspect_ratio", "16:9")),
-            resolution=str(fal_config.get("resolution", "768P")),
-            prompt_expansion_mode=str(fal_config.get("prompt_expansion_mode", "balanced")),
-            timeout_sec=float(fal_config.get("timeout_seconds", 600)),
-            poll_interval_sec=float(fal_config.get("poll_interval_seconds", 2)),
-            max_poll_retries=fal_config.get("max_poll_retries", 3),
+            duration_seconds=int(fal_config.get("duration_seconds", DEFAULT_FAL_DURATION_SECONDS)),
+            aspect_ratio=str(fal_config.get("aspect_ratio", DEFAULT_FAL_ASPECT_RATIO)),
+            resolution=str(fal_config.get("resolution", DEFAULT_FAL_RESOLUTION)),
+            prompt_expansion_mode=str(fal_config.get("prompt_expansion_mode", DEFAULT_FAL_PROMPT_EXPANSION_MODE)),
+            timeout_sec=float(fal_config.get("timeout_seconds", DEFAULT_FAL_TIMEOUT_SEC)),
+            poll_interval_sec=float(fal_config.get("poll_interval_seconds", DEFAULT_FAL_POLL_INTERVAL_SEC)),
+            max_poll_retries=int(fal_config.get("max_poll_retries", DEFAULT_FAL_MAX_POLL_RETRIES)),
             allowed_models=frozenset(fal_config.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
             canvas=canvas or DEFAULT_FAL_CANVAS,
             upscale_to=tuple(upscale) if upscale is not None else None,
@@ -459,9 +484,6 @@ def _run_generate(
 def main():
     parser = _build_parser()
     args = parser.parse_args()
-
-    # `--help` は checkout 外の設定や追加 domain module を解決せず完結させる。
-    from youtube_automation.domains.media.loop_engine import LoopEngineConfig
 
     skill_config = load_config()
     try:

--- a/src/youtube_automation/commands/media/generate_loop_video.py
+++ b/src/youtube_automation/commands/media/generate_loop_video.py
@@ -391,6 +391,7 @@ def _run_generate(
             prompt_expansion_mode=str(fal_config.get("prompt_expansion_mode", "balanced")),
             timeout_sec=float(fal_config.get("timeout_seconds", 600)),
             poll_interval_sec=float(fal_config.get("poll_interval_seconds", 2)),
+            max_poll_retries=fal_config.get("max_poll_retries", 3),
             allowed_models=frozenset(fal_config.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
             canvas=canvas or DEFAULT_FAL_CANVAS,
             upscale_to=tuple(upscale) if upscale is not None else None,

--- a/src/youtube_automation/commands/media/generate_loop_video.py
+++ b/src/youtube_automation/commands/media/generate_loop_video.py
@@ -26,6 +26,18 @@ from pathlib import Path
 
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.domains.media.video_type import VideoType, VideoTypeConfig
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_ALLOWED_MODELS as DEFAULT_FAL_ALLOWED_MODELS,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_CANVAS as DEFAULT_FAL_CANVAS,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_MODEL as DEFAULT_FAL_MODEL,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    generate_loop_video as generate_fal_loop_video,
+)
 from youtube_automation.infrastructure.media.genai_client import create_veo_genai_client
 from youtube_automation.infrastructure.media.minimax_video_generator import (
     DEFAULT_ASPECT_RATIO as DEFAULT_H3_ASPECT_RATIO,
@@ -217,9 +229,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("collection", nargs="?", help="コレクションパス")
     parser.add_argument(
         "--engine",
-        choices=("veo", "omni", "h3"),
-        default="veo",
-        help="動画生成エンジン (default: veo)",
+        choices=("veo", "fal", "omni", "h3"),
+        default=None,
+        help="動画生成エンジン (default: loop.engine、未設定時 veo)",
     )
     parser.add_argument(
         "--prompt",
@@ -363,7 +375,28 @@ def _run_generate(
         _backup_existing_loop(output_path, max_backups=max_backups)
 
     start_time = time.monotonic()
-    if engine == "h3":
+    if engine == "fal":
+        fal_config = engine_config or {}
+        raw_canvas = fal_config.get("canvas", {})
+        canvas = {str(key): tuple(value) for key, value in raw_canvas.items()}
+        upscale = fal_config.get("upscale_to", [1920, 1080])
+        success = generate_fal_loop_video(
+            image_path,
+            output_path,
+            model,
+            prompt,
+            duration_seconds=int(fal_config.get("duration_seconds", 8)),
+            aspect_ratio=str(fal_config.get("aspect_ratio", "16:9")),
+            resolution=str(fal_config.get("resolution", "768P")),
+            prompt_expansion_mode=str(fal_config.get("prompt_expansion_mode", "balanced")),
+            timeout_sec=float(fal_config.get("timeout_seconds", 600)),
+            poll_interval_sec=float(fal_config.get("poll_interval_seconds", 2)),
+            allowed_models=frozenset(fal_config.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
+            canvas=canvas or DEFAULT_FAL_CANVAS,
+            upscale_to=tuple(upscale) if upscale is not None else None,
+            compression=compression,
+        )
+    elif engine == "h3":
         h3_config = engine_config or {}
         success = generate_h3_loop_video(
             image_path,
@@ -426,12 +459,16 @@ def main():
     parser = _build_parser()
     args = parser.parse_args()
 
+    # `--help` は checkout 外の設定や追加 domain module を解決せず完結させる。
+    from youtube_automation.domains.media.loop_engine import LoopEngineConfig
+
     skill_config = load_config()
     try:
         video_type = VideoTypeConfig.from_mapping(
             skill_config,
             config_path="config/skills/loop-video.yaml::video_type",
         ).video_type
+        configured_engine = LoopEngineConfig.from_mapping(skill_config).engine.value
     except ConfigError as e:
         print(f"[ERROR] {e}", file=sys.stderr)
         sys.exit(1)
@@ -449,15 +486,20 @@ def main():
             file=sys.stderr,
         )
         sys.exit(1)
-    engine_config = skill_config.get(args.engine, {})
+    engine = args.engine or configured_engine
+    engine_config = skill_config.get(engine, {})
     compression_config = skill_config.get("compression", {})
     max_backups = int(skill_config.get("max_backups", DEFAULT_MAX_BACKUPS))
     default_model = {
         "veo": DEFAULT_MODEL,
+        "fal": DEFAULT_FAL_MODEL,
         "omni": DEFAULT_OMNI_MODEL,
         "h3": DEFAULT_H3_MODEL,
-    }[args.engine]
+    }[engine]
     model = args.model or engine_config.get("model", default_model)
+    if engine == "fal" and model not in engine_config.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS):
+        print("[ERROR] fal model は loop.fal.allowed_models に含まれる必要があります", file=sys.stderr)
+        sys.exit(1)
     prompt = resolve_prompt(args, engine_config, skill_config)
 
     collection_path = _resolve_collection_path(args, parser)
@@ -475,7 +517,7 @@ def main():
         output_path,
         model,
         prompt,
-        engine=args.engine,
+        engine=engine,
         engine_config=engine_config,
         assume_yes=args.yes,
         max_backups=max_backups,

--- a/src/youtube_automation/domains/media/loop_engine.py
+++ b/src/youtube_automation/domains/media/loop_engine.py
@@ -1,0 +1,40 @@
+"""ループ動画生成エンジンの skill-config 契約。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+from youtube_automation.core.errors import ConfigError
+
+
+class LoopEngine(str, Enum):
+    """利用可能なループ動画生成プロバイダ。"""
+
+    VEO = "veo"
+    FAL = "fal"
+    OMNI = "omni"
+    H3 = "h3"
+
+    @classmethod
+    def parse(cls, value: object, *, config_path: str = "loop.engine") -> "LoopEngine":
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(str(value).strip().lower())
+        except ValueError as exc:
+            allowed = ", ".join(item.value for item in cls)
+            raise ConfigError(f"{config_path} must be one of: {allowed} (got: {value!r})") from exc
+
+
+@dataclass(frozen=True)
+class LoopEngineConfig:
+    """実行経路を fail-fast で選ぶ最小の skill-config parser。"""
+
+    engine: LoopEngine = LoopEngine.VEO
+
+    @classmethod
+    def from_mapping(cls, config: Mapping[str, object] | None) -> "LoopEngineConfig":
+        raw_value = (config or {}).get("engine", LoopEngine.VEO.value)
+        return cls(engine=LoopEngine.parse(raw_value))

--- a/src/youtube_automation/infrastructure/media/fal_video_generator.py
+++ b/src/youtube_automation/infrastructure/media/fal_video_generator.py
@@ -21,6 +21,7 @@ from youtube_automation.infrastructure.media.veo_generator import resolve_smooth
 
 DEFAULT_MODEL = "minimax/h3-max-turbo/image-to-video"
 DEFAULT_DURATION_SECONDS = 5
+DEFAULT_ASPECT_RATIO = "16:9"
 DEFAULT_RESOLUTION = "768P"
 DEFAULT_PROMPT_EXPANSION_MODE = "balanced"
 DEFAULT_TIMEOUT_SEC = 600.0
@@ -28,6 +29,7 @@ DEFAULT_POLL_INTERVAL_SEC = 2.0
 DEFAULT_MAX_POLL_RETRIES = 3
 DEFAULT_ALLOWED_MODELS = frozenset({DEFAULT_MODEL, "minimax/h3-max/image-to-video"})
 DEFAULT_CANVAS = {"16:9": (1344, 768), "9:16": (768, 1344)}
+DEFAULT_UPSCALE_TO = (1920, 1080)
 _MAX_PROMPT_CHARS = 2000
 _RESOLUTIONS = {"480P", "768P"}
 _MODES = {"balanced", "quality"}
@@ -238,7 +240,7 @@ def generate_loop_video(
     prompt: str,
     *,
     duration_seconds: int = DEFAULT_DURATION_SECONDS,
-    aspect_ratio: str = "16:9",
+    aspect_ratio: str = DEFAULT_ASPECT_RATIO,
     resolution: str = DEFAULT_RESOLUTION,
     prompt_expansion_mode: str = DEFAULT_PROMPT_EXPANSION_MODE,
     timeout_sec: float = DEFAULT_TIMEOUT_SEC,
@@ -246,7 +248,7 @@ def generate_loop_video(
     max_poll_retries: int = DEFAULT_MAX_POLL_RETRIES,
     allowed_models: Collection[str] = DEFAULT_ALLOWED_MODELS,
     canvas: Mapping[str, tuple[int, int]] = DEFAULT_CANVAS,
-    upscale_to: tuple[int, int] | None = (1920, 1080),
+    upscale_to: tuple[int, int] | None = DEFAULT_UPSCALE_TO,
     compression: dict | None = None,
     channel_root: Path | None = None,
 ) -> bool:

--- a/tests/commands/media/test_generate_loop_video_cli.py
+++ b/tests/commands/media/test_generate_loop_video_cli.py
@@ -103,7 +103,7 @@ class TestBuildParser:
         )
 
         assert result.returncode == 0
-        assert "--engine {veo,omni,h3}" in result.stdout
+        assert "--engine {veo,fal,omni,h3}" in result.stdout
 
     def test_parser_accepts_lite_preview_model(self):
         # Given: Issue #129 のメインケース。preview モデルを CLI から指定可能。
@@ -268,8 +268,11 @@ class TestBuildParser:
         # Then
         assert args.skip_existing is False
 
-    def test_parser_engine_defaults_to_veo(self):
-        assert _build_parser().parse_args([]).engine == "veo"
+    def test_parser_engine_defaults_to_none_for_config_resolution(self):
+        assert _build_parser().parse_args([]).engine is None
+
+    def test_parser_accepts_fal_engine(self):
+        assert _build_parser().parse_args(["--engine", "fal"]).engine == "fal"
 
     def test_parser_accepts_omni_engine(self):
         assert _build_parser().parse_args(["--engine", "omni"]).engine == "omni"
@@ -1181,6 +1184,64 @@ class TestMainOmniEngine:
 
         assert excinfo.value.code == 0
         assert generate_omni.call_args.args[3] == DEFAULT_OMNI_MODEL
+
+
+class TestMainFalEngine:
+    def test_config_selects_fal_without_cli_engine(self, tmp_path, monkeypatch):
+        from youtube_automation.commands.media import generate_loop_video as mod
+
+        col = _make_collection(tmp_path)
+        _write_image(col)
+        monkeypatch.setattr(sys, "argv", ["yt-generate-loop-video", str(col), "-y"])
+        fal_config = {
+            "model": "minimax/h3-max-turbo/image-to-video",
+            "allowed_models": ["minimax/h3-max-turbo/image-to-video"],
+        }
+        with (
+            _patch_main_boundaries() as mocks,
+            patch.object(mod, "generate_fal_loop_video", return_value=True) as generate_fal,
+        ):
+            _set_default_mocks(mocks)
+            mocks["load_config"].return_value = {"engine": "fal", "fal": fal_config}
+            with pytest.raises(SystemExit) as excinfo:
+                mod.main()
+
+        assert excinfo.value.code == 0
+        generate_fal.assert_called_once()
+        mocks["create_veo_genai_client"].assert_not_called()
+
+    def test_cli_veo_overrides_configured_fal(self, tmp_path, monkeypatch):
+        from youtube_automation.commands.media import generate_loop_video as mod
+
+        col = _make_collection(tmp_path)
+        _write_image(col)
+        monkeypatch.setattr(sys, "argv", ["yt-generate-loop-video", str(col), "--engine", "veo", "-y"])
+        with _patch_main_boundaries() as mocks, patch.object(mod, "generate_fal_loop_video") as generate_fal:
+            _set_default_mocks(mocks)
+            mocks["load_config"].return_value = {"engine": "fal"}
+            with pytest.raises(SystemExit) as excinfo:
+                mod.main()
+
+        assert excinfo.value.code == 0
+        mocks["generate_loop_video"].assert_called_once()
+        generate_fal.assert_not_called()
+
+    def test_unallowed_fal_model_fails_before_generator(self, tmp_path, monkeypatch):
+        from youtube_automation.commands.media import generate_loop_video as mod
+
+        col = _make_collection(tmp_path)
+        _write_image(col)
+        monkeypatch.setattr(
+            sys, "argv", ["yt-generate-loop-video", str(col), "--engine", "fal", "--model", "unapproved", "-y"]
+        )
+        with _patch_main_boundaries() as mocks, patch.object(mod, "generate_fal_loop_video") as generate_fal:
+            _set_default_mocks(mocks)
+            mocks["load_config"].return_value = {"fal": {"allowed_models": ["minimax/h3-max-turbo/image-to-video"]}}
+            with pytest.raises(SystemExit) as excinfo:
+                mod.main()
+
+        assert excinfo.value.code == 1
+        generate_fal.assert_not_called()
 
 
 class TestMainH3Engine:

--- a/tests/commands/media/test_generate_loop_video_cli.py
+++ b/tests/commands/media/test_generate_loop_video_cli.py
@@ -1442,3 +1442,23 @@ class TestMainVideoType:
         assert excinfo.value.code == 1
         assert mocks["create_veo_genai_client"].call_count == 0
         assert mocks["generate_loop_video"].call_count == 0
+
+
+def test_fal_retry_override_reaches_generator(tmp_path):
+    from youtube_automation.commands.media import generate_loop_video as mod
+
+    image = tmp_path / "main.png"
+    image.write_bytes(b"image")
+    with patch.object(mod, "generate_fal_loop_video", return_value=True) as generate:
+        with pytest.raises(SystemExit) as exc:
+            mod._run_generate(
+                image,
+                tmp_path / "loop.mp4",
+                "minimax/h3-max-turbo/image-to-video",
+                "motion",
+                engine="fal",
+                engine_config={"max_poll_retries": 7},
+                assume_yes=True,
+            )
+    assert exc.value.code == 0
+    assert generate.call_args.kwargs["max_poll_retries"] == 7

--- a/tests/commands/media/test_generate_loop_video_cli.py
+++ b/tests/commands/media/test_generate_loop_video_cli.py
@@ -1444,7 +1444,8 @@ class TestMainVideoType:
         assert mocks["generate_loop_video"].call_count == 0
 
 
-def test_fal_retry_override_reaches_generator(tmp_path):
+@pytest.mark.parametrize("retries", [7, True, 1.5, None, "3"])
+def test_fal_retry_override_reaches_generator(tmp_path, retries):
     from youtube_automation.commands.media import generate_loop_video as mod
 
     image = tmp_path / "main.png"
@@ -1457,8 +1458,8 @@ def test_fal_retry_override_reaches_generator(tmp_path):
                 "minimax/h3-max-turbo/image-to-video",
                 "motion",
                 engine="fal",
-                engine_config={"max_poll_retries": 7},
+                engine_config={"max_poll_retries": retries},
                 assume_yes=True,
             )
     assert exc.value.code == 0
-    assert generate.call_args.kwargs["max_poll_retries"] == 7
+    assert generate.call_args.kwargs["max_poll_retries"] is retries

--- a/tests/domains/media/test_loop_engine.py
+++ b/tests/domains/media/test_loop_engine.py
@@ -1,0 +1,18 @@
+import pytest
+
+from youtube_automation.core.errors import ConfigError
+from youtube_automation.domains.media.loop_engine import LoopEngine, LoopEngineConfig
+
+
+def test_loop_engine_defaults_to_veo() -> None:
+    assert LoopEngineConfig.from_mapping({}).engine is LoopEngine.VEO
+
+
+@pytest.mark.parametrize("value", ["veo", "fal", "omni", "h3"])
+def test_loop_engine_accepts_supported_values(value: str) -> None:
+    assert LoopEngineConfig.from_mapping({"engine": value}).engine.value == value
+
+
+def test_loop_engine_rejects_unknown_value() -> None:
+    with pytest.raises(ConfigError, match="loop.engine must be one of"):
+        LoopEngineConfig.from_mapping({"engine": "unknown"})


### PR DESCRIPTION
yt-generate-loop-video に fal engine と設定検証を配線します。

Closes #4950