### PR TITLE
feat: automation update に commit オプションを追加する (#4911)

### DIFF
--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -378,7 +378,14 @@ pin 形式ごとの指定方法と通常のオプションは `uv run yt-automat
 6. smoke check: `yt-skills list`
 7. smoke check: `yt-doctor` の `channel_config` check（対象リポの config が不正なら非 0 終了）
 
-途中失敗時は表示された失敗ステップの原因を解消し、**同コマンド + `--allow-dirty`** で再実行する（apply 自身の pin 書き換えで作業ツリーが dirty になっているため。ステップは冪等）。`uv lock` 失敗が続く場合は `uv cache clean` してから再実行。pin 記法が想定外で書き換えできない旨のエラーが出た場合は `[HUMAN STEP]` で該当箇所を見せて手動編集を依頼する。
+途中失敗時は表示された失敗ステップの原因を解消し、実行時のフラグに応じて復旧する。
+
+- `--commit` 未指定: **同コマンド + `--allow-dirty`** で未完了の工程を再実行する。
+- `--commit` 指定（commit ステップ自体の失敗も含む）: 残った追従差分を手動確認して個別 commit する。更新工程が未完了なら **`--commit` を外し `--allow-dirty` を付けて** 再実行し、完了後の差分を確認して個別 commit する。無関係な既存の tracked / staged / untracked 差分は含めない。
+
+`--commit` は各起動の apply 前後で新たに status に現れた path だけを対象にする（#4911）。前回失敗時の差分は次回には開始前の既存差分となるため、`--allow-dirty --commit` で前回分まで自動 commit する復旧には使わない。
+
+`uv lock` 失敗が続く場合は `uv cache clean` してから再実行。pin 記法が想定外で書き換えできない旨のエラーが出た場合は `[HUMAN STEP]` で該当箇所を見せて手動編集を依頼する。
 
 `--prune` は upstream が管理していた既知の rename／削除跡だけを対象にする。未知の target entry はローカル自作 skill の可能性があるため保護される。利用者が明示同意した場合のみ `uv run yt-skills sync --prune --yes` を別途実行する（`--prune` 単独では既知候補の列挙のみで実削除されない）。
 
@@ -574,7 +581,3 @@ git commit -m "chore: youtube-automation <target_ref> への追従 (#N)"
 - `/automation-release`（upstream リポ）— リリース PR を作成し CHANGELOG.md を昇格させる upstream 側スキル（本スキルが読み取るリリース本文を生成する）
 - `/setup` — 追従後に `yt-doctor` で WARNING / FAILED が出た場合の再診断入口、および `[HUMAN STEP]` の書き方の参考実装
 
-
-### `--allow-dirty --commit` の再実行と既存差分
-
-`--commit` は今回の apply 前後で新たに status に現れた path だけを commit する。`--allow-dirty` を付けても開始前の tracked / staged / untracked 差分は含めない（#4911）。前回失敗時の pin 書き換え等が既に dirty な場合、その差分は手動確認して個別 commit してから再実行する。既存の変更をすべて自動 stage する復旧には使わない。

--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -517,6 +517,10 @@ sync 直後に、次の 2 点を Phase 4 へ進む前に判定する。手順は
 
 ## Phase 4: コミット（push は人間）
 
+追従開始時に commit まで一括実行できる場合は、Phase 2 の apply を
+`uv run yt-automation-update apply --commit` として、この Phase の手動 commit を省略する。
+既存の対話 wizard で追加確認や修復を挟んだ場合は、以下の明示的な staging 手順を引き続き使う。
+
 ### Step 4-1. ステージング
 
 ```bash

--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -573,3 +573,8 @@ git commit -m "chore: youtube-automation <target_ref> への追従 (#N)"
 - `src/youtube_automation/commands/system/automation_update.py`（upstream リポ）— 本スキルが委譲する機械的手順の実体（`yt-automation-update check` / `apply`）
 - `/automation-release`（upstream リポ）— リリース PR を作成し CHANGELOG.md を昇格させる upstream 側スキル（本スキルが読み取るリリース本文を生成する）
 - `/setup` — 追従後に `yt-doctor` で WARNING / FAILED が出た場合の再診断入口、および `[HUMAN STEP]` の書き方の参考実装
+
+
+### `--allow-dirty --commit` の再実行と既存差分
+
+`--commit` は今回の apply 前後で新たに status に現れた path だけを commit する。`--allow-dirty` を付けても開始前の tracked / staged / untracked 差分は含めない（#4911）。前回失敗時の pin 書き換え等が既に dirty な場合、その差分は手動確認して個別 commit してから再実行する。既存の変更をすべて自動 stage する復旧には使わない。

--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -517,7 +517,7 @@ sync 直後に、次の 2 点を Phase 4 へ進む前に判定する。手順は
 
 ## Phase 4: コミット（push は人間）
 
-追従開始時に commit まで一括実行できる場合は、Phase 2 の apply を
+追従開始時に commit まで一括実行できる場合は、Phase 3（Step 3-2）の apply を
 `uv run yt-automation-update apply --commit` として、この Phase の手動 commit を省略する。
 既存の対話 wizard で追加確認や修復を挟んだ場合は、以下の明示的な staging 手順を引き続き使う。
 
@@ -565,7 +565,7 @@ git commit -m "chore: youtube-automation <target_ref> への追従 (#N)"
 - 機械的手順（実行場所判定 / pin 形式判定 / 差分判定 / pin 書き換え / `uv lock` / `yt-skills sync` / smoke check）は `yt-automation-update` CLI に委譲し、AI が sed / uv lock 等を手で再実装しない
 - 人間が答えるべきステップ（上書き判断 / push 判断 / sha pin の bump 先 / `--prune` 付与）を AI が勝手に決めない
 - `--force-sync` / `--prune` 系の破壊的操作は必ず `[HUMAN STEP]` の同意を経る
-- commit / push は CLI の責務外。Phase 4 で AI が commit まで行い、push は人間に依頼する
+- commit は `apply --commit` を使わない場合に Phase 4 で AI が行う。push は CLI の責務外で、人間に依頼する
 - Step 2-3 の抽出セクション境界（`### Added` / `### Changed` / `### Fixed` / `### Removed` / `### Migration`）と Migration セクション必須要素（`所要時間の目安` / `local fix 衝突注意`）を配布先での **入力契約** とする。upstream 側のリリース本文契約が変わったら Step 2-3 も同期更新する
 
 ## Cross References

--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -380,7 +380,7 @@ pin 形式ごとの指定方法と通常のオプションは `uv run yt-automat
 
 途中失敗時は表示された失敗ステップの原因を解消し、実行時のフラグに応じて復旧する。
 
-- `--commit` 未指定: **同コマンド + `--allow-dirty`** で未完了の工程を再実行する。
+- `--commit` 未指定の途中失敗: **同コマンド + `--allow-dirty`** で未完了の工程を再実行する。
 - `--commit` 指定（commit ステップ自体の失敗も含む）: 残った追従差分を手動確認して個別 commit する。更新工程が未完了なら **`--commit` を外し `--allow-dirty` を付けて** 再実行し、完了後の差分を確認して個別 commit する。無関係な既存の tracked / staged / untracked 差分は含めない。
 
 `--commit` は各起動の apply 前後で新たに status に現れた path だけを対象にする（#4911）。前回失敗時の差分は次回には開始前の既存差分となるため、`--allow-dirty --commit` で前回分まで自動 commit する復旧には使わない。
@@ -580,4 +580,3 @@ git commit -m "chore: youtube-automation <target_ref> への追従 (#N)"
 - `src/youtube_automation/commands/system/automation_update.py`（upstream リポ）— 本スキルが委譲する機械的手順の実体（`yt-automation-update check` / `apply`）
 - `/automation-release`（upstream リポ）— リリース PR を作成し CHANGELOG.md を昇格させる upstream 側スキル（本スキルが読み取るリリース本文を生成する）
 - `/setup` — 追従後に `yt-doctor` で WARNING / FAILED が出た場合の再診断入口、および `[HUMAN STEP]` の書き方の参考実装
-

--- a/changelog.d/4911-automation-update-commit.added.md
+++ b/changelog.d/4911-automation-update-commit.added.md
@@ -1,0 +1,2 @@
+- `yt-automation-update apply --commit` で、追従処理が新たに作った差分だけを commit できるようにした
+- untracked ファイルだけがある作業ツリーを automation update の clean 判定で許容するようにした

--- a/changelog.d/4911-automation-update-commit.added.md
+++ b/changelog.d/4911-automation-update-commit.added.md
@@ -1,2 +1,2 @@
-- `yt-automation-update apply --commit` で、追従処理が新たに作った差分だけを commit できるようにした
-- untracked ファイルだけがある作業ツリーを automation update の clean 判定で許容するようにした
+- `yt-automation-update apply --commit` で、追従処理が新たに作った差分だけを commit できるようにした（#4911）
+- untracked ファイルだけがある作業ツリーを automation update の clean 判定で許容するようにした（#4911）

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -546,11 +546,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
             action()
         except (_StepFailed, ConfigError) as e:
             print(f"[error] ステップ {index}/{total} '{name}' で失敗しました: {e}", file=sys.stderr)
-            print(
-                "[error] 原因を解消して同じコマンドを再実行すると、続きから冪等にやり直せます"
-                "（apply 自身の pin 書き換えで作業ツリーが dirty になっている場合は --allow-dirty を付ける）",
-                file=sys.stderr,
-            )
+            print(_apply_retry_hint(committed=args.commit), file=sys.stderr)
             return 1
     _print_apply_success(committed=args.commit)
     hooks_after = _hooks_snapshot(root)
@@ -560,6 +556,19 @@ def cmd_apply(args: argparse.Namespace) -> int:
             "現在のセッションには反映されないため、Claude Code を再起動してください。"
         )
     return 0
+
+
+def _apply_retry_hint(*, committed: bool) -> str:
+    if committed:
+        return (
+            "[error] 原因を解消し、今回残った追従差分を手動確認して個別 commit してください。"
+            "--allow-dirty --commit の再実行では既存差分は commit 対象になりません。"
+            "未完了の更新工程は --commit なしで再実行し、差分を確認して commit してください。"
+        )
+    return (
+        "[error] 原因を解消して同じコマンドを再実行すると、続きから冪等にやり直せます"
+        "（apply 自身の pin 書き換えで作業ツリーが dirty になっている場合は --allow-dirty を付ける）"
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -204,12 +204,13 @@ def _git_status_paths(root: Path) -> set[str]:
 
 
 def _commit_apply_changes(root: Path, before_paths: set[str], ref: str) -> None:
+    # #4911: --allow-dirty でも開始前の変更は含めない。既存の staged 変更も commit --only で保護する。
     paths = sorted(_git_status_paths(root) - before_paths)
     if not paths:
         raise _StepFailed("apply 前後の git status に commit 対象の差分がありません")
     commands = [
         ["git", "add", "--", *paths],
-        ["git", "commit", "-m", f"chore: youtube-automation {ref} への追従"],
+        ["git", "commit", "--only", "-m", f"chore: youtube-automation {ref} への追従", "--", *paths],
     ]
     for command in commands:
         try:

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -199,6 +199,8 @@ def _git_status_paths(root: Path) -> set[str]:
             continue
         status = record[:2]
         paths.add(record[3:])
+        if "R" in status:
+            paths.add(records[index + 1])
         index += 2 if "R" in status or "C" in status else 1
     return paths
 
@@ -208,8 +210,9 @@ def _commit_apply_changes(root: Path, before_paths: set[str], ref: str) -> None:
     paths = sorted(_git_status_paths(root) - before_paths)
     if not paths:
         raise _StepFailed("apply 前後の git status に commit 対象の差分がありません")
+    existing = [p for p in paths if (root / p).exists() or (root / p).is_symlink()]
     commands = [
-        ["git", "add", "--", *paths],
+        *([["git", "add", "--", *existing]] if existing else []),
         ["git", "commit", "--only", "-m", f"chore: youtube-automation {ref} への追従", "--", *paths],
     ]
     for command in commands:

--- a/src/youtube_automation/commands/system/automation_update.py
+++ b/src/youtube_automation/commands/system/automation_update.py
@@ -7,7 +7,7 @@ Subcommands:
 設計原則:
     判断が必要な手順（リリース内容の要約 / local fix 上書き判断 / 同意取得）は
     automation-update スキル側に残し、本 CLI は機械的に決まる手順のみを担う。
-    commit / push は責務外（スキル・人間側で実施する）。
+    commit は apply --commit で任意に実行し、push はスキル・人間側で実施する。
 
 Exit codes:
     check : 0 = 既に最新 / 1 = 差分あり（要追従） / 2 = エラー
@@ -30,6 +30,7 @@ from youtube_automation.commands.system.automation_update_refs import (
     _SHA_RE,
     PACKAGE_NAME,
     UPSTREAM_REPO,
+    Pin,
     _canonicalize_name,
     _classify_git_ref,
     _describe_pin,
@@ -160,7 +161,7 @@ def _require_tag_ref(ref: str, *, source: str) -> str:
 def _git_status_porcelain(root: Path) -> str:
     try:
         proc = subprocess.run(
-            ["git", "status", "--porcelain"],
+            ["git", "status", "--porcelain", "--untracked-files=no"],
             cwd=root,
             capture_output=True,
             text=True,
@@ -171,6 +172,79 @@ def _git_status_porcelain(root: Path) -> str:
     if proc.returncode != 0:
         raise _StepFailed(f"git status に失敗しました: {proc.stderr.strip()}")
     return proc.stdout.strip()
+
+
+def _git_status_paths(root: Path) -> set[str]:
+    """Return all paths currently reported by status, including untracked files."""
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain=v1", "-z", "--untracked-files=all"],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError as e:
+        raise _StepFailed(f"git status を起動できません: {e}") from e
+    if proc.returncode != 0:
+        raise _StepFailed(f"git status に失敗しました: {proc.stderr.strip()}")
+
+    records = proc.stdout.split("\0")
+    paths: set[str] = set()
+    index = 0
+    while index < len(records):
+        record = records[index]
+        if not record:
+            index += 1
+            continue
+        status = record[:2]
+        paths.add(record[3:])
+        index += 2 if "R" in status or "C" in status else 1
+    return paths
+
+
+def _commit_apply_changes(root: Path, before_paths: set[str], ref: str) -> None:
+    paths = sorted(_git_status_paths(root) - before_paths)
+    if not paths:
+        raise _StepFailed("apply 前後の git status に commit 対象の差分がありません")
+    commands = [
+        ["git", "add", "--", *paths],
+        ["git", "commit", "-m", f"chore: youtube-automation {ref} への追従"],
+    ]
+    for command in commands:
+        try:
+            proc = subprocess.run(command, cwd=root, capture_output=True, text=True, check=False)
+        except OSError as e:
+            raise _StepFailed(f"{' '.join(command[:2])} を起動できません: {e}") from e
+        if proc.returncode != 0:
+            details = proc.stderr.strip() or proc.stdout.strip()
+            raise _StepFailed(f"exit code {proc.returncode}: {' '.join(command[:2])}\n{details}")
+
+
+def _commit_ref(root: Path, pin: Pin, new_ref: str | None) -> str:
+    """apply 後の commit message に使う追従先 ref を pin 種別から解決する。"""
+    if pin.kind == "branch":
+        locked_sha = _locked_git_sha(root)
+        if locked_sha is None:
+            raise _StepFailed("uv.lock から追従後の git sha を取得できません")
+        return locked_sha[:12]
+    assert new_ref is not None
+    return new_ref if pin.kind == "tag" else new_ref[:12]
+
+
+def _append_optional_step(
+    steps: list[tuple[str, Callable[[], None]]], *, enabled: bool, name: str, action: Callable[[], None]
+) -> None:
+    """条件付き step の組み立てを orchestrator の分岐から分離する。"""
+    if enabled:
+        steps.append((name, action))
+
+
+def _print_apply_success(*, committed: bool) -> None:
+    if committed:
+        print("✓ 追従と commit が完了しました。push は本 CLI の責務外です（スキル / 人間側で実施してください）")
+        return
+    print("✓ 追従が完了しました。commit / push は本 CLI の責務外です（スキル / 人間側で実施してください）")
 
 
 def _run_command(cmd: list[str], cwd: Path) -> int:
@@ -373,6 +447,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
     if new_ref:
         print(f"追従先: {new_ref}")
     hooks_before = _hooks_snapshot(root)
+    status_before: set[str] = set()
 
     def step_worktree() -> None:
         status = _git_status_porcelain(root)
@@ -392,6 +467,9 @@ def cmd_apply(args: argparse.Namespace) -> int:
                 "local fix を手動解消してから再実行してください"
             )
 
+    def step_status_snapshot() -> None:
+        status_before.update(_git_status_paths(root))
+
     def step_rewrite() -> None:
         if pin.kind == "branch":
             print(f"  main 追従 (branch={pin.value}) のため pin 書き換えは不要です")
@@ -410,6 +488,11 @@ def cmd_apply(args: argparse.Namespace) -> int:
     def step_channel_config() -> None:
         print(f"  {_check_channel_config(root)}")
 
+    def step_commit() -> None:
+        commit_ref = _commit_ref(root, pin, new_ref)
+        _commit_apply_changes(root, status_before, commit_ref)
+        print(f"  chore: youtube-automation {commit_ref} への追従")
+
     def run(cmd: list[str]) -> Callable[[], None]:
         def _invoke() -> None:
             print(f"  $ {' '.join(cmd)}")
@@ -424,6 +507,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
     steps: list[tuple[str, Callable[[], None]]] = []
     if not args.allow_dirty:
         steps.append(("git 作業ツリー確認", step_worktree))
+    _append_optional_step(steps, enabled=args.commit, name="commit 対象の事前確認", action=step_status_snapshot)
     steps.append(("yt-skills diff による local fix 確認", step_local_fix_guard))
     steps.append(("pyproject.toml の pin 書き換え", step_rewrite))
     steps.append(("uv lock", run(["uv", "lock", "--upgrade-package", PACKAGE_NAME])))
@@ -449,6 +533,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
         )
     steps.append(("smoke check: yt-skills list", run(["uv", "run", "yt-skills", "list"])))
     steps.append(("smoke check: channel config", step_channel_config))
+    _append_optional_step(steps, enabled=args.commit, name="追従差分を commit", action=step_commit)
 
     total = len(steps)
     for index, (name, action) in enumerate(steps, start=1):
@@ -463,7 +548,7 @@ def cmd_apply(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-    print("✓ 追従が完了しました。commit / push は本 CLI の責務外です（スキル / 人間側で実施してください）")
+    _print_apply_success(committed=args.commit)
     hooks_after = _hooks_snapshot(root)
     if args.accept_hooks and hooks_before is not None and hooks_after is not None and hooks_before != hooks_after:
         print(
@@ -533,6 +618,11 @@ def build_parser() -> argparse.ArgumentParser:
         help=(
             "途中失敗からの再実行時に作業ツリーの clean guard だけを bypass する。それ単独では local fix guard は維持"
         ),
+    )
+    p_apply.add_argument(
+        "--commit",
+        action="store_true",
+        help="apply が新たに作った差分だけを stage し、追従 ref を含むメッセージで commit する",
     )
     p_apply.set_defaults(func=cmd_apply)
 

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -1541,3 +1541,23 @@ def test_apply_pyproject_write_failure_is_step_failure(
     err = capsys.readouterr().err
     assert "'pyproject.toml の pin 書き換え' で失敗しました" in err
     assert "disk full" in err
+
+
+@pytest.mark.parametrize("staged", [False, True])
+def test_commit_apply_changes_includes_both_rename_paths(tmp_path: Path, staged: bool) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    _init_apply_git_repo(repo)
+    old = repo / "old.md"
+    old.write_text("skill contents\n")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "skill"], cwd=repo, check=True)
+    before = automation_update._git_status_paths(repo)
+    old.rename(repo / "new.md")
+    if staged:
+        subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    assert automation_update._git_status_paths(repo) == {"old.md", "new.md"}
+    automation_update._commit_apply_changes(repo, before, "v5.8.0")
+    assert subprocess.check_output(["git", "status", "--porcelain"], cwd=repo) == b""
+    tree = subprocess.check_output(["git", "ls-tree", "--name-only", "HEAD"], cwd=repo).splitlines()
+    assert b"new.md" in tree
+    assert b"old.md" not in tree

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -874,12 +874,18 @@ def _init_apply_git_repo(repo: Path) -> None:
     subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
 
 
+@pytest.mark.parametrize("branch_pin", [False, True])
+@pytest.mark.parametrize("allow_dirty", [False, True])
 def test_apply_commit_commits_only_new_status_paths(
-    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch, branch_pin: bool, allow_dirty: bool
 ) -> None:
-    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    repo = _write_repo(tmp_path, BRANCH_FOLLOW_PYPROJECT if branch_pin else INLINE_TABLE_PYPROJECT)
     _init_apply_git_repo(repo)
     (repo / "existing-untracked.txt").write_text("keep me local\n", encoding="utf-8")
+
+    if allow_dirty:
+        (repo / "preexisting-staged.txt").write_text("user work", encoding="utf-8")
+        subprocess.run(["git", "add", "preexisting-staged.txt"], cwd=repo, check=True)
 
     monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
     monkeypatch.setattr(automation_update, "_check_channel_config", lambda root: "config/channel/ ロード成功")
@@ -889,26 +895,35 @@ def test_apply_commit_commits_only_new_status_paths(
             generated = cwd / ".claude" / "skills" / "generated.md"
             generated.parent.mkdir(parents=True)
             generated.write_text("generated\n", encoding="utf-8")
+        if cmd[:2] == ["uv", "lock"] and branch_pin:
+            _write_uv_lock(cwd, _SHA_NEW)
         return 0
 
     monkeypatch.setattr(automation_update, "_run_command", _run)
 
-    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--commit"]) == 0
+    args = ["apply", "--target", str(repo), "--commit"]
+    args += [] if branch_pin else ["--tag", "v5.6.0"]
+    args += ["--allow-dirty"] if allow_dirty else []
+    assert main(args) == 0
+    expected_ref = _SHA_NEW[:12] if branch_pin else "v5.6.0"
     assert (
         subprocess.run(
             ["git", "log", "-1", "--pretty=%s"], cwd=repo, check=True, capture_output=True, text=True
         ).stdout.strip()
-        == "chore: youtube-automation v5.6.0 への追従"
+        == f"chore: youtube-automation {expected_ref} への追従"
     )
     committed = subprocess.run(
         ["git", "show", "--pretty=", "--name-only", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
     ).stdout.splitlines()
-    assert committed == [".claude/skills/generated.md", "pyproject.toml"]
+    assert committed == [".claude/skills/generated.md", "uv.lock" if branch_pin else "pyproject.toml"]
     remaining = subprocess.run(
         ["git", "status", "--porcelain"], cwd=repo, check=True, capture_output=True, text=True
     ).stdout
     assert "?? existing-untracked.txt\n" in remaining
     assert ".claude/skills/generated.md" not in remaining
+
+    if allow_dirty:
+        assert "A  preexisting-staged.txt\n" in remaining
 
 
 def test_apply_commit_failure_keeps_updated_worktree(

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -845,6 +846,92 @@ def test_apply_dirty_worktree_fails_before_any_command(
     assert commands == []
     # pin も書き換えられていない
     assert 'tag = "v5.5.0"' in (repo / "pyproject.toml").read_text(encoding="utf-8")
+
+
+def test_git_status_porcelain_ignores_untracked_files(tmp_path: Path) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    (repo / "untracked.txt").write_text("local\n", encoding="utf-8")
+
+    assert automation_update._git_status_porcelain(repo) == ""
+
+    subprocess.run(["git", "add", "pyproject.toml"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-qm", "base"],
+        cwd=repo,
+        check=True,
+    )
+    (repo / "pyproject.toml").write_text(INLINE_TABLE_PYPROJECT + "\n# changed\n", encoding="utf-8")
+
+    assert "pyproject.toml" in automation_update._git_status_porcelain(repo)
+
+
+def _init_apply_git_repo(repo: Path) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "add", "pyproject.toml"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "base"], cwd=repo, check=True)
+
+
+def test_apply_commit_commits_only_new_status_paths(
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    _init_apply_git_repo(repo)
+    (repo / "existing-untracked.txt").write_text("keep me local\n", encoding="utf-8")
+
+    monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
+    monkeypatch.setattr(automation_update, "_check_channel_config", lambda root: "config/channel/ ロード成功")
+
+    def _run(cmd: list[str], cwd: Path) -> int:
+        if cmd[:4] == ["uv", "run", "yt-skills", "sync"]:
+            generated = cwd / ".claude" / "skills" / "generated.md"
+            generated.parent.mkdir(parents=True)
+            generated.write_text("generated\n", encoding="utf-8")
+        return 0
+
+    monkeypatch.setattr(automation_update, "_run_command", _run)
+
+    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--commit"]) == 0
+    assert (
+        subprocess.run(
+            ["git", "log", "-1", "--pretty=%s"], cwd=repo, check=True, capture_output=True, text=True
+        ).stdout.strip()
+        == "chore: youtube-automation v5.6.0 への追従"
+    )
+    committed = subprocess.run(
+        ["git", "show", "--pretty=", "--name-only", "HEAD"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout.splitlines()
+    assert committed == [".claude/skills/generated.md", "pyproject.toml"]
+    remaining = subprocess.run(
+        ["git", "status", "--porcelain"], cwd=repo, check=True, capture_output=True, text=True
+    ).stdout
+    assert "?? existing-untracked.txt\n" in remaining
+    assert ".claude/skills/generated.md" not in remaining
+
+
+def test_apply_commit_failure_keeps_updated_worktree(
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
+    _init_apply_git_repo(repo)
+    hook = repo / ".git" / "hooks" / "pre-commit"
+    hook.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    hook.chmod(0o755)
+    monkeypatch.setattr(automation_update, "_skills_diff_has_changes", lambda root: False)
+    monkeypatch.setattr(automation_update, "_check_channel_config", lambda root: "config/channel/ ロード成功")
+    monkeypatch.setattr(automation_update, "_run_command", lambda cmd, cwd: 0)
+
+    assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--commit"]) == 1
+    assert 'tag = "v5.6.0"' in (repo / "pyproject.toml").read_text(encoding="utf-8")
+    assert subprocess.run(
+        ["git", "status", "--porcelain", "--untracked-files=no"],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
 
 
 def test_apply_local_fix_diff_requires_explicit_sync_decision(

--- a/tests/commands/system/test_automation_update.py
+++ b/tests/commands/system/test_automation_update.py
@@ -927,7 +927,7 @@ def test_apply_commit_commits_only_new_status_paths(
 
 
 def test_apply_commit_failure_keeps_updated_worktree(
-    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, no_network, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
 ) -> None:
     repo = _write_repo(tmp_path, INLINE_TABLE_PYPROJECT)
     _init_apply_git_repo(repo)
@@ -939,6 +939,10 @@ def test_apply_commit_failure_keeps_updated_worktree(
     monkeypatch.setattr(automation_update, "_run_command", lambda cmd, cwd: 0)
 
     assert main(["apply", "--target", str(repo), "--tag", "v5.6.0", "--commit"]) == 1
+    error = capsys.readouterr().err
+    assert "手動確認して個別 commit" in error
+    assert "既存差分は commit 対象になりません" in error
+    assert "続きから冪等" not in error
     assert 'tag = "v5.6.0"' in (repo / "pyproject.toml").read_text(encoding="utf-8")
     assert subprocess.run(
         ["git", "status", "--porcelain", "--untracked-files=no"],


### PR DESCRIPTION
## 変更内容
- `yt-automation-update apply --commit` を追加
- apply 前後に新規発生した追跡対象 path のみ stage して単一 commit を作成
- untracked file を clean 判定から除外し、失敗時は更新済み作業ツリーを保持
- wizard、テスト、changelog fragment を更新

Closes #4911

## commit 対象と再実行の契約

#4911 の提案仕様は「`--allow-dirty` 併用時は更新前後の status 差分だけを add」と明記しています。開始前から dirty な tracked ファイルを一律に commit する変更は、この要件と衝突するため採用していません。前回失敗時の変更は手動確認・個別 commit 後に再実行する手順を update.md に追記しました。

既存の staged 変更も自動 commit に混入しないよう `git commit --only -- <paths>` を使用します。tag / main pin と通常 / allow-dirty の4組合せを実際のgitリポジトリで検証し、既存untracked・stagedを保持しつつ生成ファイルと今回のpin/lock変更だけをcommitします。main pinはuv.lockに書かれた短SHAをcommitメッセージで検証します。
