### PR TITLE
feat: Shorts の fal ループ生成を追加 (#4951)

### DIFF
--- a/.claude/skills/short/SKILL.md
+++ b/.claude/skills/short/SKILL.md
@@ -92,7 +92,7 @@ generation = load_skill_config("short")[content_type]
 | `uv run yt-upload-shorts <collection-path> --short-num <short-num>` | 指定番号のショートを 1 本投稿し、結果の action を確認 |
 | `uv run yt-shorts-bulk-update-loc --dry-run` | 投稿済み collection Shorts の localization 更新を確認 |
 | `uv run yt-generate-image --aspect-ratio "9:16" --prompt "<text>" --output <collection>/10-assets/short.png -y` | `--thumbnail` の 9:16 画像生成 |
-| `uv run yt-generate-shorts-loop <collection-path> -y` | `short.png` の 9:16 ループ動画化 |
+| `uv run yt-generate-shorts-loop <collection-path> [--engine veo\|fal] -y` | `short.png` の 9:16 ループ動画化 |
 
 ## Instructions
 
@@ -117,7 +117,7 @@ generation = load_skill_config("short")[content_type]
 | thumbnails.set（50 units / 本） | collection 型の投稿本数 | release 型は 0 |
 | videos.update（50 units） | `yt-shorts-bulk-update-loc` の対象 Shorts 数 | `--dry-run` は 0 |
 | Vertex AI Gemini | `--thumbnail` の `short.png` 生成で 1 call | 再生成回数 |
-| Vertex AI Veo 3.1 | `--thumbnail` のループ動画化で 1 call | ループ不要なら 0 |
+| Vertex AI Veo 3.1 / fal.ai | `--thumbnail` のループ動画化で選択 engine に 1 call | ループ不要なら 0 |
 
 - 上限 / 承認: collection 型は `--plan` と `--short-num` で小出しに確認できる。`--thumbnail` の画像・動画生成は各 1 call ごとに承認する。release 型はローカル ffmpeg 生成だけで、投稿 API は呼ばない。
 

--- a/.claude/skills/short/config.default.yaml
+++ b/.claude/skills/short/config.default.yaml
@@ -26,6 +26,7 @@ fal:
   upscale_to: [1080, 1920]
   timeout_seconds: 600
   poll_interval_seconds: 2
+  max_poll_retries: 3
   default_prompt: |
     Gentle natural animation with a locked camera. Keep all text completely static and unchanged.
 

--- a/.claude/skills/short/config.default.yaml
+++ b/.claude/skills/short/config.default.yaml
@@ -5,6 +5,30 @@
 #
 # チャンネル側上書きは config/skills/short.yaml。
 
+# Shorts ループ動画の既定 engine。fal は低コストの opt-in。
+engine: veo
+
+veo:
+  model: "veo-3.1-fast-generate-001"
+  default_prompt: |
+    Gentle natural animation with a locked camera. Keep all text completely static and unchanged.
+
+fal:
+  model: "minimax/h3-max-turbo/image-to-video"
+  allowed_models:
+    - "minimax/h3-max-turbo/image-to-video"
+    - "minimax/h3-max/image-to-video"
+  duration_seconds: 8
+  resolution: "768P"
+  prompt_expansion_mode: balanced
+  canvas:
+    "9:16": [768, 1344]
+  upscale_to: [1080, 1920]
+  timeout_seconds: 600
+  poll_interval_seconds: 2
+  default_prompt: |
+    Gentle natural animation with a locked camera. Keep all text completely static and unchanged.
+
 collection:
   # generate-shorts.sh の env デフォルト
   duration_sec: 20          # 1 ショートあたりの尺

--- a/.claude/skills/short/references/thumbnail.md
+++ b/.claude/skills/short/references/thumbnail.md
@@ -69,10 +69,16 @@ open <collection-path>/10-assets/short.png
 
 ## Step 5: ループ動画化する
 
-承認された `short.png` を Veo 3.1 で変換する。
+承認された `short.png` を Veo 3.1（既定）または fal.ai で変換する。
 
 ```bash
 uv run yt-generate-shorts-loop <collection-path> -y
+```
+
+fal.ai を選ぶ場合は `--engine fal` を付ける。入力は 768x1344 に事前リサイズし、最終出力は 1080x1920 へアップスケールする。
+
+```bash
+uv run yt-generate-shorts-loop <collection-path> --engine fal -y
 ```
 
 カスタム動作も指定できる。
@@ -97,7 +103,7 @@ open <collection-path>/10-assets/short-loop.mp4
 
 | 配置 | 責務 |
 |---|---|
-| `.claude/skills/short/config.default.yaml` の `veo` 節 | Veo モデル / デフォルトプロンプト。未定義時は CLI 内蔵値 |
+| `.claude/skills/short/config.default.yaml` の `engine` / `veo` / `fal` | 既定 engine、各モデル / プロンプ / 解像度 |
 | `config/skills/short.yaml` | `yt-generate-shorts-loop` の skill-config 上書き |
 | `config/channel/meta.json` | channel name |
 | `config/channel/audio.json` | CTA に使う target duration |

--- a/.claude/skills/short/references/thumbnail.md
+++ b/.claude/skills/short/references/thumbnail.md
@@ -77,6 +77,8 @@ uv run yt-generate-shorts-loop <collection-path> -y
 
 fal.ai を選ぶ場合は `--engine fal` を付ける。入力は 768x1344 に事前リサイズし、最終出力は 1080x1920 へアップスケールする。
 
+fal 生成ではアップスケール前の「fal 生出力」と canvas 想定値を比較し、9:16 の実寸が推定 768x1344 と異なる場合は `config/skills/short.yaml::fal.canvas` を修正する。「最終出力実寸」は後処理後の 1080x1920 を表す。expanded prompt は `10-assets/short-loop.expanded-prompt.txt` に保存される。
+
 ```bash
 uv run yt-generate-shorts-loop <collection-path> --engine fal -y
 ```

--- a/changelog.d/4951-shorts-fal.added.md
+++ b/changelog.d/4951-shorts-fal.added.md
@@ -1,0 +1,1 @@
+- `yt-generate-shorts-loop` に fal.ai を使う `--engine fal` と 9:16 用のリサイズ設定を追加。

--- a/changelog.d/4951-shorts-fal.added.md
+++ b/changelog.d/4951-shorts-fal.added.md
@@ -1,1 +1,2 @@
 - `yt-generate-shorts-loop` に fal.ai を使う `--engine fal` と 9:16 用のリサイズ設定を追加。
+- fal 生出力の実寸をアップスケール前に canvas 想定値と併記し、最終出力寸法と区別します。Shorts の polling 再試行回数も設定できます。

--- a/site/skill-docs/short.md
+++ b/site/skill-docs/short.md
@@ -29,7 +29,7 @@ release 型では JP / EN の 9:16 動画をローカルで生成します。サ
 /short --thumbnail
 ```
 
-`--thumbnail` は collection 型だけで使える一段実行です。9:16 の `short.png` を生成・承認し、必要なら縦型の `short-loop.mp4` に動画化します。content model を切り替えるフラグではないため、release 型で指定すると対象外として停止します。
+`--thumbnail` は collection 型だけで使える一段実行です。9:16 の `short.png` を生成・承認し、必要なら縦型の `short-loop.mp4` に動画化します。ループ生成は Veo が既定で、`yt-generate-shorts-loop --engine fal` による fal.ai も選択できます。content model を切り替えるフラグではないため、release 型で指定すると対象外として停止します。
 
 ## つまずいたら
 

--- a/site/skill-docs/thumbnail.md
+++ b/site/skill-docs/thumbnail.md
@@ -49,7 +49,7 @@ collection の YouTube サムネイルを、競合の勝ちパターンとチャ
 /thumbnail --loop
 ```
 
-`--loop` は確定済みの textless `main.png` / `main.jpg` を Veo、Gemini Omni Flash、または MiniMax H3 へ渡し、動画本編で繰り返せる `loop.mp4` を作ります。静止画の確定前には実行せず、生成後は継ぎ目と意図しない文字・動きをプレビューしてください。
+`--loop` は確定済みの textless `main.png` / `main.jpg` を Veo、fal.ai、Gemini Omni Flash、または MiniMax H3 へ渡し、動画本編で繰り返せる `loop.mp4` を作ります。Shorts の 9:16 ループは `yt-generate-shorts-loop --engine fal` でも生成できます。静止画の確定前には実行せず、生成後は継ぎ目と意図しない文字・動きをプレビューしてください。
 
 ## つまずいたら
 
@@ -57,4 +57,3 @@ collection の YouTube サムネイルを、競合の勝ちパターンとチャ
 - **provider の認証や quota で失敗する** — 自動では別 provider に切り替わりません。ADC、API key、利用上限を直すか、設定で provider を明示変更してから再実行してください
 - **`--compare` で不合格になる** — 正式画像へ確定せず、文字量、コントラスト、顔や主役の大きさを直した候補を生成して比較し直してください
 - **`--loop` が始まらない** — `main.png` または `main.jpg` が確定済みか、チャンネルで loop-video が有効かを確認してください
-

--- a/src/youtube_automation/commands/media/generate_short_loop.py
+++ b/src/youtube_automation/commands/media/generate_short_loop.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Shorts (9:16) 用ループ動画を Veo 3.1 API で生成する.
+"""Shorts (9:16) 用ループ動画を Veo / fal で生成する.
 
 `10-assets/short.png`（無ければ `short.jpg`）を入力に、`aspect_ratio="9:16"` で
 8秒の縦型シームレスループ動画を生成し `10-assets/short-loop.mp4` に保存する.
@@ -20,7 +20,15 @@ from pathlib import Path
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import ConfigError
 from youtube_automation.infrastructure.media.collection_paths import CollectionPaths
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    DEFAULT_ALLOWED_MODELS as DEFAULT_FAL_ALLOWED_MODELS,
+)
+from youtube_automation.infrastructure.media.fal_video_generator import DEFAULT_MODEL as DEFAULT_FAL_MODEL
+from youtube_automation.infrastructure.media.fal_video_generator import (
+    generate_loop_video as generate_fal_loop_video,
+)
 from youtube_automation.infrastructure.media.genai_client import create_veo_genai_client
+from youtube_automation.infrastructure.media.probe import probe_video
 from youtube_automation.infrastructure.media.veo_generator import (
     DEFAULT_MODEL,
     DEFAULT_PROMPT,
@@ -56,7 +64,13 @@ def _build_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument("collection", nargs="?", help="コレクションパス (collections/live/<name>/)")
-    parser.add_argument("--prompt", help="動画生成プロンプト (default: skill-config の veo.default_prompt)")
+    parser.add_argument(
+        "--engine",
+        choices=("veo", "fal"),
+        default=None,
+        help="動画生成エンジン (default: skill-config の engine、未設定時 veo)",
+    )
+    parser.add_argument("--prompt", help="動画生成プロンプト (default: 選択 engine の default_prompt)")
     parser.add_argument(
         "--model",
         help=(
@@ -72,11 +86,15 @@ def main() -> None:
     parser = _build_parser()
     args = parser.parse_args()
 
-    # short skill-config から veo セクションを読み込む（plan 要件 14-c）
+    # short skill-config から選択 engine のセクションを読み込む。
     skill_cfg = load_skill_config(SHORT_SKILL_NAME)
-    veo_cfg = skill_cfg.get("veo", {})
-    model = args.model or veo_cfg.get("model", DEFAULT_MODEL)
-    prompt = args.prompt or veo_cfg.get("default_prompt", DEFAULT_PROMPT)
+    engine = args.engine or skill_cfg.get("engine", "veo")
+    if engine not in {"veo", "fal"}:
+        parser.error("skill-config の engine は veo または fal を指定してください")
+    engine_cfg = skill_cfg.get(engine, {})
+    default_model = DEFAULT_FAL_MODEL if engine == "fal" else DEFAULT_MODEL
+    model = args.model or engine_cfg.get("model", default_model)
+    prompt = args.prompt or engine_cfg.get("default_prompt", DEFAULT_PROMPT)
 
     # コレクションパス解決
     if args.collection:
@@ -100,7 +118,7 @@ def main() -> None:
     # 確認プロンプト
     print()
     print("===========================================")
-    print("  Veo 3.1 Shorts (9:16) ループ動画生成")
+    print(f"  {engine} Shorts (9:16) ループ動画生成")
     print("===========================================")
     print(f"  入力:     {image_path}")
     print(f"  出力:     {output_path}")
@@ -116,21 +134,40 @@ def main() -> None:
             sys.exit(0)
 
     # 生成実行
-    try:
-        client = create_veo_genai_client()
-    except ConfigError as e:
-        print(f"[ERROR] {e}")
-        sys.exit(1)
-
     start_time = time.monotonic()
-    success = generate_loop_video(
-        client,
-        image_path,
-        output_path,
-        model,
-        prompt,
-        aspect_ratio=SHORT_ASPECT_RATIO,
-    )
+    if engine == "fal":
+        raw_canvas = engine_cfg.get("canvas", {})
+        canvas = {str(key): tuple(value) for key, value in raw_canvas.items()}
+        upscale = engine_cfg.get("upscale_to", [1080, 1920])
+        success = generate_fal_loop_video(
+            image_path,
+            output_path,
+            model,
+            prompt,
+            duration_seconds=int(engine_cfg.get("duration_seconds", 8)),
+            aspect_ratio=SHORT_ASPECT_RATIO,
+            resolution=str(engine_cfg.get("resolution", "768P")),
+            prompt_expansion_mode=str(engine_cfg.get("prompt_expansion_mode", "balanced")),
+            timeout_sec=float(engine_cfg.get("timeout_seconds", 600)),
+            poll_interval_sec=float(engine_cfg.get("poll_interval_seconds", 2)),
+            allowed_models=frozenset(engine_cfg.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
+            canvas=canvas or {SHORT_ASPECT_RATIO: (768, 1344)},
+            upscale_to=tuple(upscale) if upscale is not None else None,
+        )
+    else:
+        try:
+            client = create_veo_genai_client()
+        except ConfigError as e:
+            print(f"[ERROR] {e}")
+            sys.exit(1)
+        success = generate_loop_video(
+            client,
+            image_path,
+            output_path,
+            model,
+            prompt,
+            aspect_ratio=SHORT_ASPECT_RATIO,
+        )
     elapsed = time.monotonic() - start_time
 
     print()
@@ -138,6 +175,9 @@ def main() -> None:
     if success:
         print("  Shorts ループ動画生成: 完了")
         print(f"  ファイル: {output_path}")
+        video = probe_video(output_path)
+        if video is not None:
+            print(f"  出力実寸: {video.width}x{video.height}")
         print(f"  時間:     {elapsed:.1f}秒")
     else:
         print("  Shorts ループ動画生成: 失敗")

--- a/src/youtube_automation/commands/media/generate_short_loop.py
+++ b/src/youtube_automation/commands/media/generate_short_loop.py
@@ -82,11 +82,11 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main() -> None:
-    parser = _build_parser()
-    args = parser.parse_args()
-
-    # short skill-config から選択 engine のセクションを読み込む。
+def _resolve_generation_settings(
+    args: argparse.Namespace,
+    parser: argparse.ArgumentParser,
+) -> tuple[str, dict, str, str]:
+    """CLI 引数と short 設定から生成パラメータを解決する."""
     skill_cfg = load_skill_config(SHORT_SKILL_NAME)
     engine = args.engine or skill_cfg.get("engine", "veo")
     if engine not in {"veo", "fal"}:
@@ -95,19 +95,72 @@ def main() -> None:
     default_model = DEFAULT_FAL_MODEL if engine == "fal" else DEFAULT_MODEL
     model = args.model or engine_cfg.get("model", default_model)
     prompt = args.prompt or engine_cfg.get("default_prompt", DEFAULT_PROMPT)
+    return engine, engine_cfg, model, prompt
 
-    # コレクションパス解決
+
+def _resolve_collection_path(args: argparse.Namespace, parser: argparse.ArgumentParser) -> Path:
+    """CLI 引数または現在位置からコレクションパスを解決する."""
     if args.collection:
         collection_path = Path(args.collection)
         if not collection_path.is_absolute():
-            collection_path = Path.cwd() / collection_path
-    else:
-        cwd = Path.cwd()
-        if CollectionPaths(cwd).assets_dir.exists():
-            collection_path = cwd
-        else:
-            parser.error("コレクションパスを指定するか、コレクションディレクトリ内で実行してください")
-            return
+            return Path.cwd() / collection_path
+        return collection_path
+
+    cwd = Path.cwd()
+    if CollectionPaths(cwd).assets_dir.exists():
+        return cwd
+    parser.error("コレクションパスを指定するか、コレクションディレクトリ内で実行してください")
+
+
+def _generate(
+    engine: str,
+    engine_cfg: dict,
+    image_path: Path,
+    output_path: Path,
+    model: str,
+    prompt: str,
+) -> bool:
+    """選択されたエンジンで Shorts ループを生成する."""
+    if engine != "fal":
+        try:
+            client = create_veo_genai_client()
+        except ConfigError as e:
+            print(f"[ERROR] {e}")
+            return False
+        return generate_loop_video(
+            client,
+            image_path,
+            output_path,
+            model,
+            prompt,
+            aspect_ratio=SHORT_ASPECT_RATIO,
+        )
+
+    raw_canvas = engine_cfg.get("canvas", {})
+    canvas = {str(key): tuple(value) for key, value in raw_canvas.items()}
+    upscale = engine_cfg.get("upscale_to", [1080, 1920])
+    return generate_fal_loop_video(
+        image_path,
+        output_path,
+        model,
+        prompt,
+        duration_seconds=int(engine_cfg.get("duration_seconds", 8)),
+        aspect_ratio=SHORT_ASPECT_RATIO,
+        resolution=str(engine_cfg.get("resolution", "768P")),
+        prompt_expansion_mode=str(engine_cfg.get("prompt_expansion_mode", "balanced")),
+        timeout_sec=float(engine_cfg.get("timeout_seconds", 600)),
+        poll_interval_sec=float(engine_cfg.get("poll_interval_seconds", 2)),
+        allowed_models=frozenset(engine_cfg.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
+        canvas=canvas or {SHORT_ASPECT_RATIO: (768, 1344)},
+        upscale_to=tuple(upscale) if upscale is not None else None,
+    )
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+    engine, engine_cfg, model, prompt = _resolve_generation_settings(args, parser)
+    collection_path = _resolve_collection_path(args, parser)
 
     try:
         image_path, output_path = resolve_paths(collection_path)
@@ -135,39 +188,7 @@ def main() -> None:
 
     # 生成実行
     start_time = time.monotonic()
-    if engine == "fal":
-        raw_canvas = engine_cfg.get("canvas", {})
-        canvas = {str(key): tuple(value) for key, value in raw_canvas.items()}
-        upscale = engine_cfg.get("upscale_to", [1080, 1920])
-        success = generate_fal_loop_video(
-            image_path,
-            output_path,
-            model,
-            prompt,
-            duration_seconds=int(engine_cfg.get("duration_seconds", 8)),
-            aspect_ratio=SHORT_ASPECT_RATIO,
-            resolution=str(engine_cfg.get("resolution", "768P")),
-            prompt_expansion_mode=str(engine_cfg.get("prompt_expansion_mode", "balanced")),
-            timeout_sec=float(engine_cfg.get("timeout_seconds", 600)),
-            poll_interval_sec=float(engine_cfg.get("poll_interval_seconds", 2)),
-            allowed_models=frozenset(engine_cfg.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
-            canvas=canvas or {SHORT_ASPECT_RATIO: (768, 1344)},
-            upscale_to=tuple(upscale) if upscale is not None else None,
-        )
-    else:
-        try:
-            client = create_veo_genai_client()
-        except ConfigError as e:
-            print(f"[ERROR] {e}")
-            sys.exit(1)
-        success = generate_loop_video(
-            client,
-            image_path,
-            output_path,
-            model,
-            prompt,
-            aspect_ratio=SHORT_ASPECT_RATIO,
-        )
+    success = _generate(engine, engine_cfg, image_path, output_path, model, prompt)
     elapsed = time.monotonic() - start_time
 
     print()

--- a/src/youtube_automation/commands/media/generate_short_loop.py
+++ b/src/youtube_automation/commands/media/generate_short_loop.py
@@ -153,6 +153,7 @@ def _generate(
         prompt_expansion_mode=str(engine_cfg.get("prompt_expansion_mode", "balanced")),
         timeout_sec=float(engine_cfg.get("timeout_seconds", 600)),
         poll_interval_sec=float(engine_cfg.get("poll_interval_seconds", 2)),
+        max_poll_retries=engine_cfg.get("max_poll_retries", 3),
         allowed_models=frozenset(engine_cfg.get("allowed_models", DEFAULT_FAL_ALLOWED_MODELS)),
         canvas=canvas or {SHORT_ASPECT_RATIO: (768, 1344)},
         upscale_to=tuple(upscale) if upscale is not None else None,
@@ -201,7 +202,7 @@ def main() -> None:
         print(f"  ファイル: {output_path}")
         video = probe_video(output_path)
         if video is not None:
-            print(f"  出力実寸: {video.width}x{video.height}")
+            print(f"  最終出力実寸: {video.width}x{video.height}")
         print(f"  時間:     {elapsed:.1f}秒")
     else:
         print("  Shorts ループ動画生成: 失敗")

--- a/src/youtube_automation/commands/media/generate_short_loop.py
+++ b/src/youtube_automation/commands/media/generate_short_loop.py
@@ -7,6 +7,7 @@
 Usage:
     yt-generate-shorts-loop <collection-path>
     yt-generate-shorts-loop <collection-path> --model veo-3.1-lite-generate-preview
+    yt-generate-shorts-loop <collection-path> --engine fal
     yt-generate-shorts-loop <collection-path> -y    # 確認スキップ
 """
 
@@ -37,6 +38,7 @@ from youtube_automation.infrastructure.media.veo_generator import (
 
 SHORT_ASPECT_RATIO = "9:16"
 SHORT_SKILL_NAME = "short"
+ENGINES = ("veo", "fal")
 
 
 def resolve_paths(collection_path: Path) -> tuple[Path, Path]:
@@ -60,13 +62,13 @@ def _build_parser() -> argparse.ArgumentParser:
     # `generate_loop_video.py` と同じく `--model` は preview/GA 切替を許容するため
     # choices で縛らず任意文字列を受ける（未知モデルは Vertex AI 側でエラー）.
     parser = argparse.ArgumentParser(
-        description="Veo 3.1 Shorts (9:16) ループ動画生成",
+        description="Shorts (9:16) ループ動画生成 (Veo / fal)",
         formatter_class=argparse.RawTextHelpFormatter,
     )
     parser.add_argument("collection", nargs="?", help="コレクションパス (collections/live/<name>/)")
     parser.add_argument(
         "--engine",
-        choices=("veo", "fal"),
+        choices=ENGINES,
         default=None,
         help="動画生成エンジン (default: skill-config の engine、未設定時 veo)",
     )
@@ -74,8 +76,9 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--model",
         help=(
-            "Veo モデル名 (default: skill-config の veo.model, fallback: veo-3.1-fast-generate-001)。"
-            " 例: veo-3.1-fast-generate-001 / veo-3.1-generate-001 / veo-3.1-lite-generate-preview"
+            "モデル名 (default: skill-config の <engine>.model,"
+            f" fallback: veo={DEFAULT_MODEL} / fal={DEFAULT_FAL_MODEL})。"
+            " 例: veo-3.1-generate-001 / veo-3.1-lite-generate-preview / minimax/h3-max/image-to-video"
         ),
     )
     parser.add_argument("-y", "--yes", action="store_true", help="確認をスキップ")
@@ -89,8 +92,8 @@ def _resolve_generation_settings(
     """CLI 引数と short 設定から生成パラメータを解決する."""
     skill_cfg = load_skill_config(SHORT_SKILL_NAME)
     engine = args.engine or skill_cfg.get("engine", "veo")
-    if engine not in {"veo", "fal"}:
-        parser.error("skill-config の engine は veo または fal を指定してください")
+    if engine not in ENGINES:
+        parser.error(f"skill-config の engine は {' または '.join(ENGINES)} を指定してください")
     engine_cfg = skill_cfg.get(engine, {})
     default_model = DEFAULT_FAL_MODEL if engine == "fal" else DEFAULT_MODEL
     model = args.model or engine_cfg.get("model", default_model)

--- a/src/youtube_automation/infrastructure/media/fal_video_generator.py
+++ b/src/youtube_automation/infrastructure/media/fal_video_generator.py
@@ -15,7 +15,7 @@ from PIL import Image, ImageOps, UnidentifiedImageError
 
 from youtube_automation.core.errors import ConfigError, GenerationFailedError, GeneratorError, ValidationError
 from youtube_automation.infrastructure import cost_tracker
-from youtube_automation.infrastructure.media import fal_client
+from youtube_automation.infrastructure.media import fal_client, probe
 from youtube_automation.infrastructure.media import fal_video_task_store as task_store
 from youtube_automation.infrastructure.media.veo_generator import resolve_smooth_codec, smooth_loop
 
@@ -212,6 +212,12 @@ def _persist(video: bytes, output_path: Path) -> None:
         raise GeneratorError("fal video を保存できません") from error
 
 
+def _report_raw_dimensions(raw_video: Path, canvas: tuple[int, int]) -> None:
+    video = probe.probe_video(raw_video)
+    if video is not None:
+        print(f"  fal 生出力: {video.width}x{video.height}（canvas 想定: {canvas[0]}x{canvas[1]}）")
+
+
 def _finalize_video(
     raw_video: Path,
     output_path: Path,
@@ -332,6 +338,7 @@ def generate_loop_video(
         if not cached:
             _persist(fal_client.download(_video_url(result), timeout=timeout_sec), raw_video)
             task_store.save_result(output_path, result, channel_root=channel_root)
+        _report_raw_dimensions(raw_video, size)
         _finalize_video(raw_video, output_path, result, upscale_to=upscale_to, compression=compression)
     except GenerationFailedError as error:
         task_store.clear(output_path, channel_root=channel_root)

--- a/tests/commands/media/test_generate_short_loop.py
+++ b/tests/commands/media/test_generate_short_loop.py
@@ -65,6 +65,13 @@ class TestBuildParser:
         # Then
         assert args.model == "veo-3.1-lite-generate-preview"
 
+    def test_parser_accepts_fal_engine(self):
+        from youtube_automation.commands.media.generate_short_loop import _build_parser
+
+        args = _build_parser().parse_args(["--engine", "fal"])
+
+        assert args.engine == "fal"
+
 
 # ---------------------------------------------------------------------------
 # 2. パス解決
@@ -189,6 +196,99 @@ class TestMain:
             call = mocks["generate_loop_video"].call_args
             kwargs = call.kwargs
             assert kwargs.get("aspect_ratio") == "9:16"
+
+    @pytest.mark.parametrize(
+        ("cli", "configured_engine", "expected_engine"),
+        [([], None, "veo"), ([], "fal", "fal"), (["--engine", "fal"], "veo", "fal")],
+    )
+    def test_main_selects_engine(self, tmp_path, monkeypatch, cli, configured_engine, expected_engine):
+        from youtube_automation.commands.media import generate_short_loop as mod
+
+        col = tmp_path / "collection"
+        assets = col / "10-assets"
+        assets.mkdir(parents=True)
+        (assets / "short.png").write_bytes(b"image")
+        monkeypatch.setattr(sys, "argv", ["yt-generate-shorts-loop", str(col), *cli, "-y"])
+        config = {"veo": {}, "fal": {}}
+        if configured_engine is not None:
+            config["engine"] = configured_engine
+
+        with patch.multiple(
+            mod,
+            load_skill_config=DEFAULT,
+            create_veo_genai_client=DEFAULT,
+            generate_loop_video=DEFAULT,
+            generate_fal_loop_video=DEFAULT,
+            probe_video=DEFAULT,
+        ) as mocks:
+            mocks["load_skill_config"].return_value = config
+            mocks["generate_loop_video"].return_value = True
+            mocks["generate_fal_loop_video"].return_value = True
+            with pytest.raises(SystemExit) as excinfo:
+                mod.main()
+
+        assert excinfo.value.code == 0
+        if expected_engine == "fal":
+            mocks["generate_fal_loop_video"].assert_called_once()
+            mocks["generate_loop_video"].assert_not_called()
+        else:
+            mocks["generate_loop_video"].assert_called_once()
+            mocks["generate_fal_loop_video"].assert_not_called()
+
+    def test_fal_uses_vertical_canvas_and_upscale(self, tmp_path, monkeypatch):
+        from youtube_automation.commands.media import generate_short_loop as mod
+
+        col = tmp_path / "collection"
+        assets = col / "10-assets"
+        assets.mkdir(parents=True)
+        (assets / "short.png").write_bytes(b"image")
+        monkeypatch.setattr(sys, "argv", ["yt-generate-shorts-loop", str(col), "--engine", "fal", "-y"])
+
+        with patch.multiple(
+            mod,
+            load_skill_config=DEFAULT,
+            generate_fal_loop_video=DEFAULT,
+            probe_video=DEFAULT,
+        ) as mocks:
+            mocks["load_skill_config"].return_value = {
+                "fal": {
+                    "canvas": {"9:16": [768, 1344]},
+                    "upscale_to": [1080, 1920],
+                }
+            }
+            mocks["generate_fal_loop_video"].return_value = True
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        kwargs = mocks["generate_fal_loop_video"].call_args.kwargs
+        assert kwargs["aspect_ratio"] == "9:16"
+        assert kwargs["canvas"] == {"9:16": (768, 1344)}
+        assert kwargs["upscale_to"] == (1080, 1920)
+
+    def test_success_prints_actual_output_dimensions(self, tmp_path, monkeypatch, capsys):
+        from youtube_automation.commands.media import generate_short_loop as mod
+        from youtube_automation.infrastructure.media.probe import VideoProbe
+
+        col = tmp_path / "collection"
+        assets = col / "10-assets"
+        assets.mkdir(parents=True)
+        (assets / "short.png").write_bytes(b"image")
+        monkeypatch.setattr(sys, "argv", ["yt-generate-shorts-loop", str(col), "-y"])
+
+        with patch.multiple(
+            mod,
+            load_skill_config=DEFAULT,
+            create_veo_genai_client=DEFAULT,
+            generate_loop_video=DEFAULT,
+            probe_video=DEFAULT,
+        ) as mocks:
+            mocks["load_skill_config"].return_value = {"veo": {}}
+            mocks["generate_loop_video"].return_value = True
+            mocks["probe_video"].return_value = VideoProbe(7.0, 1080, 1920, "h264")
+            with pytest.raises(SystemExit):
+                mod.main()
+
+        assert "出力実寸: 1080x1920" in capsys.readouterr().out
 
     def test_main_propagates_model_override_via_cli(self, tmp_path, monkeypatch):
         """plan 要件 14-c: `--model` 指定が Veo 呼出に伝搬する."""

--- a/tests/commands/media/test_generate_short_loop.py
+++ b/tests/commands/media/test_generate_short_loop.py
@@ -259,6 +259,7 @@ class TestMain:
                 "fal": {
                     "canvas": {"9:16": [768, 1344]},
                     "upscale_to": [1080, 1920],
+                    "max_poll_retries": 7,
                 }
             }
             mocks["generate_fal_loop_video"].return_value = True
@@ -269,6 +270,7 @@ class TestMain:
         assert kwargs["aspect_ratio"] == "9:16"
         assert kwargs["canvas"] == {"9:16": (768, 1344)}
         assert kwargs["upscale_to"] == (1080, 1920)
+        assert kwargs["max_poll_retries"] == 7
 
     def test_success_prints_actual_output_dimensions(self, tmp_path, monkeypatch, capsys):
         from youtube_automation.commands.media import generate_short_loop as mod

--- a/tests/commands/media/test_generate_short_loop.py
+++ b/tests/commands/media/test_generate_short_loop.py
@@ -199,7 +199,12 @@ class TestMain:
 
     @pytest.mark.parametrize(
         ("cli", "configured_engine", "expected_engine"),
-        [([], None, "veo"), ([], "fal", "fal"), (["--engine", "fal"], "veo", "fal")],
+        [
+            ([], None, "veo"),
+            ([], "fal", "fal"),
+            (["--engine", "fal"], "veo", "fal"),
+            (["--engine", "veo"], "fal", "veo"),
+        ],
     )
     def test_main_selects_engine(self, tmp_path, monkeypatch, cli, configured_engine, expected_engine):
         from youtube_automation.commands.media import generate_short_loop as mod

--- a/tests/infrastructure/media/test_fal_video_generator.py
+++ b/tests/infrastructure/media/test_fal_video_generator.py
@@ -483,3 +483,39 @@ def test_changed_input_canvas_submits_new_job_after_postprocessing_failure(tmp_p
     assert submit.call_count == 2
     assert generator.fal_client.upload_file.call_count == 2
     assert generator.fal_client.download.call_count == 2
+
+
+def test_raw_dimensions_are_reported_before_upscale(tmp_path, monkeypatch, capsys):
+    from youtube_automation.infrastructure.media import probe
+
+    image = _image(tmp_path / "short.png", (800, 1400))
+    _mock_successful_new_job(monkeypatch)
+    monkeypatch.setattr(
+        generator.fal_client,
+        "get_url",
+        Mock(
+            side_effect=[
+                {"status": "COMPLETED"},
+                {"video": {"url": "https://v3.fal.media/out.mp4"}},
+            ]
+        ),
+    )
+
+    def smooth(*args, **kwargs):
+        stdout = capsys.readouterr().out
+        assert "fal 生出力: 720x1280" in stdout
+        assert "canvas 想定: 768x1344" in stdout
+        assert kwargs["scale_to"] == (1080, 1920)
+        return True
+
+    monkeypatch.setattr(generator, "smooth_loop", smooth)
+    monkeypatch.setattr(probe, "probe_video", Mock(return_value=probe.VideoProbe(8.0, 720, 1280, "h264")))
+    assert generator.generate_loop_video(
+        image,
+        tmp_path / "10-assets" / "short-loop.mp4",
+        generator.DEFAULT_MODEL,
+        "motion",
+        aspect_ratio="9:16",
+        upscale_to=(1080, 1920),
+        channel_root=tmp_path,
+    )


### PR DESCRIPTION
yt-generate-shorts-loop に fal を配線し 9:16 の生成・拡大を追加します。

Closes #4951