### PR TITLE
feat: チャンネルの直列追従コマンドを追加 (#4913)

### DIFF
--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -15,7 +15,7 @@
 
 このスキルは **AI 主導の追従 wizard** である。下流チャンネルリポジトリ（bobble / deepfocus365 / rjn 等）で発動し、自リポの `pyproject.toml` を official upstream（`automation_update_refs.UPSTREAM_REPO` が単一ソース。既定: `daiki-beppu/youtube-automation`）の最新 tag まで bump して、`.claude/skills/` の同期、動作確認、コミットまでを 1 コマンドで回す。
 
-複数チャンネルを一度に追従する場合は、channel registry を使う `yt-channels update` を実行する。
+複数チャンネルを一度に追従する場合は、channel registry を使う `yt-channels update` を実行する。 `--tag <tag>` は tag pin のみに適用し、main / sha pin は理由付きで skip する。main pin は `--tag` なしで追従する。
 
 機械的に決まる手順（実行場所判定 / pin 形式判定 / 差分判定 / pin 書き換え / `uv lock` / `yt-skills sync` / smoke check）は upstream 同梱の **`yt-automation-update` CLI** に委譲する。本スキル（AI）は判断が必要なポイント — リリース内容の要約、local fix 上書き判断、同意取得、コミット — に専任する。
 

--- a/.claude/skills/automation/references/update.md
+++ b/.claude/skills/automation/references/update.md
@@ -15,6 +15,8 @@
 
 このスキルは **AI 主導の追従 wizard** である。下流チャンネルリポジトリ（bobble / deepfocus365 / rjn 等）で発動し、自リポの `pyproject.toml` を official upstream（`automation_update_refs.UPSTREAM_REPO` が単一ソース。既定: `daiki-beppu/youtube-automation`）の最新 tag まで bump して、`.claude/skills/` の同期、動作確認、コミットまでを 1 コマンドで回す。
 
+複数チャンネルを一度に追従する場合は、channel registry を使う `yt-channels update` を実行する。
+
 機械的に決まる手順（実行場所判定 / pin 形式判定 / 差分判定 / pin 書き換え / `uv lock` / `yt-skills sync` / smoke check）は upstream 同梱の **`yt-automation-update` CLI** に委譲する。本スキル（AI）は判断が必要なポイント — リリース内容の要約、local fix 上書き判断、同意取得、コミット — に専任する。
 
 利用者は upstream のリリース内容を都度追わなくてよい。AI が各リリースの **GitHub Release 本文** と **`CHANGELOG.md` の該当バージョンセクション** から累積影響を要約してから、破壊的操作の前で `[HUMAN STEP]` として人間判断を求める。

--- a/changelog.d/4913-channels-update.added.md
+++ b/changelog.d/4913-channels-update.added.md
@@ -1,0 +1,1 @@
+- `yt-channels update` を追加し、channel registry 内の適格な tag / main pin チャンネルを安全に直列追従できるようにしました。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -301,6 +301,7 @@ assets/stock/           # ボツ画像ストック (#364)。<theme-slug>/ 配下
 | `application.live_chat.{codex,filters,history,models,runner}` | active broadcast のチャット取得、Codex 構造化判定、入出力フィルタ、PT 日次・時間・連続 user 上限、重複防止履歴、返信投稿 loop |
 | `commands.youtube.live_chat_reply` | `yt-live-chat-reply` 常駐 CLI。`comments.live_chat.enabled` を opt-in とし、VPS では独立した `live-chat-reply.service` から起動 |
 | `commands.system.skills_sync` | `yt-skills` 本体 |
+| `commands.system.channels` | channel registry の一覧表示と、適格な下流チャンネルを宣言順に `yt-automation-update apply` へ委譲する直列 fan-out CLI |
 | `commands.collections.collection_serve_discovery` | 固定 loopback endpoint の稼働 server registry、heartbeat、TTL、owner takeover |
 | `commands.media.audio_studio` | collection 音源の loopback 限定 API、Range 配信、static asset、server lifecycle |
 | `extensions/shared/server-discovery.ts` | registry schema v1 の検証と `/server-info` probe を両 helper 拡張へ提供 |

--- a/src/youtube_automation/commands/system/channels.py
+++ b/src/youtube_automation/commands/system/channels.py
@@ -1,9 +1,10 @@
-"""Channel registry を読み取り専用で一覧表示する CLI。"""
+"""Channel registry の一覧表示と直列更新を行う CLI。"""
 
 from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import tomllib
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -24,6 +25,15 @@ class ChannelListing:
     path: str
     status: str
     pin: str
+
+
+@dataclass(frozen=True)
+class ChannelUpdate:
+    path: str
+    status: str
+    ref: str
+    actions: tuple[str, ...] = ()
+    detail: str = ""
 
 
 def _pin_label(path: Path) -> str | None:
@@ -64,7 +74,7 @@ def _summary(channels: list[ChannelListing]) -> dict[str, int]:
     }
 
 
-def _run(args: argparse.Namespace) -> int:
+def _run_list(args: argparse.Namespace) -> int:
     channels = [_classify(path) for path in load_channel_registry(args.registry)]
     summary = _summary(channels)
     if args.json:
@@ -75,6 +85,119 @@ def _run(args: argparse.Namespace) -> int:
         print(f"{channel.path}\t{channel.status}\t{channel.pin}")
     print(" ".join(f"{key}={value}" for key, value in summary.items()))
     return 0
+
+
+def _same_path(left: Path, right: Path) -> bool:
+    return left.resolve(strict=False) == right.resolve(strict=False)
+
+
+def _selected_channels(channels: list[Path], selected: list[Path] | None) -> list[Path]:
+    if not selected:
+        return channels
+    result: list[Path] = []
+    for requested in selected:
+        match = next((channel for channel in channels if _same_path(channel, requested)), None)
+        if match is None:
+            raise ConfigError(f"--channel は registry 内の path に限定されます: {requested}")
+        if match not in result:
+            result.append(match)
+    return result
+
+
+def _run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def _ineligible_update(listing: ChannelListing, tag: str | None) -> ChannelUpdate | None:
+    if listing.status == "workspace":
+        return ChannelUpdate(listing.path, "skipped", listing.pin, detail="workspace")
+    if listing.status == "missing":
+        return ChannelUpdate(listing.path, "error", listing.pin, detail="path 不在")
+
+    pin_kind = listing.pin.split(maxsplit=1)[0]
+    if tag is None and pin_kind in {"tag", "sha"}:
+        return ChannelUpdate(listing.path, "skipped", listing.pin, detail=f"{pin_kind} pin（--tag 未指定）")
+    if tag is not None and pin_kind != "tag":
+        return ChannelUpdate(listing.path, "skipped", listing.pin, detail=f"{pin_kind} pin（--tag は tag pin 専用）")
+    return None
+
+
+def _update_command(args: argparse.Namespace) -> list[str]:
+    operation = "check" if args.dry_run else "apply"
+    command = ["uv", "run", "yt-automation-update", operation]
+    if not args.dry_run and not args.no_commit:
+        command.append("--commit")
+    if args.tag is not None:
+        command.extend(["--tag", args.tag])
+    if not args.dry_run and args.force_sync:
+        command.append("--force-sync")
+    if not args.dry_run and args.allow_dirty:
+        command.append("--allow-dirty")
+    if not args.dry_run and args.accept_hooks:
+        command.append("--accept-hooks")
+    return command
+
+
+def _followup_actions(path: Path, apply_output: str) -> tuple[str, ...]:
+    actions: list[str] = []
+    if "Claude Code を再起動" in apply_output:
+        actions.append("Claude Code 再起動")
+    try:
+        migrate = _run_command(
+            ["uv", "run", "yt-skills", "migrate-config", "--channel-dir", str(path), "--dry-run"], path
+        )
+        if "dry-run 完了:" in migrate.stdout:
+            actions.append("要 migrate")
+    except OSError:
+        actions.append("migrate 確認失敗")
+    try:
+        render = _run_command(["uv", "run", "yt-document-render", "--check", "--all"], path)
+        if render.returncode != 0:
+            actions.append("要 render")
+    except OSError:
+        actions.append("render 確認失敗")
+    return tuple(actions)
+
+
+def _update_one(path: Path, args: argparse.Namespace) -> ChannelUpdate:
+    listing = _classify(path)
+    ineligible = _ineligible_update(listing, args.tag)
+    if ineligible is not None:
+        return ineligible
+
+    try:
+        completed = _run_command(_update_command(args), path)
+    except OSError as exc:
+        return ChannelUpdate(str(path), "failed", args.tag or listing.pin, detail=str(exc))
+    output = "\n".join(part for part in (completed.stdout.strip(), completed.stderr.strip()) if part)
+    if completed.returncode != 0:
+        detail = output.splitlines()[-1] if output else f"exit {completed.returncode}"
+        return ChannelUpdate(str(path), "failed", args.tag or listing.pin, detail=detail)
+    if args.dry_run:
+        return ChannelUpdate(str(path), "success", args.tag or listing.pin)
+    return ChannelUpdate(str(path), "success", args.tag or listing.pin, _followup_actions(path, output))
+
+
+def _run_update(args: argparse.Namespace) -> int:
+    channels = _selected_channels(load_channel_registry(args.registry), args.channel)
+    cwd = Path.cwd()
+    channels.sort(key=lambda channel: _same_path(channel, cwd))
+    results = [_update_one(channel, args) for channel in channels]
+    summary = {
+        "total": len(results),
+        "success": sum(result.status == "success" for result in results),
+        "skipped": sum(result.status == "skipped" for result in results),
+        "failed": sum(result.status in {"failed", "error"} for result in results),
+    }
+    if args.json:
+        print(json.dumps({"channels": [asdict(result) for result in results], "summary": summary}, ensure_ascii=False))
+    else:
+        for result in results:
+            actions = ", ".join(result.actions) or "なし"
+            detail = f"\t{result.detail}" if result.detail else ""
+            print(f"{result.path}\t{result.status}\t{result.ref}\t要対応: {actions}{detail}")
+        print(" ".join(f"{key}={value}" for key, value in summary.items()))
+    return 1 if summary["failed"] else 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -88,13 +211,29 @@ def build_parser() -> argparse.ArgumentParser:
         help=f"読み込む channel registry の JSON path（既定: {DEFAULT_CHANNEL_REGISTRY}）",
     )
     list_parser.add_argument("--json", action="store_true", help="各 entry と件数 summary を JSON で出力する")
+    list_parser.set_defaults(func=_run_list)
+    update_parser = subcommands.add_parser("update", help="registry の適格チャンネルを宣言順に直列更新する")
+    update_parser.add_argument(
+        "--registry", type=Path, default=DEFAULT_CHANNEL_REGISTRY, help="channel registry の JSON path"
+    )
+    update_parser.add_argument("--channel", type=Path, action="append", help="registry 内の更新対象 path（複数指定可）")
+    update_parser.add_argument("--tag", help="tag pin チャンネルの追従先 vX.Y.Z")
+    update_parser.add_argument("--force-sync", action="store_true", help="apply の local fix guard を bypass する")
+    update_parser.add_argument("--allow-dirty", action="store_true", help="apply に dirty 作業ツリーの続行を許可する")
+    update_parser.add_argument("--dry-run", action="store_true", help="apply せず各チャンネルで check のみ実行する")
+    update_parser.add_argument("--no-commit", action="store_true", help="apply に --commit を渡さない")
+    update_parser.add_argument(
+        "--no-accept-hooks", dest="accept_hooks", action="store_false", help="hook 追加への同意を渡さない"
+    )
+    update_parser.add_argument("--json", action="store_true", help="チャンネル別結果と summary を JSON で出力する")
+    update_parser.set_defaults(func=_run_update, accept_hooks=True)
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     return run_cli(
         build_parser,
-        _run,
+        lambda args: args.func(args),
         argv,
         failure_message="channel registry を読み込めません",
         failure_exit_code=EXIT_REGISTRY_ERROR,

--- a/src/youtube_automation/commands/system/channels.py
+++ b/src/youtube_automation/commands/system/channels.py
@@ -170,11 +170,12 @@ def _update_one(path: Path, args: argparse.Namespace) -> ChannelUpdate:
     except OSError as exc:
         return ChannelUpdate(str(path), "failed", args.tag or listing.pin, detail=str(exc))
     output = "\n".join(part for part in (completed.stdout.strip(), completed.stderr.strip()) if part)
+    if args.dry_run and completed.returncode in {0, 1}:
+        detail = "更新差分あり" if completed.returncode == 1 else "最新です"
+        return ChannelUpdate(str(path), "success", args.tag or listing.pin, detail=detail)
     if completed.returncode != 0:
-        detail = output.splitlines()[-1] if output else f"exit {completed.returncode}"
+        detail = completed.stderr.strip() or completed.stdout.strip() or f"exit {completed.returncode}"
         return ChannelUpdate(str(path), "failed", args.tag or listing.pin, detail=detail)
-    if args.dry_run:
-        return ChannelUpdate(str(path), "success", args.tag or listing.pin)
     return ChannelUpdate(str(path), "success", args.tag or listing.pin, _followup_actions(path, output))
 
 

--- a/src/youtube_automation/commands/system/channels.py
+++ b/src/youtube_automation/commands/system/channels.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import subprocess
+import sys
 import tomllib
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -101,7 +102,7 @@ def _selected_channels(channels: list[Path], selected: list[Path] | None) -> lis
             raise ConfigError(f"--channel は registry 内の path に限定されます: {requested}")
         if match not in result:
             result.append(match)
-    return result
+    return [channel for channel in channels if channel in result]
 
 
 def _run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
@@ -180,7 +181,12 @@ def _update_one(path: Path, args: argparse.Namespace) -> ChannelUpdate:
 
 
 def _run_update(args: argparse.Namespace) -> int:
-    channels = _selected_channels(load_channel_registry(args.registry), args.channel)
+    registered = load_channel_registry(args.registry)
+    try:
+        channels = _selected_channels(registered, args.channel)
+    except ConfigError as error:
+        print(f"[error] 更新対象の指定が不正です: {error}", file=sys.stderr)
+        return 1
     cwd = Path.cwd()
     channels.sort(key=lambda channel: _same_path(channel, cwd))
     results = [_update_one(channel, args) for channel in channels]

--- a/tests/commands/system/test_channels.py
+++ b/tests/commands/system/test_channels.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -93,3 +94,145 @@ def test_list_does_not_depend_on_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
     assert main(["list", "--registry", str(registry), "--json"]) == 0
     assert json.loads(capsys.readouterr().out)["summary"]["missing"] == 1
+
+
+def _tag_channel(path: Path) -> None:
+    _write_channel(
+        path,
+        '[project]\nname="channel"\ndependencies=["youtube-channels-automation"]\n'
+        '[tool.uv.sources]\nyoutube-channels-automation={git="https://github.com/daiki-beppu/youtube-automation", '
+        'tag="v5.6.0"}\n',
+    )
+
+
+def test_update_is_serial_self_last_and_isolates_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    first, failed, current = (tmp_path / name for name in ("first", "failed", "current"))
+    for channel in (first, failed, current):
+        _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [current, first, failed])
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run(command, *, cwd, **kwargs):
+        calls.append((cwd, command))
+        code = 1 if cwd == failed and "yt-automation-update" in command else 0
+        stdout = "error detail" if code else "移行対象はありません"
+        return subprocess.CompletedProcess(command, code, stdout, "")
+
+    monkeypatch.chdir(current)
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+
+    assert main(["update", "--registry", str(registry), "--tag", "v5.7.0"]) == 1
+    apply_calls = [(cwd, command) for cwd, command in calls if "yt-automation-update" in command]
+    assert [cwd for cwd, _ in apply_calls] == [first, failed, current]
+    assert all(command[-3:] == ["--tag", "v5.7.0", "--accept-hooks"] for _, command in apply_calls)
+    assert "failed=1" in capsys.readouterr().out
+
+
+def test_update_respects_pin_kind_and_reports_followups(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    tag = tmp_path / "tag"
+    main_pin = tmp_path / "main"
+    sha_pin = tmp_path / "sha"
+    _tag_channel(tag)
+    _write_channel(
+        main_pin,
+        '[project]\nname="channel"\ndependencies=["youtube-channels-automation"]\n'
+        "[tool.uv.sources]\nyoutube-channels-automation="
+        '{git="https://github.com/daiki-beppu/youtube-automation", branch="main"}\n',
+    )
+    _write_channel(
+        sha_pin,
+        '[project]\nname="channel"\ndependencies=["youtube-channels-automation"]\n'
+        '[tool.uv.sources]\nyoutube-channels-automation={git="https://github.com/daiki-beppu/youtube-automation", rev="'
+        + "a" * 40
+        + '"}\n',
+    )
+    registry = _registry(tmp_path / "channels.json", [main_pin, sha_pin, tag])
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, cwd, **kwargs):
+        commands.append(command)
+        if "yt-automation-update" in command:
+            return subprocess.CompletedProcess(command, 0, "Claude Code を再起動", "")
+        if "migrate-config" in command:
+            return subprocess.CompletedProcess(command, 0, "dry-run 完了: 1 ファイル（変更なし）", "")
+        return subprocess.CompletedProcess(command, 1, "stale 1 document pair(s)", "")
+
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+    assert main(["update", "--registry", str(registry), "--tag", "v5.7.0"]) == 0
+    output = capsys.readouterr().out
+    assert "main pin（--tag は tag pin 専用）" in output
+    assert "sha pin（--tag は tag pin 専用）" in output
+    assert "要 migrate, 要 render, Claude Code 再起動" not in output
+    assert "Claude Code 再起動, 要 migrate, 要 render" in output
+    assert sum("yt-automation-update" in command for command in commands) == 1
+
+
+def test_update_dry_run_and_passthrough_flags(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    channel = tmp_path / "tag"
+    _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [channel])
+    commands: list[list[str]] = []
+
+    def fake_run(command, *, cwd, **kwargs):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+    assert main(["update", "--registry", str(registry), "--tag", "v5.7.0", "--dry-run"]) == 0
+    assert commands == [["uv", "run", "yt-automation-update", "check", "--tag", "v5.7.0"]]
+
+    commands.clear()
+    assert (
+        main(
+            [
+                "update",
+                "--registry",
+                str(registry),
+                "--tag",
+                "v5.7.0",
+                "--no-commit",
+                "--force-sync",
+                "--allow-dirty",
+                "--no-accept-hooks",
+            ]
+        )
+        == 0
+    )
+    assert commands[0] == [
+        "uv",
+        "run",
+        "yt-automation-update",
+        "apply",
+        "--tag",
+        "v5.7.0",
+        "--force-sync",
+        "--allow-dirty",
+    ]
+    assert not any("push" in command or "pull" in command for command in commands)
+
+
+def test_update_without_tag_only_updates_main_pin(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    main_pin = tmp_path / "main"
+    tag_pin = tmp_path / "tag"
+    _write_channel(
+        main_pin,
+        '[project]\nname="channel"\ndependencies=["youtube-channels-automation"]\n'
+        "[tool.uv.sources]\nyoutube-channels-automation="
+        '{git="https://github.com/daiki-beppu/youtube-automation", branch="main"}\n',
+    )
+    _tag_channel(tag_pin)
+    registry = _registry(tmp_path / "channels.json", [tag_pin, main_pin])
+    calls: list[tuple[Path, list[str]]] = []
+
+    def fake_run(command, *, cwd, **kwargs):
+        calls.append((cwd, command))
+        return subprocess.CompletedProcess(command, 0, "移行対象はありません", "")
+
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+    assert main(["update", "--registry", str(registry)]) == 0
+    apply_calls = [(cwd, command) for cwd, command in calls if "yt-automation-update" in command]
+    assert apply_calls == [(main_pin, ["uv", "run", "yt-automation-update", "apply", "--commit", "--accept-hooks"])]

--- a/tests/commands/system/test_channels.py
+++ b/tests/commands/system/test_channels.py
@@ -236,3 +236,40 @@ def test_update_without_tag_only_updates_main_pin(tmp_path: Path, monkeypatch: p
     assert main(["update", "--registry", str(registry)]) == 0
     apply_calls = [(cwd, command) for cwd, command in calls if "yt-automation-update" in command]
     assert apply_calls == [(main_pin, ["uv", "run", "yt-automation-update", "apply", "--commit", "--accept-hooks"])]
+
+
+@pytest.mark.parametrize("check_code", [0, 1, 2])
+def test_dry_run_distinguishes_update_available_from_error(
+    tmp_path: Path, monkeypatch, capsys, check_code: int
+) -> None:
+    channel = tmp_path / "tag"
+    _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [channel])
+    calls = []
+
+    def fake_run(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, check_code, "", "check error" if check_code == 2 else "")
+
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+    result = main(["update", "--registry", str(registry), "--tag", "v5.7.0", "--dry-run", "--json"])
+    output = json.loads(capsys.readouterr().out)
+    assert result == (1 if check_code == 2 else 0)
+    assert output["summary"]["failed"] == (1 if check_code == 2 else 0)
+    assert len(calls) == 1
+    if check_code == 1:
+        assert output["channels"][0]["detail"] == "更新差分あり"
+
+
+def test_failed_update_preserves_cause_before_retry_hint(tmp_path: Path, monkeypatch, capsys) -> None:
+    channel = tmp_path / "tag"
+    _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [channel])
+    cause = "[error] ステップ 1/5 '確認' で失敗しました: local fix あり"
+    retry = "[error] 原因を解消して同じコマンドを再実行してください"
+    monkeypatch.setattr(
+        "youtube_automation.commands.system.channels.subprocess.run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 1, "apply start", cause + "\n" + retry),
+    )
+    assert main(["update", "--registry", str(registry), "--tag", "v5.7.0", "--json"]) == 1
+    assert cause in json.loads(capsys.readouterr().out)["channels"][0]["detail"]

--- a/tests/commands/system/test_channels.py
+++ b/tests/commands/system/test_channels.py
@@ -273,3 +273,51 @@ def test_failed_update_preserves_cause_before_retry_hint(tmp_path: Path, monkeyp
     )
     assert main(["update", "--registry", str(registry), "--tag", "v5.7.0", "--json"]) == 1
     assert cause in json.loads(capsys.readouterr().out)["channels"][0]["detail"]
+
+
+def test_selected_channels_keep_registry_order_and_deduplicate(tmp_path: Path, monkeypatch, capsys) -> None:
+    first, second, third = [tmp_path / name for name in ("first", "second", "third")]
+    for channel in (first, second, third):
+        _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [first, second, third])
+    calls = []
+
+    def fake_run(command, *, cwd, **kwargs):
+        calls.append(cwd)
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    monkeypatch.setattr("youtube_automation.commands.system.channels.subprocess.run", fake_run)
+    assert (
+        main(
+            [
+                "update",
+                "--registry",
+                str(registry),
+                "--tag",
+                "v5.7.0",
+                "--dry-run",
+                "--json",
+                "--channel",
+                str(third),
+                "--channel",
+                str(first),
+                "--channel",
+                str(third),
+            ]
+        )
+        == 0
+    )
+    assert calls == [first, third]
+    assert json.loads(capsys.readouterr().out)["summary"]["total"] == 2
+
+
+def test_unregistered_selection_is_not_reported_as_registry_failure(tmp_path: Path, monkeypatch, capsys) -> None:
+    channel = tmp_path / "tag"
+    _tag_channel(channel)
+    registry = _registry(tmp_path / "channels.json", [channel])
+    monkeypatch.setattr(
+        "youtube_automation.commands.system.channels.subprocess.run",
+        lambda *args, **kwargs: pytest.fail("invalid selection must not start an update"),
+    )
+    assert main(["update", "--registry", str(registry), "--channel", str(tmp_path / "other")]) == 1
+    assert "更新対象の指定が不正" in capsys.readouterr().err


### PR DESCRIPTION
## 変更内容
- `yt-channels update` に registry 順の直列追従と実行元の後回しを実装
- 失敗隔離、pass-through、dry-run、JSON 出力を追加
- `--tag` は tag pin のみに適用し main / sha pin は理由付き skip
- migrate / render / hook 再起動要否を結果へ表示

Closes #4913