### PR TITLE
test: 固有保証を残して同一入力の重複検証を整理する (#4998)

### DIFF
--- a/tests/application/comments/test_comments_replier.py
+++ b/tests/application/comments/test_comments_replier.py
@@ -1436,7 +1436,6 @@ def test_disabled_short_circuits(tmp_path):
     yt = _mock_youtube(video_ids=[], comments_by_video={})
     replier = CommentReplier(yt, config=_make_config(enabled=False), channel_dir=tmp_path, default_language="ja")
     plan = replier.run(dry_run=True)
-    assert plan == plan  # no exception
     assert plan.planned == []
     # API も呼ばれない（disabled なので video 解決にも行かない）
     yt.channels.return_value.list.assert_not_called()

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -1366,23 +1366,6 @@ def test_workflow_wf_next_must_be_object(tmp_path, monkeypatch):
         load_config()
 
 
-@pytest.mark.parametrize("legacy_value", [{}, [], "legacy", False, None])
-def test_comments_rules_are_rejected_by_key_presence(tmp_path, monkeypatch, legacy_value):
-    """廃止された comments.rules は値の形によらず拒否する."""
-    sections = _minimal_sections()
-    sections["comments.json"] = {
-        "comments": {
-            "enabled": True,
-            "rules": legacy_value,
-        }
-    }
-    ch = _setup_channel(tmp_path, sections)
-    monkeypatch.setenv("CHANNEL_DIR", str(ch))
-
-    with pytest.raises(ConfigError, match=r"comments\.rules"):
-        load_config()
-
-
 def test_comments_templates_must_be_object(tmp_path, monkeypatch):
     sections = _minimal_sections()
     sections["comments.json"] = {"comments": {"templates": ["not", "an", "object"]}}
@@ -2098,6 +2081,7 @@ def test_comments_section_non_object_raises(tmp_path, monkeypatch, comments_raw)
 
 @pytest.mark.parametrize("legacy_value", [{}, [], "legacy", False, None, [{"name": "legacy"}]])
 def test_comments_rules_legacy_values_are_rejected(tmp_path, monkeypatch, legacy_value):
+    """廃止された comments.rules は値の形によらずキーの存在で拒否する。"""
     sections = _minimal_sections()
     sections["comments.json"] = {"comments": {"enabled": True, "rules": legacy_value}}
     ch = _setup_channel(tmp_path, sections)

--- a/tests/domains/distrokid/test_distrokid_release_endpoint.py
+++ b/tests/domains/distrokid/test_distrokid_release_endpoint.py
@@ -177,17 +177,6 @@ def test_build_release_payload_main_only_yields_null_cover(tmp_path):
     assert build_release_payload(collection, distrokid)["release"]["cover"] is None
 
 
-def test_build_release_payload_no_workflow_state_yields_null_release_date(tmp_path):
-    """Given workflow-state.json 無し
-    When build_release_payload を呼ぶ
-    Then release_date は None（発明せず null）。
-    """
-    collection = _make_collection(tmp_path, publish_target_at=None)
-    distrokid = Distrokid(enabled=True, profile=_profile())
-
-    assert build_release_payload(collection, distrokid)["release"]["release_date"] is None
-
-
 # ---------------------------------------------------------------------------
 # resolve_asset_path: トラバーサルガード
 # ---------------------------------------------------------------------------

--- a/tests/domains/uploads/test_schedule_cadence.py
+++ b/tests/domains/uploads/test_schedule_cadence.py
@@ -120,7 +120,7 @@ class TestCadenceScheduling:
         assert dt.isoweekday() == 6  # 土曜
 
 
-class TestSchedulingEnabledHeuristic:
+class TestResolvedSchedulingEnabled:
     """解決済み ScheduleConfig から予約公開有効性を判定する観測契約。"""
 
     @staticmethod
@@ -131,29 +131,20 @@ class TestSchedulingEnabledHeuristic:
         scheduler.get_published_dates = MagicMock(return_value=set())
         return scheduler.calculate_publish_at()
 
-    def test_explicit_true_enables(self):
+    def test_enabled_without_cadence_returns_publish_at(self):
         assert self._calculate(enabled=True) is not None
 
-    def test_explicit_false_disables_even_when_cadence_present(self):
-        """auto_schedule_enabled=false が明示されていればスケジュール無効（後方互換）."""
+    def test_disabled_with_cadence_returns_none(self):
         assert self._calculate(enabled=False, cadence=("tue", "thu", "sat")) is None
 
-    def test_cadence_alone_implies_enabled(self):
-        """cadence が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
+    def test_enabled_with_cadence_returns_publish_at(self):
         assert self._calculate(enabled=True, cadence=("tue", "thu", "sat")) is not None
 
-    def test_publish_time_alone_implies_enabled(self):
-        """publish_time が明示されていれば auto_schedule_enabled 未設定でも有効扱い（#647）."""
+    def test_enabled_with_custom_publish_time_returns_publish_at(self):
         assert self._calculate(enabled=True, publish_time="20:00") is not None
 
-    def test_empty_cadence_does_not_imply_enabled(self):
-        """空 cadence はオプトインシグナルにならない."""
+    def test_disabled_without_cadence_returns_none(self):
         assert self._calculate(enabled=False) is None
 
-    def test_day1_time_alone_does_not_imply_enabled(self):
-        """day1_time のみは過去テンプレで既定値が入っていることがあるためシグナルにしない."""
-        # 旧テンプレ互換（auto_schedule_enabled なしで day1_time のみ）はスケジュール無効
+    def test_disabled_with_custom_publish_time_returns_none(self):
         assert self._calculate(enabled=False, publish_time="20:00") is None
-
-    def test_empty_dict_disables(self):
-        assert self._calculate(enabled=False) is None

--- a/tests/infrastructure/runtime/test_schedule.py
+++ b/tests/infrastructure/runtime/test_schedule.py
@@ -59,13 +59,6 @@ def test_ensure_tz_aware_includes_context_in_message():
 # ─── now_in_schedule_tz（永続化用 timestamp 生成の集約, #533） ───
 
 
-def test_now_in_schedule_tz_returns_tz_aware_datetime():
-    now = now_in_schedule_tz(ScheduleConfig())
-
-    assert now.tzinfo is not None
-    assert now.utcoffset() == timedelta(hours=9)
-
-
 def test_now_in_schedule_tz_defaults_to_tokyo():
     now = now_in_schedule_tz(ScheduleConfig())
 


### PR DESCRIPTION
同一の入力・fixture・assertionを持つ重複4組（8ケース相当）と自己比較1行を整理しました。scheduleテスト名を解決済み設定のconsumer検証へ合わせ、loaderの推論8ケースとdisabled時のAPI非呼出を保持します。

検証: 関連6ファイルのpytest: 463 passed。Ruff check/format、git diff --check成功。

独立レビュー: Standards 0件、Spec ブロッキング0件。

参照: CLAUDE.md、docs/development.md、docs/takt-operations.md。

Closes #4998

親issue: #4997
