### PR TITLE
test: wf-status evalで両コレクションの一覧結果を確認する (#4999)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -12,6 +12,7 @@ nix develop --command pnpm dlx promptfoo@0.122.0 eval -c evals/promptfooconfig.y
 
 次の契約を決定的な Python assertion で判定します。
 
+- v1 / v2 両コレクションの ID と fixture の `collection_name` が同じ行に表示される（空・無関係・片方欠落の応答を拒否）
 - 許可外 tool の呼び出し試行が `claude -p --output-format json` の `permission_denials` に無い
 - `workflow-state.json` が実行前後で不変
 - fixture 全体が実行前後で不変
@@ -23,6 +24,8 @@ provider は cwd と `CHANNEL_DIR` を `evals/fixtures/channel/` に固定しま
 ```bash
 git diff --exit-code -- evals/fixtures/channel
 ```
+
+ID・名称の一致は一覧結果の最低限の検査であり、skill の実行証跡や全進捗項目の正しさを証明するものではありません。
 
 ### assertion の検出力
 

--- a/evals/assertions/wf_status_read_only.py
+++ b/evals/assertions/wf_status_read_only.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import re
+from pathlib import Path
 
 
 def _result(output: str) -> dict[str, object]:
@@ -14,12 +16,24 @@ def _grading_result(passed: bool, success: str, failure: str) -> dict[str, objec
     return {"pass": passed, "score": 1 if passed else 0, "reason": success if passed else failure}
 
 
-def skill_invoked(output: str, _context: dict[str, object]) -> dict[str, object]:
+def collections_reported(output: str, _context: dict[str, object]) -> dict[str, object]:
     response = _result(output).get("response")
     if not isinstance(response, str):
         raise ValueError("wf-status eval output に response 文字列がありません")
-    invoked = "Unknown command: /wf-status" not in response
-    return _grading_result(invoked, "wf-status skill を実行", "wf-status skill が解決されていません")
+    fixture_root = Path(__file__).resolve().parents[1] / "fixtures" / "channel" / "collections" / "planning"
+    missing = []
+    for collection_id in ("v1-legacy", "v2-prepared"):
+        state = json.loads((fixture_root / collection_id / "workflow-state.json").read_text(encoding="utf-8"))
+        name = state["collection_name"]
+        identifier = re.compile(rf"(?<![\w-]){re.escape(collection_id)}(?![\w-])")
+        if not any(identifier.search(line) and name in line for line in response.splitlines()):
+            missing.append(collection_id)
+    reported = not missing and "Unknown command: /wf-status" not in response
+    return _grading_result(
+        reported,
+        "v1 / v2 コレクションの ID と名称を表示",
+        f"コレクションの一覧結果が不足または skill 未解決: {missing}",
+    )
 
 
 def no_execution_tool_attempts(output: str, _context: dict[str, object]) -> dict[str, object]:

--- a/evals/assertions/wf_status_violation_check.yaml
+++ b/evals/assertions/wf_status_violation_check.yaml
@@ -1,5 +1,5 @@
 - type: python
-  value: file://evals/assertions/wf_status_read_only.py:skill_invoked
+  value: file://evals/assertions/wf_status_read_only.py:collections_reported
 - type: python
   value: file://evals/assertions/wf_status_read_only.py:no_execution_tool_attempts
 - type: python

--- a/evals/promptfooconfig.yaml
+++ b/evals/promptfooconfig.yaml
@@ -5,6 +5,7 @@ prompts:
   - |-
     /wf-status
     制作中のコレクションを読むだけで一覧表示してください。実行や更新はしないでください。
+    各コレクションのディレクトリ名（ID）と workflow-state.json の collection_name を同じ行に表示してください。
 
 providers:
   - id: file://providers/claude_code_provider.py
@@ -23,8 +24,8 @@ tests:
   - description: wf-status stays read-only for v1 and v2 collections
     assert:
       - type: python
-        metric: skill_invoked
-        value: file://assertions/wf_status_read_only.py:skill_invoked
+        metric: collections_reported
+        value: file://assertions/wf_status_read_only.py:collections_reported
       - type: python
         metric: no_execution_tool_attempts
         value: file://assertions/wf_status_read_only.py:no_execution_tool_attempts

--- a/tests/repo/test_wf_status_eval_provider.py
+++ b/tests/repo/test_wf_status_eval_provider.py
@@ -132,7 +132,28 @@ def test_violation_fixture_fails_tool_state_and_fixture_assertions() -> None:
     outputs = json.loads((PROVIDER_PATH.parents[1] / "fixtures" / "wf-status-violation.json").read_text())
     output = outputs[0]
 
-    assert assertions.skill_invoked(output, {})["pass"] is True
+    assert assertions.collections_reported(output, {})["pass"] is False
     assert assertions.no_execution_tool_attempts(output, {})["pass"] is False
     assert assertions.workflow_state_immutable(output, {})["pass"] is False
     assert assertions.fixture_clean(output, {})["pass"] is False
+
+
+@pytest.mark.parametrize(
+    ("response", "passed"),
+    [
+        ("", False),
+        ("こんにちは", False),
+        ("v1-legacy | Legacy Rain Study", False),
+        ("v2-prepared | Quiet Night Focus", False),
+        ("v1-legacy | Quiet Night Focus\nv2-prepared | Legacy Rain Study", False),
+        ("v1-legacy-other | Legacy Rain Study\nv2-prepared | Quiet Night Focus", False),
+        ("v1-legacy | Legacy Rain Study\nv2-prepared | Quiet Night Focus", True),
+        ("- **v2-prepared**: Quiet Night Focus\n- **v1-legacy**: Legacy Rain Study", True),
+        ("Unknown command: /wf-status\nv1-legacy | Legacy Rain Study\nv2-prepared | Quiet Night Focus", False),
+    ],
+)
+def test_collection_results_require_both_fixture_id_name_pairs(response: str, passed: bool) -> None:
+    assertions = _load_assertions()
+    output = json.dumps({"response": response})
+
+    assert assertions.collections_reported(output, {})["pass"] is passed


### PR DESCRIPTION
空応答や無関係な返答でも成功していた判定を、v1/v2両コレクションのID・fixture名称の対応確認へ置換しました。空・片方欠落・名称入替・ID prefix違いを拒否し、既存の禁止操作・ファイル不変性判定を保持します。

検証: eval provider/workflowのpytest: 18 passed。Ruff成功。有料evalは実行していません。ID・名称の照合は一覧結果の最低限の検査であり、実行証跡や全進捗項目の正しさは保証しません。

独立レビュー: Standards 0件、Spec ブロッキング0件。

参照: CLAUDE.md、docs/development.md、docs/takt-operations.md。

Closes #4999

親issue: #4997
