### PR TITLE
fix(skills): 既知hookの更新候補と承認付き移行を統一する (#5004)

### DIFF
--- a/changelog.d/5004-hook-upgrade.fixed.md
+++ b/changelog.d/5004-hook-upgrade.fixed.md
@@ -1,0 +1,1 @@
+- settings の diff と sync dry-run で hook の追加・除去候補を一致させ、既知の旧 progress hook と秘密ファイル編集ガードを承認後に移行するよう修正しました。ローカル hook と timeout を保持し、再同期で重複追加しません。

--- a/src/youtube_automation/commands/system/skills_sync/_diff.py
+++ b/src/youtube_automation/commands/system/skills_sync/_diff.py
@@ -80,30 +80,23 @@ def _diff_file_asset(asset: str, spec: dict[str, str], root: Path, target: Path)
 
 def _diff_settings_asset(spec: dict[str, str], root: Path, target: Path) -> int:
     from youtube_automation.commands.system.skills_sync._settings import (
-        merge_unique_strings,
-        missing_hooks,
-        read_json_object,
+        _report_hook_candidates,
+        _settings_changes,
     )
 
     try:
-        template = read_json_object(root / spec["source_filename"])
-        current = read_json_object(target, missing_ok=True)
-        missing_allow = merge_unique_strings(current, template, "allow")
-        missing_deny = merge_unique_strings(current, template, "deny")
-        hook_additions = missing_hooks(current, template)
+        changes = _settings_changes(root / spec["source_filename"], target)
     except (OSError, ValueError) as exc:
         print(f"settings の比較に失敗: {exc}", file=sys.stderr)
         return 1
-    if not (missing_allow or missing_deny or hook_additions):
+    if not (changes.missing_allow or changes.missing_deny or changes.hooks or changes.removals):
         print("差分なし。必要な settings はすべて存在します。")
         return 0
-    for value in missing_allow:
+    for value in changes.missing_allow:
         print(f"  + permissions.allow: {value}")
-    for value in missing_deny:
+    for value in changes.missing_deny:
         print(f"  + permissions.deny: {value}")
-    for event, group in hook_additions:
-        for hook in group["hooks"]:
-            print(f"  + hooks.{event}: {group.get('matcher')} / {hook.get('type')} / {hook.get('command')}")
+    _report_hook_candidates(changes)
     return 0
 
 

--- a/src/youtube_automation/commands/system/skills_sync/_settings.py
+++ b/src/youtube_automation/commands/system/skills_sync/_settings.py
@@ -8,6 +8,10 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+# 旧 hook から引き継ぐフィールド（timeout 等）の照合キーで matcher を無視するための番兵。
+# template 側が matcher を変更しても引き継ぎが黙って外れないよう、matcher 一致を前提にしない。
+_ANY_MATCHER = object()
+
 _KNOWN_REPLACED_HOOK_COMMANDS = {
     "uv run yt-progress-hook": 'uv run --project "$CLAUDE_PROJECT_DIR" yt-progress-hook',
     'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
@@ -62,10 +66,10 @@ def _index_existing_hooks(
     target_hooks: dict[str, object],
 ) -> tuple[
     dict[str, set[tuple[object, object, object]]],
-    dict[tuple[object, object, object], dict[str, object]],
+    dict[tuple[str, object, object], dict[str, object]],
 ]:
     existing_by_event: dict[str, set[tuple[object, object, object]]] = {}
-    replacements: dict[tuple[object, object, object], dict[str, object]] = {}
+    replacements: dict[tuple[str, object, object], dict[str, object]] = {}
     for event, groups in target_hooks.items():
         if not isinstance(groups, list):
             raise ValueError("hooks の event は配列である必要があります")
@@ -78,9 +82,26 @@ def _index_existing_hooks(
                 if not isinstance(hook, dict) or hook.get("type") != "command":
                     continue
                 replacement = _KNOWN_REPLACED_HOOK_COMMANDS.get(hook.get("command"))
-                if replacement is not None:
-                    replacements[(event, group.get("matcher"), replacement)] = {**hook, "command": replacement}
+                if replacement is None:
+                    continue
+                upgraded = {**hook, "command": replacement}
+                replacements[(str(event), group.get("matcher"), replacement)] = upgraded
+                replacements.setdefault((str(event), _ANY_MATCHER, replacement), upgraded)
     return existing_by_event, replacements
+
+
+def _upgraded_hook(
+    replacements: dict[tuple[str, object, object], dict[str, object]],
+    event: str,
+    matcher: object,
+    hook: object,
+) -> object:
+    """旧 hook から引き継いだフィールドを template hook へ重ねる（matcher 変更にも追従する）。"""
+    if not isinstance(hook, dict):
+        return hook
+    command = hook.get("command")
+    preserved = replacements.get((event, matcher, command)) or replacements.get((event, _ANY_MATCHER, command))
+    return {**hook, **preserved} if preserved else hook
 
 
 def missing_hooks(target: dict[str, object], template: dict[str, object]) -> list[tuple[str, dict[str, object]]]:
@@ -99,9 +120,7 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
                 raise ValueError("template hook group の形式が不正です")
             matcher = group.get("matcher")
             hooks = [
-                {**hook, **replacements.get((event, matcher, hook.get("command")), {})}
-                if isinstance(hook, dict)
-                else hook
+                _upgraded_hook(replacements, str(event), matcher, hook)
                 for hook in group["hooks"]
                 if _hook_signature(matcher, hook) not in signatures
             ]

--- a/src/youtube_automation/commands/system/skills_sync/_settings.py
+++ b/src/youtube_automation/commands/system/skills_sync/_settings.py
@@ -8,6 +8,14 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+_KNOWN_REPLACED_HOOK_COMMANDS = {
+    "uv run yt-progress-hook": 'uv run --project "$CLAUDE_PROJECT_DIR" yt-progress-hook',
+    'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
+    "*auth/client_secrets.json|*auth/token.json|*.env) "
+    'echo "BLOCKED: $f は AI から直接編集禁止。専用ツール経由で更新してください" >&2; '
+    "exit 2;; esac; done": 'python3 "$CLAUDE_PROJECT_DIR/.claude/skills/automation/references/guard_secret_edit.py"',
+}
+
 _KNOWN_REMOVED_HOOK_COMMANDS = frozenset(
     {
         'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
@@ -16,6 +24,7 @@ _KNOWN_REMOVED_HOOK_COMMANDS = frozenset(
         "data|data/*|*/data|*/data/*|auth|auth/*|*/auth|*/auth/*) "
         "uv run yt-workspace-guard check $CLAUDE_FILE_PATHS; exit $?;; esac; done; exit 0",
         "uv run yt-workspace-guard context",
+        *_KNOWN_REPLACED_HOOK_COMMANDS,
     }
 )
 
@@ -55,6 +64,7 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
     if not isinstance(target_hooks, dict) or not isinstance(template_hooks, dict):
         raise ValueError("hooks は object である必要があります")
     existing_by_event: dict[str, set[tuple[object, object, object]]] = {}
+    replacements: dict[tuple[object, object, object], dict[str, object]] = {}
     for event, groups in target_hooks.items():
         if not isinstance(groups, list):
             raise ValueError("hooks の event は配列である必要があります")
@@ -63,6 +73,12 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
             if not isinstance(group, dict) or not isinstance(group.get("hooks", []), list):
                 raise ValueError("hook group の形式が不正です")
             signatures.update(_hook_signature(group.get("matcher"), hook) for hook in group.get("hooks", []))
+            for hook in group.get("hooks", []):
+                if not isinstance(hook, dict) or hook.get("type") != "command":
+                    continue
+                replacement = _KNOWN_REPLACED_HOOK_COMMANDS.get(hook.get("command"))
+                if replacement is not None:
+                    replacements[(event, group.get("matcher"), replacement)] = {**hook, "command": replacement}
     missing: list[tuple[str, dict[str, object]]] = []
     for event, groups in template_hooks.items():
         if not isinstance(groups, list):
@@ -72,7 +88,13 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
             if not isinstance(group, dict) or not isinstance(group.get("hooks", []), list):
                 raise ValueError("template hook group の形式が不正です")
             matcher = group.get("matcher")
-            hooks = [hook for hook in group["hooks"] if _hook_signature(matcher, hook) not in signatures]
+            hooks = [
+                {**hook, **replacements.get((event, matcher, hook.get("command")), {})}
+                if isinstance(hook, dict)
+                else hook
+                for hook in group["hooks"]
+                if _hook_signature(matcher, hook) not in signatures
+            ]
             if hooks:
                 missing.append((event, {"matcher": matcher, "hooks": hooks}))
                 signatures.update(_hook_signature(matcher, hook) for hook in hooks)

--- a/src/youtube_automation/commands/system/skills_sync/_settings.py
+++ b/src/youtube_automation/commands/system/skills_sync/_settings.py
@@ -58,11 +58,12 @@ def _hook_signature(matcher: object, hook: object) -> tuple[object, object, obje
     return (matcher, hook.get("type"), hook.get("command")) if isinstance(hook, dict) else (matcher, None, None)
 
 
-def missing_hooks(target: dict[str, object], template: dict[str, object]) -> list[tuple[str, dict[str, object]]]:
-    target_hooks = target.get("hooks", {})
-    template_hooks = template.get("hooks", {})
-    if not isinstance(target_hooks, dict) or not isinstance(template_hooks, dict):
-        raise ValueError("hooks は object である必要があります")
+def _index_existing_hooks(
+    target_hooks: dict[str, object],
+) -> tuple[
+    dict[str, set[tuple[object, object, object]]],
+    dict[tuple[object, object, object], dict[str, object]],
+]:
     existing_by_event: dict[str, set[tuple[object, object, object]]] = {}
     replacements: dict[tuple[object, object, object], dict[str, object]] = {}
     for event, groups in target_hooks.items():
@@ -79,6 +80,15 @@ def missing_hooks(target: dict[str, object], template: dict[str, object]) -> lis
                 replacement = _KNOWN_REPLACED_HOOK_COMMANDS.get(hook.get("command"))
                 if replacement is not None:
                     replacements[(event, group.get("matcher"), replacement)] = {**hook, "command": replacement}
+    return existing_by_event, replacements
+
+
+def missing_hooks(target: dict[str, object], template: dict[str, object]) -> list[tuple[str, dict[str, object]]]:
+    target_hooks = target.get("hooks", {})
+    template_hooks = template.get("hooks", {})
+    if not isinstance(target_hooks, dict) or not isinstance(template_hooks, dict):
+        raise ValueError("hooks は object である必要があります")
+    existing_by_event, replacements = _index_existing_hooks(target_hooks)
     missing: list[tuple[str, dict[str, object]]] = []
     for event, groups in template_hooks.items():
         if not isinstance(groups, list):
@@ -171,9 +181,11 @@ def _report_hook_candidates(changes: _SettingsChanges) -> None:
         assert isinstance(group_hooks, list)
         for hook in group_hooks:
             assert isinstance(hook, dict)
-            print(f"  hook 追加候補: {event} / {group.get('matcher')} / {hook.get('type')} / {hook.get('command')}")
+            print(
+                f"  hook 追加候補: hooks.{event} / {group.get('matcher')} / {hook.get('type')} / {hook.get('command')}"
+            )
     for event, matcher, command in changes.removals:
-        print(f"  hook 除去候補: {event} / {matcher} / command / {command}")
+        print(f"  hook 除去候補: hooks.{event} / {matcher} / command / {command}")
 
 
 def _hooks_accepted(args: argparse.Namespace, *, has_changes: bool) -> bool:

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -415,25 +415,24 @@ def test_settings_diff_and_dry_run_report_same_removed_hooks(tmp_path, monkeypat
     assert target.read_bytes() == before
 
 
-_LEGACY_SECRET_GUARD = (
-    'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
-    "*auth/client_secrets.json|*auth/token.json|*.env) "
-    'echo "BLOCKED: $f は AI から直接編集禁止。専用ツール経由で更新してください" >&2; '
-    "exit 2;; esac; done"
-)
+# 移行前の command は `_settings` の移行表を正本として引く（テスト側に再定義するとソースだけ
+# 変更されたときにドリフトが黙って通る）。移行後の command は配布 template の実文字列と一致するか
+# を検証したいので、上部の `_DISTRIBUTED_PROGRESS_HOOK_COMMAND` などを明示したまま使う。
+_LEGACY_HOOK_COMMANDS = {new: old for old, new in _settings._KNOWN_REPLACED_HOOK_COMMANDS.items()}
 
 
 def test_settings_upgrade_known_hooks_preserves_local_options(tmp_path, monkeypatch, capsys) -> None:
     target = tmp_path / "settings.json"
     current = json.loads((REPO_ROOT / ".claude/settings.template.json").read_text(encoding="utf-8"))
     expected_guard = dict(current["hooks"]["PreToolUse"][0]["hooks"][0])
+    legacy_guard = _LEGACY_HOOK_COMMANDS[expected_guard["command"]]
     for event in ("PreToolUse", "PostToolUse"):
         for group in current["hooks"][event]:
             for hook in group["hooks"]:
                 if "yt-progress-hook" in hook["command"]:
-                    hook["command"] = "uv run yt-progress-hook"
+                    hook["command"] = _LEGACY_HOOK_COMMANDS[_DISTRIBUTED_PROGRESS_HOOK_COMMAND]
                     hook["timeout"] = 37
-    current["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = _LEGACY_SECRET_GUARD
+    current["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = legacy_guard
     local_hook = {"type": "command", "command": "uv run yt-progress-hook --local", "timeout": 71}
     current["hooks"]["PreToolUse"][0]["hooks"].append(local_hook)
     current["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = 83
@@ -466,8 +465,21 @@ def test_settings_upgrade_known_hooks_preserves_local_options(tmp_path, monkeypa
     pre_hooks = [hook for group in merged["hooks"]["PreToolUse"] for hook in group["hooks"]]
     assert local_hook in pre_hooks
     assert expected_guard in pre_hooks
-    assert not any(hook["command"] == _LEGACY_SECRET_GUARD for hook in pre_hooks)
+    assert not any(hook["command"] == legacy_guard for hook in pre_hooks)
     assert merged["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] == 83
     after = target.read_bytes()
     assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
     assert target.read_bytes() == after
+
+
+def test_missing_hooks_preserves_local_options_when_template_matcher_changes() -> None:
+    # template 側が matcher を変更したリリースでも、旧 hook の timeout 等が黙って失われないこと。
+    legacy_command = _LEGACY_HOOK_COMMANDS[_DISTRIBUTED_PROGRESS_HOOK_COMMAND]
+    legacy_hook = {"type": "command", "command": legacy_command, "timeout": 41}
+    new_hook = {"type": "command", "command": _DISTRIBUTED_PROGRESS_HOOK_COMMAND}
+    target = {"hooks": {"PreToolUse": [{"matcher": "Bash|Task", "hooks": [legacy_hook]}]}}
+    template = {"hooks": {"PreToolUse": [{"matcher": "Bash", "hooks": [new_hook]}]}}
+
+    assert _settings.missing_hooks(target, template) == [
+        ("PreToolUse", {"matcher": "Bash", "hooks": [{**new_hook, "timeout": 41}]}),
+    ]

--- a/tests/commands/system/test_skills_sync_settings.py
+++ b/tests/commands/system/test_skills_sync_settings.py
@@ -390,3 +390,84 @@ def test_edit_guard_preserves_repository_only_lock_protection(
     payload = json.dumps({"hook_event_name": "PreToolUse", "tool_name": "Write", "tool_input": {"file_path": name}})
     result = _run_edit_guard(tmp_path, guard_project, settings_file, payload)
     assert result.returncode == expected
+
+
+def test_settings_diff_and_dry_run_report_same_removed_hooks(tmp_path, monkeypatch, capsys) -> None:
+    target = tmp_path / "settings.json"
+    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+    current = json.loads(target.read_text(encoding="utf-8"))
+    current["hooks"]["SessionStart"].append(
+        {"hooks": [{"type": "command", "command": "uv run yt-workspace-guard context"}]}
+    )
+    target.write_text(json.dumps(current), encoding="utf-8")
+    before = target.read_bytes()
+    capsys.readouterr()
+
+    assert skills_sync.main(["diff", "--asset", "settings", "--target", str(target)]) == 0
+    diff_output = capsys.readouterr().out
+    assert "hook 除去候補" in diff_output
+    assert "差分なし" not in diff_output
+    assert _run(REPO_ROOT, target, monkeypatch, "--dry-run", "--accept-hooks") == 0
+    dry_run_output = capsys.readouterr().out
+    assert [line for line in diff_output.splitlines() if "hook " in line] == [
+        line for line in dry_run_output.splitlines() if "hook " in line
+    ]
+    assert target.read_bytes() == before
+
+
+_LEGACY_SECRET_GUARD = (
+    'for f in $CLAUDE_FILE_PATHS; do case "$f" in '
+    "*auth/client_secrets.json|*auth/token.json|*.env) "
+    'echo "BLOCKED: $f は AI から直接編集禁止。専用ツール経由で更新してください" >&2; '
+    "exit 2;; esac; done"
+)
+
+
+def test_settings_upgrade_known_hooks_preserves_local_options(tmp_path, monkeypatch, capsys) -> None:
+    target = tmp_path / "settings.json"
+    current = json.loads((REPO_ROOT / ".claude/settings.template.json").read_text(encoding="utf-8"))
+    expected_guard = dict(current["hooks"]["PreToolUse"][0]["hooks"][0])
+    for event in ("PreToolUse", "PostToolUse"):
+        for group in current["hooks"][event]:
+            for hook in group["hooks"]:
+                if "yt-progress-hook" in hook["command"]:
+                    hook["command"] = "uv run yt-progress-hook"
+                    hook["timeout"] = 37
+    current["hooks"]["PreToolUse"][0]["hooks"][0]["command"] = _LEGACY_SECRET_GUARD
+    local_hook = {"type": "command", "command": "uv run yt-progress-hook --local", "timeout": 71}
+    current["hooks"]["PreToolUse"][0]["hooks"].append(local_hook)
+    current["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] = 83
+    target.write_text(json.dumps(current), encoding="utf-8")
+    before = target.read_bytes()
+
+    assert _run(REPO_ROOT, target, monkeypatch) == 0
+    assert target.read_bytes() == before
+    capsys.readouterr()
+    assert skills_sync.main(["diff", "--asset", "settings", "--target", str(target)]) == 0
+    diff_output = capsys.readouterr().out
+    assert _run(REPO_ROOT, target, monkeypatch, "--dry-run", "--accept-hooks") == 0
+    dry_run_output = capsys.readouterr().out
+    assert [line for line in diff_output.splitlines() if "hook " in line] == [
+        line for line in dry_run_output.splitlines() if "hook " in line
+    ]
+    assert target.read_bytes() == before
+    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+    merged = json.loads(target.read_text(encoding="utf-8"))
+    for event in ("PreToolUse", "PostToolUse"):
+        progress = [
+            hook
+            for group in merged["hooks"][event]
+            for hook in group["hooks"]
+            if "yt-progress-hook" in hook["command"] and hook != local_hook
+        ]
+        assert len(progress) == 1
+        assert progress[0]["command"] == _DISTRIBUTED_PROGRESS_HOOK_COMMAND
+        assert progress[0]["timeout"] == 37
+    pre_hooks = [hook for group in merged["hooks"]["PreToolUse"] for hook in group["hooks"]]
+    assert local_hook in pre_hooks
+    assert expected_guard in pre_hooks
+    assert not any(hook["command"] == _LEGACY_SECRET_GUARD for hook in pre_hooks)
+    assert merged["hooks"]["SessionStart"][0]["hooks"][0]["timeout"] == 83
+    after = target.read_bytes()
+    assert _run(REPO_ROOT, target, monkeypatch, "--accept-hooks") == 0
+    assert target.read_bytes() == after


### PR DESCRIPTION
既存環境で配布済みの旧 progress hook と秘密編集ガードが残る問題を修正します。diff と sync の dry-run は同じ更新候補を表示し、承認後の同期で既知の旧 command を置き換えます。利用者独自の hook と timeout は保持します。

検証: 関連テスト214件、ruff check/format、any gate、changelog検証が成功。再同期の冪等性も確認済みです。

Closes #5004
