### PR TITLE
fix(short): 番号付き生成物の投稿手順と完了判定を整える (#5005)

### DIFF
--- a/.claude/skills/short/SKILL.md
+++ b/.claude/skills/short/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when collection 型（BGM テイスター）または release 
 ## 前後工程
 
 - `前工程`: `/setup`
-- `後工程`: `/publish --upload`
+- `後工程`: collection 型は投稿・state 照合まで本 skill で完結、release 型は投稿対象外
 - `委譲先`: `なし`
 
 ## 成果物
@@ -42,7 +42,7 @@ description: "Use when collection 型（BGM テイスター）または release 
 
 ## 完了条件
 
-- collection 型: 生成物のプレビュー後に `uv run yt-upload-shorts` の実投稿が完了し、`workflow-state.json::post_upload.shorts` に記録されている
+- collection 型: 生成した全番号をプレビューし、番号指定の実投稿結果と `workflow-state.json::post_upload.shorts` の `short_num`・`video_id` が一致する。blocked・失敗を含む場合は未完了として番号別に報告する（[投稿手順](references/collection.md#プレビュー投稿state-を確認する)）
 - release 型: `shorts.release.languages` の対象言語ぶん `video/short-<lang>.mp4` が生成され、プレビュー確認済み。アップロードは現時点ではスコープ外
 - `--thumbnail`: `10-assets/short.png` が生成・承認され、ループ動画化する場合は `short-loop.mp4` も確認済み
 
@@ -88,8 +88,8 @@ generation = load_skill_config("short")[content_type]
 | `bash .claude/skills/short/references/generate-shorts.sh <target-path>` | config の型に従いショートを生成 |
 | `bash .claude/skills/short/references/generate-shorts.sh <release-path> -s 30 -t 40` | release 型でサビ位置・尺を指定 |
 | `bash .claude/skills/short/references/test-crop-positions.sh <master> 30` | collection の loop-mp4 素材でクロップ候補を確認 |
-| `uv run yt-upload-shorts <collection-path> --plan` | collection 型の投稿内容を API なしで確認 |
-| `uv run yt-upload-shorts <collection-path>` | collection 型の全ショートを順次投稿 |
+| `uv run yt-upload-shorts <collection-path> --short-num <short-num> --plan` | 生成物の番号を指定して投稿内容を API なしで確認 |
+| `uv run yt-upload-shorts <collection-path> --short-num <short-num>` | 指定番号のショートを 1 本投稿し、結果の action を確認 |
 | `uv run yt-shorts-bulk-update-loc --dry-run` | 投稿済み collection Shorts の localization 更新を確認 |
 | `uv run yt-generate-image --aspect-ratio "9:16" --prompt "<text>" --output <collection>/10-assets/short.png -y` | `--thumbnail` の 9:16 画像生成 |
 | `uv run yt-generate-shorts-loop <collection-path> -y` | `short.png` の 9:16 ループ動画化 |

--- a/.claude/skills/short/SKILL.md
+++ b/.claude/skills/short/SKILL.md
@@ -7,7 +7,7 @@ description: "Use when collection 型（BGM テイスター）または release 
 ## 前後工程
 
 - `前工程`: `/setup`
-- `後工程`: collection 型は投稿・state 照合まで本 skill で完結、release 型は投稿対象外
+- `後工程`: `なし`
 - `委譲先`: `なし`
 
 ## 成果物

--- a/.claude/skills/short/references/collection.md
+++ b/.claude/skills/short/references/collection.md
@@ -39,13 +39,29 @@ bash .claude/skills/short/references/generate-shorts.sh <collection-path>
 
 ## プレビュー・投稿・state を確認する
 
+生成に成功した `01-master/shorts/short-NN-<label>.mp4` の絶対パスと番号を全件列挙し、各動画をプレビューする。`NN` を整数（`01` → `1`）として以下の `<short-num>` に渡す。同じ番号が複数ある場合や生成予定の番号が欠けた場合は投稿前に解消する。番号なしコマンドは legacy `01-master/short.mp4` の単件用で、番号付き生成物の全件投稿には使わない。
+
+番号ごとに plan の動画対象・公開予定を確認する。
+
 ```bash
-open <collection>/01-master/shorts/short-01-*.mp4
-uv run yt-upload-shorts <collection-path> --plan
-uv run yt-upload-shorts <collection-path>
+uv run yt-upload-shorts <collection-path> --short-num <short-num> --plan
 ```
 
-投稿後、`workflow-state.json::post_upload.shorts` に `short_num`, `video_id`, `publish_at`, `uploaded_at`, `title` が upsert されたことを確認する。同じ `short_num` は置換、別番号は append、番号なし投稿は `short_num: null` とする。
+対象番号・動画・投稿内容を提示し、外部投稿の承認を得る。同じ対象・内容についてセッション内で得た承認は再利用する。承認済みの各番号について次を 1 回ずつ実行し、直後に結果を判定する。
+
+```bash
+uv run yt-upload-shorts <collection-path> --short-num <short-num>
+```
+
+| 結果の `action` | 判定・次の行動 |
+|---|---|
+| `short_uploaded` | 結果の `details.short_num`・`details.video_id` と `workflow-state.json::post_upload.shorts` の同じ番号の記録を照合する。一致し、`publish_at`・`uploaded_at` が記録されていればその番号は成功 |
+| `short_upload_blocked` | 未投稿。`details.reason` と未完了番号を報告し、間隔制約が解消してから同じ番号で再開する。exit 0 でも成功に数えない |
+| `short_upload_failed` または非 0 終了 | 失敗。エラーと対象番号を報告する。再試行前に state と投稿 CLI の結果を確認する。投稿成否を確定できない場合は確認が済むまで止め、既に投稿済みの番号を重複投稿しない |
+
+state と結果が一致しない場合も未完了として止め、state を手書きで成功へ変更しない。同じ `short_num` の記録は CLI が置換し、別番号は追加する。
+
+生成した全番号について成功・blocked・失敗・未実行を報告する。成功済み番号は再実行せず、残る番号の再開コマンドを番号付きで示す。collection 型は投稿と state 照合までがこの skill の責務であり、全番号の照合が済むまでは完了としない。
 
 ## Gotchas
 

--- a/changelog.d/5005-short-upload-number.fixed.md
+++ b/changelog.d/5005-short-upload-number.fixed.md
@@ -1,0 +1,1 @@
+- collection Shorts の投稿手順を生成番号ごとの `--short-num` 指定へ修正し、既存承認の再利用、投稿間隔による blocked、番号別の結果と state の照合・再開条件を明確にしました。


### PR DESCRIPTION
番号付きの生成物を作った後に、番号なしの旧形式ショートを投稿対象にしてしまう手順を修正します。生成番号を一覧にして各番号で plan・投稿し、戻り値の action と投稿stateを番号別に照合します。投稿間隔による blocked・失敗・未実行を成功と区別し、既存の投稿承認を再利用します。

検証: 関連テスト57件、skills lint、ruff check/format、changelog検証が成功。番号付き生成fixture 2本と文書のplan/uploadコマンドの対象一致も確認しました。実API投稿は行っていません。

Closes #5005
