### PR TITLE
fix(streaming): 上流Terraform資産の所在と実行rootを明示する (#5007)

### DIFF
--- a/.claude/skills/reply/references/live.md
+++ b/.claude/skills/reply/references/live.md
@@ -6,10 +6,11 @@
 
 以下を上から確認し、1 件でも FAIL なら示した前工程を案内して停止する。後続 Step へ進まない。
 
-- `config/channel/comments.json` が存在し、`comments.live_chat.enabled` が `true`。無ければ `examples/channel_config.example/comments.json` から作成する
-- `terraform version` が 1.10 以上で、`infra/terraform/streaming/` と `.claude/skills/streaming/references/deploy_live_chat.sh` が存在する。無ければ automation を更新して `/streaming` を実行する
-- `terraform -chdir=infra/terraform/streaming output -raw instance_ip` で配信 VPS を解決し、`ssh root@$INSTANCE_IP 'systemctl is-active youtube-stream'` が `active` を返す。VPS 未構築、接続失敗、service 非 active は前提未達として停止し、`/streaming` の構築・復旧を案内する。active broadcast がまだ無いだけなら daemon の待機契約を維持して続行する
-- `auth/client_secrets.json` と `auth/token.json`、`${CODEX_HOME:-$HOME/.codex}/auth.json` が存在する。認証が必要なら AI が `uv run yt-oauth` / `codex login` を起動して完了まで待ち、人間はブラウザ上のログイン・アカウント選択・同意だけを行う
+- 最初に [Terraform 資産と実行場所の確定](../../streaming/references/upstream-checkout.md) を実行し、上流 `AUTOMATION_ROOT`・対象 `CHANNEL_DIR`・`TF_DIR` を確定する。資産が無ければ取得先を示して停止する
+- `$CHANNEL_DIR/config/channel/comments.json` が存在し、`comments.live_chat.enabled` が `true`。無ければ Step 1 の配布済み設定モデルから生成・確認してから再判定する
+- `terraform version` が上流 README の要件を満たすこと。以降の Terraform / 配備 helper は上流 root、設定・認証の準備はチャンネル root で実行する
+- `terraform -chdir="$TF_DIR" output -raw instance_ip` で配信 VPS を解決し、`ssh root@$INSTANCE_IP 'systemctl is-active youtube-stream'` が `active` を返す。VPS 未構築、接続失敗、service 非 active は前提未達として停止し、`/streaming` の構築・復旧を案内する。active broadcast がまだ無いだけなら daemon の待機契約を維持して続行する
+- `$CHANNEL_DIR/auth/client_secrets.json` と `$CHANNEL_DIR/auth/token.json`、`${CODEX_HOME:-$HOME/.codex}/auth.json` が存在する。認証が必要なら AI が `uv run yt-oauth` / `codex login` を起動して完了まで待ち、人間はブラウザ上のログイン・アカウント選択・同意だけを行う
 - 1Password CLI `op` が利用でき、session が有効。未認証なら AI が `op signin` を起動し、人間が 1Password app 上で承認する。JSON 本文をチャット、argv、tfvars、リポジトリへ出さない
 
 ## 完了条件
@@ -35,7 +36,23 @@
 
 ## Step 1: 設定を確定する
 
-`examples/channel_config.example/comments.json` の `comments.live_chat` を channel へ反映する。初回は次を維持する。
+`$CHANNEL_DIR/config/channel/comments.json` が無い場合は、インストール済みの設定モデルを使いチャンネル root で次を実行する。既存ファイルは上書きせず、その `comments.live_chat` だけを確認する。
+
+```bash
+uv run python - <<'PYCONFIG'
+from dataclasses import asdict
+import json
+from pathlib import Path
+from youtube_automation.configuration.comments import Comments
+
+path = Path("config/channel/comments.json")
+with path.open("x", encoding="utf-8") as output:
+    json.dump({"comments": asdict(Comments())}, output, ensure_ascii=False, indent=2)
+    output.write("\n")
+PYCONFIG
+```
+
+既定は無効。対象チャンネルの live chat 返信を有効にすることを確認して `comments.live_chat.enabled` を `true` にし、以下を維持する。
 
 - `process_initial_messages: false`: 起動時 backlog を履歴へ記録するだけで返信しない
 - `max_replies_per_hour: 12` / `max_consecutive_per_user: 2`: 過剰返信を抑止
@@ -56,7 +73,7 @@ Codex auth が無ければ AI が `codex login` を起動し、表示された�
 AI が次を実行する。`write_op_secret` は JSON template を stdin で `op` へ渡すため、secret は argv に載らない。
 
 ```bash
-CHANNEL_DIR=/absolute/path/to/channel uv run python - <<'PY'
+uv run python - <<'PY'
 import os
 from pathlib import Path
 from youtube_automation.infrastructure.secrets import write_op_secret
@@ -85,7 +102,7 @@ export OP_CODEX_AUTH_REF='op://Personal/YouTube_Live_Chat/codex_auth_json'
 `/streaming` の通常 secret と 3 参照を環境へ設定後、AI が PTY / background session で次を起動する。
 
 ```bash
-"$(git rev-parse --show-toplevel)/.claude/skills/streaming/references/deploy_live_chat.sh" /absolute/path/to/channel
+"$AUTOMATION_ROOT/.claude/skills/streaming/references/deploy_live_chat.sh" --tf-dir "$TF_DIR" "$CHANNEL_DIR"
 ```
 
 Terraform の apply 確認 prompt で外部反映ゲートを実施する。承認後だけ `yes`、キャンセルなら `no` を送る。
@@ -93,7 +110,7 @@ Terraform の apply 確認 prompt で外部反映ゲートを実施する。承�
 ## Step 5: 完了を検証する
 
 ```bash
-INSTANCE_IP=$(terraform -chdir=infra/terraform/streaming output -raw instance_ip)
+INSTANCE_IP=$(terraform -chdir="$TF_DIR" output -raw instance_ip)
 ssh root@$INSTANCE_IP 'systemctl is-active youtube-stream live-chat-reply'
 ssh root@$INSTANCE_IP 'stat -c "%a %U %n" /var/lib/live-chat-reply/channel/auth/{token.json,client_secrets.json} /var/lib/live-chat-reply/codex/auth.json'
 ssh root@$INSTANCE_IP 'journalctl -u live-chat-reply -n 100 --no-pager'

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -23,6 +23,8 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 
 ## 前提
 
+最初に [Terraform 資産と実行場所の確定](references/upstream-checkout.md) を実行し、上流 `AUTOMATION_ROOT`・対象 `CHANNEL_DIR`・`TF_DIR` を確定する。以下の相対パスとコマンドは上流 root 基準。動画など下流の入力は絶対パスで渡す。
+
 以下を確認し、満たさなければ整備手順（各項目に記載、詳細は README §前提）を案内してから先へ進む:
 
 - `terraform` 1.15.x / `python3` / `uv` / 1Password CLI (`op`)
@@ -58,7 +60,7 @@ description: "Use when ライブ配信用 Vultr VPS・動画配信本体を Terr
 | ログ追跡 | 同上 + `journalctl -u youtube-stream -f` |
 | 破棄 | §5 |
 
-workspace は state だけを切り替える。既存 workspace の操作は `select_channel.sh` で切替・一致検証・state 表示と `TF_VAR_video_path` / `TF_VAR_stream_key` / `TF_VAR_discord_webhook_url` / `TF_VAR_channel_slug` の再注入を一体化する。workspace の新規作成だけは明示操作とし、apply 前の照合まで含む詳細手順は [README の「チャンネル別 Terraform workspace 運用」](../../../infra/terraform/streaming/README.md#チャンネル別-terraform-workspace-運用) を正本とする。
+workspace は state だけを切り替える。既存 workspace の操作は `select_channel.sh` で切替・一致検証・state 表示と `TF_VAR_video_path` / `TF_VAR_stream_key` / `TF_VAR_discord_webhook_url` / `TF_VAR_channel_slug` の再注入を一体化する。workspace の新規作成だけは明示操作とし、apply 前の照合まで含む詳細手順は `$TF_DIR/README.md` の「チャンネル別 Terraform workspace 運用」 を正本とする。
 
 | CLI / スクリプト | 用途 |
 |---|---|

--- a/.claude/skills/streaming/SKILL.md
+++ b/.claude/skills/streaming/SKILL.md
@@ -147,7 +147,7 @@ ffmpeg -i input.mp4 \
 - `/etc/logrotate.d/youtube-stream`（daily / rotate 7 / copytruncate）
 - `/etc/youtube-stream-healthcheck.env`（mode 0600、Discord webhook URL）
 
-`enable_broadcast_recovery=true` かつ `stream_hours=0` では、専用 user と 0600 OAuth files、`youtube-broadcast-recovery.service/.timer` も配備される。既定 120 秒ごとに ffmpeg service と ingest を確認し、active broadcast が消えたときだけ upcoming 再利用または create → bind → live を行う。`recovered` は既存 notify 経路へ送り、結果は常に `journalctl -t youtube-broadcast-recovery` に残る。導入、disable cleanup、資格情報更新、明示承認が必要な手動終了テストは [README の「24/7 broadcast 自動復旧 timer」](../../../infra/terraform/streaming/README.md#247-broadcast-自動復旧-timer) を正本とする。
+`enable_broadcast_recovery=true` かつ `stream_hours=0` では、専用 user と 0600 OAuth files、`youtube-broadcast-recovery.service/.timer` も配備される。既定 120 秒ごとに ffmpeg service と ingest を確認し、active broadcast が消えたときだけ upcoming 再利用または create → bind → live を行う。`recovered` は既存 notify 経路へ送り、結果は常に `journalctl -t youtube-broadcast-recovery` に残る。導入、disable cleanup、資格情報更新、明示承認が必要な手動終了テストは `$TF_DIR/README.md` の「24/7 broadcast 自動復旧 timer」 を正本とする。
 
 healthcheck は systemd 状態を 4 通りに分類し、**真の異常のみ通知**:
 

--- a/.claude/skills/streaming/references/upstream-checkout.md
+++ b/.claude/skills/streaming/references/upstream-checkout.md
@@ -1,0 +1,33 @@
+# Terraform 資産と実行場所の確定
+
+`/streaming` と `/reply --live` の操作前に実行する。Terraform モジュールと README は [youtube-automation 上流リポジトリ](https://github.com/daiki-beppu/youtube-automation) の checkout が所有する。wheel / `yt-skills sync` は `infra/terraform/streaming/` を配布しない。
+
+既存の運用 checkout の絶対パスを `AUTOMATION_ROOT`、対象チャンネルの絶対パスを `CHANNEL_DIR` として確定する。上流内で実行中ならその checkout をそのまま使う。所在が不明なら運用者に既存 checkout を確認する。未取得なら、GitHub アクセスを確認し `gh repo clone daiki-beppu/youtube-automation <取得先>` で取得する場所を示して停止する。下流の `/automation --update` だけではこの前提は解消しない。
+
+値を確定した後、次の存在確認を行う。欠損時は不足パスを報告し、上流 checkout の取得・修復が済むまで Terraform、認証、外部 API 操作へ進まない。
+
+```bash
+: "${AUTOMATION_ROOT:?上流 checkout の絶対パスを設定してください}"
+: "${CHANNEL_DIR:?対象チャンネルの絶対パスを設定してください}"
+AUTOMATION_ROOT=$(cd "$AUTOMATION_ROOT" && pwd -P) || exit 1
+CHANNEL_DIR=$(cd "$CHANNEL_DIR" && pwd -P) || exit 1
+export AUTOMATION_ROOT CHANNEL_DIR
+export TF_DIR="$AUTOMATION_ROOT/infra/terraform/streaming"
+for asset in main.tf variables.tf versions.tf outputs.tf cloud-init.yaml README.md; do
+  if [ ! -f "$TF_DIR/$asset" ]; then
+    printf 'STOP: 上流 Terraform 資産がありません: %s\n' "$TF_DIR/$asset" >&2
+    exit 1
+  fi
+done
+for helper in select_channel.sh deploy_live_chat.sh; do
+  if [ ! -f "$AUTOMATION_ROOT/.claude/skills/streaming/references/$helper" ]; then
+    printf 'STOP: 上流 helper がありません: %s\n' "$helper" >&2
+    exit 1
+  fi
+done
+cd "$AUTOMATION_ROOT" || exit 1
+```
+
+以降の Terraform と配備 helper はこの上流 root で実行する。既存 helper の `--tf-dir "$TF_DIR"` で対象を明示できる。チャンネルの設定・認証・動画のパスは `CHANNEL_DIR` を基準とする絶対パスで渡す。チャンネル用 CLI はチャンネル root で実行し、Terraform 操作前に上流 root へ戻る。
+
+`$TF_DIR/README.md` を読み、既存 backend と workspace を照合してから運用する。新しい checkout を既存 VPS の運用に使う場合も README に従って元の backend へ接続する。`.terraform/`、tfstate、tfvars、秘密ファイルを下流や別 checkout へコピーしない。

--- a/changelog.d/5007-streaming-upstream-assets.fixed.md
+++ b/changelog.d/5007-streaming-upstream-assets.fixed.md
@@ -1,0 +1,1 @@
+- streaming / reply live で非配布の Terraform 資産を上流 checkout から確認・利用する手順を明確にし、欠損時は取得先を示して停止するよう修正しました。comments 設定は配布済み設定モデルから新規生成でき、既存 state や秘密情報のコピーは不要です。

--- a/tests/repo/streaming/test_skill_streaming.py
+++ b/tests/repo/streaming/test_skill_streaming.py
@@ -6,9 +6,16 @@
 
 from __future__ import annotations
 
+import os
 import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
 
 from tests.helpers.hcl import read_file
+from tests.helpers.paths import REPO_ROOT
 from tests.repo.streaming._helpers import (
     _STREAMING_README,
     _STREAMING_SKILL,
@@ -113,7 +120,7 @@ class TestStreamingSkillWorkspaces:
     """Quick Reference から README 正本の workspace 手順へ到達できる契約。"""
 
     def test_quick_reference_indexes_workspace_operations_and_variable_warning(self):
-        """workspace 操作、変数再注入警告、詳細正本への link を固定する。"""
+        """workspace 操作、変数再注入警告、詳細正本への参照を確認する。"""
         text = read_file(_STREAMING_SKILL)
         match = re.search(
             r"^## Quick Reference\s*$\n(.*?)(?=^##\s|\Z)",
@@ -134,9 +141,47 @@ class TestStreamingSkillWorkspaces:
             "TF_VAR_stream_key",
             "TF_VAR_discord_webhook_url",
             "再注入",
-            "../../../infra/terraform/streaming/README.md#チャンネル別-terraform-workspace-運用",
+            "$TF_DIR/README.md",
+            "チャンネル別 Terraform workspace 運用",
         ):
             assert required in section, f"Quick Reference に {required!r} が無い"
+
+    @pytest.mark.parametrize("upstream_available", [True, False])
+    def test_distributed_skill_resolves_upstream_readme_or_stops(self, tmp_path: Path, upstream_available: bool):
+        downstream = tmp_path / "channel"
+        skill_dir = downstream / ".claude/skills/streaming"
+        shutil.copytree(_STREAMING_SKILL.parent, skill_dir)
+        skill_text = (skill_dir / "SKILL.md").read_text(encoding="utf-8")
+        local_links = re.findall(r"\]\(([^)]+\.md)(?:#[^)]*)?\)", skill_text)
+        assert local_links
+        for link in local_links:
+            assert (skill_dir / link).is_file(), f"配布先から参照できない: {link}"
+        reference = skill_dir / "references/upstream-checkout.md"
+        assert reference.relative_to(skill_dir).as_posix() in local_links
+        bash_blocks = re.findall(r"```bash\n(.*?)```", reference.read_text(encoding="utf-8"), re.DOTALL)
+        assert len(bash_blocks) == 1
+        upstream = REPO_ROOT if upstream_available else tmp_path / "missing-upstream"
+        if not upstream_available:
+            upstream.mkdir()
+        result = subprocess.run(
+            ["bash", "-c", bash_blocks[0] + '\nprintf "%s\\n" "$TF_DIR/README.md"'],
+            cwd=downstream,
+            env={"PATH": os.defpath, "AUTOMATION_ROOT": str(upstream), "CHANNEL_DIR": str(downstream)},
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert not (downstream / "infra").exists()
+        if upstream_available:
+            assert result.returncode == 0, result.stderr
+            resolved_readme = Path(result.stdout.strip())
+            assert resolved_readme == _STREAMING_README
+            assert "## チャンネル別 Terraform workspace 運用" in resolved_readme.read_text(encoding="utf-8")
+        else:
+            assert result.returncode != 0
+            assert "STOP:" in result.stderr
+            assert result.stdout == ""
 
 
 # ============================================================================


### PR DESCRIPTION
下流に同梱されないTerraformや旧commentsサンプルを参照していた配信手順を修正します。上流checkoutの取得・所在確認・実行rootと資産欠損時の停止を共有referenceへまとめ、reply liveも絶対tf-dirを使用します。comments設定は配布済みモデルの既定値から新規生成し、既存設定は保持します。

検証: 関連139テスト、skills lint、ruff、changelog検証。隔離下流で資産欠損停止・helper dry-runのtf-dir・comments生成と読み込み、既存設定保持を確認。配布先からのリンク到達性と資産欠損時の停止も検証済み。実Terraform/APIは未実行。

Closes #5007
