### PR TITLE
fix(suno-helper): Library の遅延読み込みを待機する (#5036)

### DIFF
--- a/changelog.d/5036-studio-library-lazy-scroll.fixed.md
+++ b/changelog.d/5036-studio-library-lazy-scroll.fixed.md
@@ -1,0 +1,1 @@
+- Studio Library の遅延読み込みを待ってから clip 探索を終了し、曲数が多い環境でも Multitrack export を継続できるようにした（#5036）。

--- a/extensions/suno-helper/lib/studio-export.ts
+++ b/extensions/suno-helper/lib/studio-export.ts
@@ -3,6 +3,7 @@ import { sendMessage } from "./messaging";
 const STUDIO_CLIP_DRAG_TYPE = "application/x-suno-studio-clip";
 const DOM_TIMEOUT_MS = 30_000;
 const DOM_POLL_MS = 200;
+const LIBRARY_LAZY_LOAD_WAIT_MS = 2_000;
 
 export interface StudioExportRequest {
   collectionId: string;
@@ -213,7 +214,7 @@ function findLibraryScroller(element: Element): HTMLElement | null {
   return null;
 }
 
-async function findLibraryClip(clipId: string): Promise<HTMLElement> {
+export async function findLibraryClip(clipId: string): Promise<HTMLElement> {
   const selector = `[draggable="true"][data-clip-id="${CSS.escape(clipId)}"]`;
   const firstVisibleClip = await waitForElement(
     () =>
@@ -229,13 +230,35 @@ async function findLibraryClip(clipId: string): Promise<HTMLElement> {
     const clip = document.querySelector<HTMLElement>(selector);
     if (clip && isVisible(clip)) return clip;
     const before = scroller.scrollTop;
+    const beforeHeight = scroller.scrollHeight;
+    const beforeClipCount = document.querySelectorAll(
+      '[draggable="true"][data-clip-id]'
+    ).length;
     scroller.scrollTop = Math.min(
       scroller.scrollHeight,
       before + Math.max(200, scroller.clientHeight * 0.8)
     );
     scroller.dispatchEvent(new Event("scroll", { bubbles: true }));
     await new Promise((resolve) => setTimeout(resolve, DOM_POLL_MS));
-    if (scroller.scrollTop === before) break;
+    if (scroller.scrollTop !== before) continue;
+
+    const lazyLoadDeadline = Math.min(
+      deadline,
+      Date.now() + LIBRARY_LAZY_LOAD_WAIT_MS
+    );
+    let libraryGrew = false;
+    while (Date.now() < lazyLoadDeadline) {
+      if (
+        scroller.scrollHeight > beforeHeight ||
+        document.querySelectorAll('[draggable="true"][data-clip-id]').length >
+          beforeClipCount
+      ) {
+        libraryGrew = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, DOM_POLL_MS));
+    }
+    if (!libraryGrew) break;
   }
   throw new Error(`Studio Library に clip ${clipId} が見つかりません`);
 }

--- a/extensions/suno-helper/lib/studio-export.ts
+++ b/extensions/suno-helper/lib/studio-export.ts
@@ -4,6 +4,7 @@ const STUDIO_CLIP_DRAG_TYPE = "application/x-suno-studio-clip";
 const DOM_TIMEOUT_MS = 30_000;
 const DOM_POLL_MS = 200;
 const LIBRARY_LAZY_LOAD_WAIT_MS = 2_000;
+const LIBRARY_CLIP_SELECTOR = '[draggable="true"][data-clip-id]';
 
 export interface StudioExportRequest {
   collectionId: string;
@@ -214,11 +215,14 @@ function findLibraryScroller(element: Element): HTMLElement | null {
   return null;
 }
 
+function countLibraryClips(): number {
+  return document.querySelectorAll(LIBRARY_CLIP_SELECTOR).length;
+}
+
 export async function findLibraryClip(clipId: string): Promise<HTMLElement> {
   const selector = `[draggable="true"][data-clip-id="${CSS.escape(clipId)}"]`;
   const firstVisibleClip = await waitForElement(
-    () =>
-      document.querySelector<HTMLElement>('[draggable="true"][data-clip-id]'),
+    () => document.querySelector<HTMLElement>(LIBRARY_CLIP_SELECTOR),
     "Library の clip 一覧"
   );
   const scroller = findLibraryScroller(firstVisibleClip);
@@ -231,9 +235,7 @@ export async function findLibraryClip(clipId: string): Promise<HTMLElement> {
     if (clip && isVisible(clip)) return clip;
     const before = scroller.scrollTop;
     const beforeHeight = scroller.scrollHeight;
-    const beforeClipCount = document.querySelectorAll(
-      '[draggable="true"][data-clip-id]'
-    ).length;
+    const beforeClipCount = countLibraryClips();
     scroller.scrollTop = Math.min(
       scroller.scrollHeight,
       before + Math.max(200, scroller.clientHeight * 0.8)
@@ -250,8 +252,7 @@ export async function findLibraryClip(clipId: string): Promise<HTMLElement> {
     while (Date.now() < lazyLoadDeadline) {
       if (
         scroller.scrollHeight > beforeHeight ||
-        document.querySelectorAll('[draggable="true"][data-clip-id]').length >
-          beforeClipCount
+        countLibraryClips() > beforeClipCount
       ) {
         libraryGrew = true;
         break;

--- a/extensions/suno-helper/tests/studio-export.test.ts
+++ b/extensions/suno-helper/tests/studio-export.test.ts
@@ -98,8 +98,10 @@ describe("Studio multitrack export", () => {
     try {
       const { scroller, setScrollHeight } = createLibrary();
       appendLibraryClip(scroller, "visible-clip");
+      let lazyLoadScheduled = false;
       scroller.addEventListener("scroll", () => {
-        if (scroller.scrollTop < 200 || scroller.childElementCount > 1) return;
+        if (lazyLoadScheduled || scroller.scrollTop < 200) return;
+        lazyLoadScheduled = true;
         setTimeout(() => {
           setScrollHeight(800);
           appendLibraryClip(scroller, "lazy-clip");

--- a/extensions/suno-helper/tests/studio-export.test.ts
+++ b/extensions/suno-helper/tests/studio-export.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../lib/messaging", () => ({ sendMessage: vi.fn() }));
 
@@ -11,12 +11,26 @@ import {
   commitStudioInputValue,
   dispatchStudioPointerClick,
   exportStudioMultitrack,
+  findLibraryClip,
 } from "../lib/studio-export";
 
 const TITLE_BY_CLIP = new Map([
   ["clip-a", "Song A"],
   ["clip-b", "Song B"],
 ]);
+
+beforeEach(() => {
+  document.body.replaceChildren();
+  Object.defineProperty(globalThis, "CSS", {
+    configurable: true,
+    value: { escape: (value: string) => value },
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.replaceChildren();
+});
 
 function createDeps(
   trackCount = 2,
@@ -39,6 +53,99 @@ function createDeps(
 }
 
 describe("Studio multitrack export", () => {
+  function appendLibraryClip(
+    scroller: HTMLElement,
+    clipId: string
+  ): HTMLElement {
+    const clip = document.createElement("div");
+    clip.dataset.clipId = clipId;
+    clip.draggable = true;
+    clip.getBoundingClientRect = () =>
+      ({ left: 0, top: 0, width: 20, height: 20 }) as DOMRect;
+    scroller.append(clip);
+    return clip;
+  }
+
+  function createLibrary(): {
+    scroller: HTMLElement;
+    setScrollHeight: (height: number) => void;
+  } {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    let scrollHeight = 400;
+    let scrollTop = 0;
+    Object.defineProperties(scroller, {
+      clientHeight: { value: 200 },
+      scrollHeight: { get: () => scrollHeight },
+      scrollTop: {
+        get: () => scrollTop,
+        set: (value: number) => {
+          scrollTop = Math.min(value, scrollHeight - 200);
+        },
+      },
+    });
+    document.body.append(scroller);
+    return {
+      scroller,
+      setScrollHeight: (height: number) => {
+        scrollHeight = height;
+      },
+    };
+  }
+
+  it("Given 遅延読み込み境界の clip When 行が追加される Then スクロールを再開して見つける", async () => {
+    vi.useFakeTimers();
+    try {
+      const { scroller, setScrollHeight } = createLibrary();
+      appendLibraryClip(scroller, "visible-clip");
+      scroller.addEventListener("scroll", () => {
+        if (scroller.scrollTop < 200 || scroller.childElementCount > 1) return;
+        setTimeout(() => {
+          setScrollHeight(800);
+          appendLibraryClip(scroller, "lazy-clip");
+        }, 600);
+      });
+
+      const resultPromise = findLibraryClip("lazy-clip");
+      const assertion = expect(resultPromise).resolves.toHaveProperty(
+        "dataset.clipId",
+        "lazy-clip"
+      );
+      await vi.runAllTimersAsync();
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+      document.body.replaceChildren();
+    }
+  });
+
+  it("Given 存在しない clip When Library が増えない Then 遅延読み込み待ち後に失敗する", async () => {
+    vi.useFakeTimers();
+    try {
+      const { scroller } = createLibrary();
+      appendLibraryClip(scroller, "visible-clip");
+
+      const resultPromise = findLibraryClip("missing-clip");
+      const assertion = expect(resultPromise).rejects.toThrow(
+        "Studio Library に clip missing-clip が見つかりません"
+      );
+      await vi.advanceTimersByTimeAsync(2_400);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+      document.body.replaceChildren();
+    }
+  });
+
+  it("Given 最初の表示範囲に対象 clip When 探索 Then スクロールせず即座に返す", async () => {
+    const { scroller } = createLibrary();
+    const clip = appendLibraryClip(scroller, "visible-clip");
+
+    await expect(findLibraryClip("visible-clip")).resolves.toBe(clip);
+    expect(scroller.scrollTop).toBe(0);
+    document.body.replaceChildren();
+  });
+
   it("Given pointerdown で開く Studio menu When 操作 Then click() ではなく pointer sequence で開く", () => {
     const button = document.createElement("button");
     const menu = document.createElement("div");


### PR DESCRIPTION
## Summary
- Studio Library のスクロール停止後に遅延読み込みによる高さ・clip 行数の増加を待機する
- 遅延追加、増加なし、初期表示内ヒットの jsdom 回帰テストを追加する
- 修正内容の changelog fragment を追加する

Closes #5036