### PR TITLE
feat(gcp): GCS backend と初回 init 手順を整備 (#4927)

### DIFF
--- a/changelog.d/4927-gcp-backend.changed.md
+++ b/changelog.d/4927-gcp-backend.changed.md
@@ -1,0 +1,1 @@
+- GCP Terraform stack の state 保存先を GCS backend（prefix `gcp`、bucket は init 時注入）に揃え、初回 init 手順と tfvars 設定例を更新した。

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -47,14 +47,12 @@ cd infra/terraform/gcp
 cp terraform.tfvars.example terraform.tfvars
 # → project_id, adc_email, billing_account を実値に書き換え
 
-# 2. apply
-terraform init
+# 2. bootstrap stack の output bucket_name を使って初回 backend 設定
+terraform init -backend-config="bucket=$(terraform -chdir=../bootstrap output -raw bucket_name)"
 terraform plan
-terraform apply
-
-# 3. project ID を ADC quota project に設定
-gcloud auth application-default set-quota-project "$(terraform output -raw project_id)"
 ```
+
+backend の bucket 名は `terraform -chdir=../bootstrap output -raw bucket_name` で取得するため、先に bootstrap stack の構築を完了しておく。GCP stack は未 apply で state が無いため初回設定となり、init 後も state は空のまま。既存リソースの import を行う #4929 まで apply は実行しない。
 
 Vertex AI の location はモデル用途別にアプリが決定する。project ID を一時的に上書きする必要がある実行だけ `GOOGLE_CLOUD_PROJECT` process env を使う。
 

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -1,14 +1,13 @@
 # 使い方:
 #   cp terraform.tfvars.example terraform.tfvars
 #   <実値に書き換え>
-#   terraform init
-#   terraform apply
+#   terraform init -backend-config="bucket=$(terraform -chdir=../bootstrap output -raw bucket_name)"
+#   terraform plan
 
 project_id      = "my-youtube-channel-prod"
 create_project  = true
 billing_account = "012345-6789AB-CDEF01"
 adc_email       = "you@example.com"
-location        = "us-central1"
 
 # 任意
 # project_name = "My YouTube Channel"
@@ -19,4 +18,5 @@ location        = "us-central1"
 #   "youtubeanalytics.googleapis.com",
 #   "aiplatform.googleapis.com",
 #   "generativelanguage.googleapis.com",
+#   "storage.googleapis.com",
 # ]

--- a/infra/terraform/gcp/versions.tf
+++ b/infra/terraform/gcp/versions.tf
@@ -1,4 +1,8 @@
 terraform {
+  backend "gcs" {
+    prefix = "gcp"
+  }
+
   required_version = "~> 1.15.0"
 
   required_providers {

--- a/tests/repo/test_terraform_bootstrap.py
+++ b/tests/repo/test_terraform_bootstrap.py
@@ -134,3 +134,21 @@ def test_streaming_readme_documents_executable_state_migration_commands():
     assert "rm -f terraform.tfstate terraform.tfstate.backup" in streaming_text, (
         "streaming README にローカル tfstate 削除手順が無い"
     )
+
+
+def test_gcp_backend_uses_isolated_gcs_prefix_and_injected_bucket():
+    text = strip_hcl_comments(read_file(_GCP_VERSIONS_TF))
+    terraform_block = extract_block(text, r"terraform")
+    assert terraform_block is not None
+    backend_block = extract_block(terraform_block, r'backend\s+"gcs"')
+    assert backend_block is not None
+    assert re.search(r'\bprefix\s*=\s*"gcp"', backend_block)
+    assert not re.search(r"\bbucket\s*=", backend_block)
+
+
+def test_gcp_tfvars_example_only_assigns_declared_variables():
+    variables = strip_hcl_comments(read_file(_GCP_VARIABLES_TF))
+    example = strip_hcl_comments(read_file(_GCP_DIR / "terraform.tfvars.example"))
+    declared = set(re.findall(r'\bvariable\s+"([^\"]+)"', variables))
+    assigned = set(re.findall(r"^\s*(\w+)\s*=", example, re.MULTILINE))
+    assert assigned <= declared, f"未定義の変数: {assigned - declared}"


### PR DESCRIPTION
GCP stack の state を GCS backend（prefix `gcp`）で管理し、bucket 名を `terraform init` 時に注入する手順を追加します。tfvars.example の未定義 location を削除し、API 一覧を既定値に合わせます。

検証: 対象 pytest 9 件、Terraform fmt / init -backend=false / validate、ruff、changelog 検証は成功。全体 pytest は 10579 passed / 4 skipped / 1 failed（ローカルにコピーされた既存 auth/client_secrets.json が root auth 不在契約に抵触）。実環境への init / apply は未実行です。

Closes #4927
