### PR TITLE
feat(gcp): 既存資源の宣言的取り込みと削除保護を追加 (#4929)

### DIFF
--- a/changelog.d/4929-gcp-imports.added.md
+++ b/changelog.d/4929-gcp-imports.added.md
@@ -1,0 +1,1 @@
+- 共有 GCP プロジェクト・API 6 件・Vertex AI IAM の宣言的 import と billing 管理、二重の削除保護を追加し、Terraform を唯一の変更経路とする ADR-0030 と取り込み検証手順を整備。

--- a/changelog.d/4929-gcp-imports.added.md
+++ b/changelog.d/4929-gcp-imports.added.md
@@ -1,1 +1,2 @@
-- 共有 GCP プロジェクト・API 6 件・Vertex AI IAM の宣言的 import と billing 管理、二重の削除保護を追加し、Terraform を唯一の変更経路とする ADR-0030 と取り込み検証手順を整備。
+- 共有 GCP プロジェクト・API 6 件・Vertex AI IAM を宣言的 import で Terraform 管理へ取り込み、`deletion_policy = "PREVENT"` と `prevent_destroy` による二重の削除保護を追加しました。
+- Terraform を GCP 構成の唯一の変更経路とする ADR-0030 と、取り込み・drift 確認の運用手順を整備しました。

--- a/changelog.d/4929-gcp-imports.changed.md
+++ b/changelog.d/4929-gcp-imports.changed.md
@@ -1,0 +1,2 @@
+- 共有プロジェクトの `billing_account` を必須変数にし、`billing_account` / `adc_email` を `sensitive` として plan / apply 出力から秘匿するようにしました。既存の `terraform.tfvars` に `billing_account` がない場合は追記が必要です。
+- 管理対象 API の既定値に `youtubereporting.googleapis.com` を追加し、doctor が要求する API を包含するようにしました。

--- a/changelog.d/4929-gcp-imports.removed.md
+++ b/changelog.d/4929-gcp-imports.removed.md
@@ -1,0 +1,1 @@
+- `create_project` 変数と `data "google_project"` による既存参照分岐を削除し、共有プロジェクトを `google_project` リソース 1 つで管理するよう統一しました。既存流用は `create_project = false` ではなく `imports.tf` の import で表します。

--- a/docs/adr/0030-terraform-sole-change-path-for-gcp.md
+++ b/docs/adr/0030-terraform-sole-change-path-for-gcp.md
@@ -1,0 +1,29 @@
+# Terraform を GCP の唯一の変更経路とする
+
+## Status
+
+accepted (2026-09-05)。Wayfinder map [#4714](https://github.com/daiki-beppu/youtube-automation/issues/4714)、起草 [#4929](https://github.com/daiki-beppu/youtube-automation/issues/4929)。決定の正本は #4719（ADR 番号の訂正を含む）、#4720 §12、#4721 §11。
+
+## Context
+
+ADR-0010 の単一共有プロジェクトには既存リソースがあるが、Terraform の定義と doctor / bootstrap の変更経路が併存していた。存在確認だけの data source ではプロジェクトの billing 紐付けを drift として検出できず、複数の変更経路は構成の正本を曖昧にする。
+
+## Decision
+
+1. 既存リソースの取り込み完了後、GCP プロジェクト `yt-channels-automation` への変更は `infra/terraform/gcp/` からのみ行う。project と billing を managed にし、`deletion_policy = "PREVENT"` と `prevent_destroy = true` の二重ガードで共有プロジェクトを保護する。
+2. doctor `--apply` と `gcp-bootstrap.sh` は GCP を変更しない。GCP 層の `gcp_project` / `billing_linked` / `apis_enabled` / `iam_aiplatform_user` は読み取り専用にする（実装 #4933）。doctor は不足の観測と Terraform への案内を担う。
+3. CI は静的ゲートと読み取り専用 drift 検知に限定し、apply は CI から実行しない。WIF は読み取り専用サービスアカウント 1 本とする（実装 #4930 / #4931 / #4932）。apply は ADC を持つ運用者がローカルで plan を確認して行う。
+4. project 1 + API 6 + IAM 1 の 8 件を宣言的 import ブロックで取り込む。ブロックは apply 後も保持し、取り込み済みには no-op、state 喪失時には復旧の対象宣言として利用する。
+5. 定義外で有効な 26 API、`roles/owner`、aiplatform サービスエージェントは管理外のままとする。API / IAM は additive に共存させ、owner は Terraform が使えないときの人間の break-glass として残す。
+
+## Considered Options
+
+- doctor と bootstrap からの変更を維持する: セットアップ時の便利さはあるが、Terraform 外の更新と宣言との不一致が生まれる。
+- CLI import 後に取り込み宣言を残さない: 実施は容易だが、PR での範囲レビューと state 喪失時の再現性を失う。
+- CI から apply する: 自動化できるが、変更頻度と運用者数に対して書き込み権限と承認経路の維持が重い。必要性が変われば再評価する。
+
+## Consequences
+
+Terraform を構成の正本とし、drift はローカル apply で実体を宣言に戻して解消する。意図した変更であれば先に Terraform 定義を PR で変更する。初回の合格条件は **8 to import, 0 to add, 0 to change, 0 to destroy** とし、異なる差分があれば apply を止めて #4929 で議論する。
+
+doctor / setup と CI の帰結は実装 epic [#4939](https://github.com/daiki-beppu/youtube-automation/issues/4939) の各段で反映する。この ADR の accepted は決定の採用を表し、HUMAN STEP の import 完了証拠は #4929 の plan / apply / No changes コメントで確認する。Google Auth Platform の provider 未対応設定は引き続き手動設定の境界にあり、この import の管理対象へ追加しない。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,8 @@ CLAUDE.md の「アーキテクチャ」節の詳細版。要点は CLAUDE.md �
 
 `CONTEXT.md` から移管した、本プロジェクト固有の用語と決定の正本。実装詳細ではなく、設計・運用・移行時に使う語彙を定義する。
 
+**唯一の変更経路**: 取り込み完了後の共有 GCP プロジェクトへの変更を Terraform に集約する運用原則（[ADR-0030](adr/0030-terraform-sole-change-path-for-gcp.md)）。
+
 ### 配布・移行
 
 > [!NOTE]

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -208,7 +208,7 @@ Billing account が紐付いていない。`--billing-account` を渡して再�
 ### terraform 固有
 
 #### `already exists but is not managed by this terraform configuration`
-プロジェクト ID がグローバルで衝突している。`project_id` を別名に変えるか、`create_project = false` で既存流用。
+`project_id` が既存の共有プロジェクトを指し、`imports.tf` が読み込まれていることを確認する。プロジェクトを新規作成して回避せず、[`infra/terraform/gcp/README.md`](../infra/terraform/gcp/README.md) の import 手順に戻る。
 
 #### `Error 400: ... not enabled for billing`
 `aiplatform.googleapis.com` には Billing が必須。`billing_account` を正しく指定。

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -10,10 +10,11 @@
 
 ## 管理するリソース
 
-- `google_project`（`create_project=true` 時のみ）
-- `google_project_service` × 5
+- `google_project.this`（既存共有プロジェクトと billing 紐付け。`PREVENT` + `prevent_destroy` で削除保護）
+- `google_project_service` × 6
   - `youtube.googleapis.com`
   - `youtubeanalytics.googleapis.com`
+  - `youtubereporting.googleapis.com`
   - `aiplatform.googleapis.com`
   - `generativelanguage.googleapis.com`
   - `storage.googleapis.com`
@@ -27,7 +28,7 @@ Terraform apply 後に表示される Console URL を開き、**Branding** を�
 
 - `terraform` 1.15.x インストール済み
 - `gcloud auth application-default login` 実行済み（Terraform は ADC 経由で認証）
-- Project を新規作成する場合: Organization / Billing Account に対する権限保持
+- 既存プロジェクト、Billing 紐付け、API、IAM を読み取り・管理する権限保持
 
 ## 使い方
 
@@ -42,22 +43,32 @@ terraform init -backend-config="bucket=$(terraform -chdir=../bootstrap output -r
 terraform plan
 ```
 
-backend の bucket 名は `terraform -chdir=../bootstrap output -raw bucket_name` で取得するため、先に bootstrap stack の構築を完了しておく。GCP stack は未 apply で state が無いため初回設定となり、init 後も state は空のまま。既存リソースの import を行う #4929 まで apply は実行しない。
+backend の bucket 名は `terraform -chdir=../bootstrap output -raw bucket_name` で取得するため、先に bootstrap stack の構築を完了しておく。初回取り込みは次節の合格条件を確認してから実施する。
 
 Vertex AI の location はモデル用途別にアプリが決定する。project ID を一時的に上書きする必要がある実行だけ `GOOGLE_CLOUD_PROJECT` process env を使う。
 
-## 既存プロジェクトを流用する場合
+## 既存リソースの import
 
-`terraform.tfvars`:
+ADC を保持するこのマシンで人間が実施する。`terraform.tfvars` は gitignore のまま、実在する `project_id` / `billing_account` / `adc_email` をローカルに設定する。`org_id` / `folder_id` は null のままとし、表示名は実在する project ID と同じ値を使用する。
 
-```hcl
-project_id     = "existing-project-id"
-create_project = false
-adc_email      = "you@example.com"
-# billing_account は不要 (既存で設定済み前提)
+```bash
+cd infra/terraform/gcp
+terraform init -backend-config="bucket=$(terraform -chdir=../bootstrap output -raw bucket_name)"
+terraform plan -out=.terraform/import.tfplan
 ```
 
-`data.google_project` で既存を参照するため、API 有効化と IAM 付与のみ反映される。
+初回 plan の合格条件は **8 to import, 0 to add, 0 to change, 0 to destroy**（project 1 + API 6 + IAM 1）。それ以外の差分が 1 件でも出たら **apply せず停止**し、[#4929](https://github.com/daiki-beppu/youtube-automation/issues/4929) で原因を議論する。合格条件を満たす plan だけを確認して適用する。
+
+```bash
+terraform apply .terraform/import.tfplan
+terraform plan
+```
+
+plan / apply の出力と直後の **No changes** を #4929 のコメントに evidence として残す。`billing_account` / `adc_email` は sensitive として扱うが、provider の import ID や refresh ログにも個人値が現れる可能性があるため、投稿前に出力全体を確認してマスクする。保存した plan と state には sensitive の実値が含まれるため共有しない。
+
+`imports.tf` は apply 後も削除しない。取り込み済みリソースには no-op となり、state 喪失時の復旧でも同じ対象を使える。定義外で有効な 26 API、`roles/owner`、aiplatform サービスエージェントは管理外のままとし、無効化・削除しない。API と IAM は additive に管理し、owner は人間の break-glass として残す。
+
+取り込み後の変更経路と drift 解消原則は [ADR-0030](../../../docs/adr/0030-terraform-sole-change-path-for-gcp.md) に従う。
 
 ## Outputs
 
@@ -70,13 +81,13 @@ adc_email      = "you@example.com"
 ## トラブルシューティング
 
 ### `Error 403: The caller does not have permission`
-ADC ユーザーが Organization / Billing Account に対する必要な権限を持っていない。`roles/resourcemanager.projectCreator` と `roles/billing.user` が最低必要。
+ADC ユーザーの project / billing / API / IAM に対する権限を確認する。取り込みでは新規プロジェクト作成権限ではなく、既存リソースの読み取り権限が必要。権限エラーを解消して plan を再確認するまで apply しない。
 
 ### `Error: googleapi: Error 400: ... billingEnabled`
 `aiplatform.googleapis.com` を有効化するには Billing が必要。`billing_account` を正しく指定すること。
 
 ### `Error: project ... already exists but is not managed by this terraform configuration`
-プロジェクト ID がグローバルで衝突している。`project_id` を別名に変えるか、既存流用なら `create_project = false` に。
+`project_id` が既存の共有プロジェクトを指し、`imports.tf` が読み込まれていることを確認する。プロジェクトを新規作成して回避せず、上記の import 手順に戻る。
 
 ### `Permission denied` (apply 後の実行時)
 ADC を更新してから実行: `gcloud auth application-default login && gcloud auth application-default set-quota-project <project-id>`

--- a/infra/terraform/gcp/apis.tf
+++ b/infra/terraform/gcp/apis.tf
@@ -1,7 +1,7 @@
 resource "google_project_service" "apis" {
   for_each = toset(var.apis)
 
-  project = local.project_id
+  project = google_project.this.project_id
   service = each.key
 
   # terraform destroy でも API は無効化しない (他の資産が残るケースを考慮)

--- a/infra/terraform/gcp/iam.tf
+++ b/infra/terraform/gcp/iam.tf
@@ -1,5 +1,5 @@
 resource "google_project_iam_member" "aiplatform_user" {
-  project = local.project_id
+  project = google_project.this.project_id
   role    = "roles/aiplatform.user"
   member  = "user:${var.adc_email}"
 }

--- a/infra/terraform/gcp/imports.tf
+++ b/infra/terraform/gcp/imports.tf
@@ -1,0 +1,40 @@
+# apply 後も保持し、state 喪失時に同じ取り込み範囲を復元できるようにする。
+import {
+  to = google_project.this
+  id = "projects/${var.project_id}"
+}
+
+import {
+  to = google_project_service.apis["youtube.googleapis.com"]
+  id = "${var.project_id}/youtube.googleapis.com"
+}
+
+import {
+  to = google_project_service.apis["youtubeanalytics.googleapis.com"]
+  id = "${var.project_id}/youtubeanalytics.googleapis.com"
+}
+
+import {
+  to = google_project_service.apis["youtubereporting.googleapis.com"]
+  id = "${var.project_id}/youtubereporting.googleapis.com"
+}
+
+import {
+  to = google_project_service.apis["aiplatform.googleapis.com"]
+  id = "${var.project_id}/aiplatform.googleapis.com"
+}
+
+import {
+  to = google_project_service.apis["generativelanguage.googleapis.com"]
+  id = "${var.project_id}/generativelanguage.googleapis.com"
+}
+
+import {
+  to = google_project_service.apis["storage.googleapis.com"]
+  id = "${var.project_id}/storage.googleapis.com"
+}
+
+import {
+  to = google_project_iam_member.aiplatform_user
+  id = "${var.project_id} roles/aiplatform.user user:${var.adc_email}"
+}

--- a/infra/terraform/gcp/main.tf
+++ b/infra/terraform/gcp/main.tf
@@ -1,23 +1,14 @@
-# プロジェクト: create_project=true なら resource で作成、そうでなければ data source で既存参照
 resource "google_project" "this" {
-  count = var.create_project ? 1 : 0
-
   project_id      = var.project_id
   name            = coalesce(var.project_name, var.project_id)
   billing_account = var.billing_account
   org_id          = var.org_id
   folder_id       = var.folder_id
 
-  # terraform destroy 時にプロジェクトを本当に削除する
-  # (共有プロジェクトを Terraform 管理下に置きたくない場合は create_project=false で)
-  deletion_policy = "DELETE"
-}
+  # 全チャンネルで共有するプロジェクトの削除事故を二重に防ぐ。
+  deletion_policy = "PREVENT"
 
-data "google_project" "this" {
-  count      = var.create_project ? 0 : 1
-  project_id = var.project_id
-}
-
-locals {
-  project_id = var.create_project ? google_project.this[0].project_id : data.google_project.this[0].project_id
+  lifecycle {
+    prevent_destroy = true
+  }
 }

--- a/infra/terraform/gcp/outputs.tf
+++ b/infra/terraform/gcp/outputs.tf
@@ -1,11 +1,11 @@
 output "project_id" {
   description = "確定した GCP project ID"
-  value       = local.project_id
+  value       = google_project.this.project_id
 }
 
 output "oauth_console_url" {
   description = "Google Auth Platform の Branding / Audience / Clients 手動設定用 Console URL"
-  value       = "https://console.cloud.google.com/apis/credentials?project=${local.project_id}"
+  value       = "https://console.cloud.google.com/apis/credentials?project=${google_project.this.project_id}"
 }
 
 output "enabled_apis" {

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -5,7 +5,6 @@
 #   terraform plan
 
 project_id      = "my-youtube-channel-prod"
-create_project  = true
 billing_account = "012345-6789AB-CDEF01"
 adc_email       = "you@example.com"
 
@@ -16,6 +15,7 @@ adc_email       = "you@example.com"
 # apis = [
 #   "youtube.googleapis.com",
 #   "youtubeanalytics.googleapis.com",
+#   "youtubereporting.googleapis.com",
 #   "aiplatform.googleapis.com",
 #   "generativelanguage.googleapis.com",
 #   "storage.googleapis.com",

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -1,6 +1,6 @@
 variable "project_id" {
   type        = string
-  description = "GCP project ID (作成する or 既存流用する)"
+  description = "Terraform が管理する既存の共有 GCP project ID"
 }
 
 variable "project_name" {
@@ -9,16 +9,10 @@ variable "project_name" {
   default     = null
 }
 
-variable "create_project" {
-  type        = bool
-  description = "true の場合 google_project で新規作成。false なら data source で既存を参照"
-  default     = false
-}
-
 variable "billing_account" {
   type        = string
-  description = "Billing account ID (例: 012345-6789AB-CDEF01)。create_project=true なら必須、aiplatform を使うなら実質必須"
-  default     = null
+  description = "共有プロジェクトに紐付ける Billing account ID (例: 012345-6789AB-CDEF01)"
+  sensitive   = true
 }
 
 variable "org_id" {
@@ -36,6 +30,7 @@ variable "folder_id" {
 variable "adc_email" {
   type        = string
   description = "roles/aiplatform.user を付与する Google アカウント (ADC で使うユーザー)"
+  sensitive   = true
 }
 
 variable "apis" {
@@ -44,6 +39,7 @@ variable "apis" {
   default = [
     "youtube.googleapis.com",
     "youtubeanalytics.googleapis.com",
+    "youtubereporting.googleapis.com",
     "aiplatform.googleapis.com",
     "generativelanguage.googleapis.com",
     "storage.googleapis.com",

--- a/tests/commands/channel/test_no_setup_dotenv.py
+++ b/tests/commands/channel/test_no_setup_dotenv.py
@@ -55,7 +55,6 @@ def test_terraform_public_schema_has_no_dotenv_output_or_location_input() -> Non
     assert variables == {
         "project_id",
         "project_name",
-        "create_project",
         "billing_account",
         "org_id",
         "folder_id",

--- a/tests/repo/test_terraform_gcp_imports.py
+++ b/tests/repo/test_terraform_gcp_imports.py
@@ -1,0 +1,62 @@
+"""#4929 の GCP import と共有プロジェクト保護の設定契約。"""
+
+import re
+
+from tests.helpers.hcl import extract_block, read_file, strip_hcl_comments
+from tests.helpers.paths import REPO_ROOT
+from youtube_automation.application.channel_readiness.checks import REQUIRED_APIS
+
+_GCP = REPO_ROOT / "infra/terraform/gcp"
+
+
+def test_shared_project_manages_billing_with_two_deletion_guards():
+    project = extract_block(
+        strip_hcl_comments(read_file(_GCP / "main.tf")),
+        r'resource\s+"google_project"\s+"this"',
+    )
+    assert project is not None
+    assert re.search(r'deletion_policy\s*=\s*"PREVENT"', project)
+    assert re.search(r"billing_account\s*=\s*var\.billing_account\b", project)
+    lifecycle = extract_block(project, r"lifecycle")
+    assert lifecycle is not None
+    assert re.search(r"prevent_destroy\s*=\s*true", lifecycle)
+    assert not re.search(r"\b(count|for_each)\s*=", project)
+
+
+def test_personal_inputs_are_required_and_redacted():
+    variables = strip_hcl_comments(read_file(_GCP / "variables.tf"))
+    for name in ("billing_account", "adc_email"):
+        variable = extract_block(variables, rf'variable\s+"{name}"')
+        assert variable is not None
+        assert re.search(r"sensitive\s*=\s*true", variable)
+        assert not re.search(r"\bdefault\s*=", variable)
+
+
+def test_managed_apis_cover_doctor_and_the_state_backend():
+    apis = extract_block(strip_hcl_comments(read_file(_GCP / "variables.tf")), r'variable\s+"apis"')
+    assert apis is not None
+    default = re.search(r"default\s*=\s*\[([^]]*)\]", apis)
+    assert default is not None
+    services = set(re.findall(r'"([^\"]+)"', default.group(1)))
+    assert len(services) == 6
+    assert services >= set(REQUIRED_APIS) | {"storage.googleapis.com"}
+
+
+def test_imports_adopt_only_the_eight_existing_resources():
+    imports = strip_hcl_comments(read_file(_GCP / "imports.tf"))
+    blocks = re.findall(r"\bimport\s*\{(.*?)^\}", imports, re.MULTILINE | re.DOTALL)
+    assert len(blocks) == 8
+    actual = {}
+    for block in blocks:
+        target = re.search(r"^\s*to\s*=\s*(.+)$", block, re.MULTILINE)
+        identifier = re.search(r'^\s*id\s*=\s*"(.+)"$', block, re.MULTILINE)
+        assert target is not None
+        assert identifier is not None
+        actual[target.group(1).strip()] = identifier.group(1)
+    apis = set(REQUIRED_APIS) | {"storage.googleapis.com"}
+    expected = {
+        "google_project.this": "projects/${var.project_id}",
+        "google_project_iam_member.aiplatform_user": ("${var.project_id} roles/aiplatform.user user:${var.adc_email}"),
+    }
+    expected.update({f'google_project_service.apis["{api}"]': "${var.project_id}/" + api for api in apis})
+    assert actual == expected


### PR DESCRIPTION
共有 GCP プロジェクト・API 6 件・IAM 1 件を宣言的 import で Terraform 管理へ取り込み、project の削除保護と必須の請求先管理を追加します。ADR-0030 と取り込み・drift 運用手順を整備します。

実環境の import は完了し、直後の plan は No changes です。初回の 2 changes は値を変えない sensitive 属性付与のみで、ユーザー承認のうえ適用しました。[マスク済み証跡](https://github.com/daiki-beppu/youtube-automation/issues/4929#issuecomment-5550357612)。

検証: Terraform fmt / init / validate、Ruff、changelog、focused pytest 94 件成功。全体 pytest 10570 passed / 4 skipped / 2 failed のうち変数集合の追従漏れを修正・再検証済み。残り 1 件は既存ローカル auth ファイル配置に起因します。

Closes #4929
