### PR TITLE
feat(gcp): main 限定 WIF と読み取り専用 drift SA を追加 (#4931)

### DIFF
--- a/changelog.d/4931-gcp-wif.added.md
+++ b/changelog.d/4931-gcp-wif.added.md
@@ -1,0 +1,1 @@
+- GCP drift 検知用の GitHub main 限定 WIF と読み取り専用 SA を追加し、tfstate 本文の読み取りを gcp/ prefix に限定しました。

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -80,7 +80,7 @@ plan / apply の出力と直後の **No changes** を #4929 のコメントに e
 |------|------|------|
 | project | `roles/browser` | project と billing 紐付けの取得 |
 | project | `roles/serviceusage.serviceUsageViewer` | 有効 API の取得 |
-| project | `roles/iam.securityReviewer` | project / SA / bucket IAM policy と custom role の取得 |
+| project | `roles/iam.securityReviewer` | project / SA / bucket IAM policy と custom role の取得。既定ロールには object list も含むが本文 get は含まない |
 | project | `roles/iam.workloadIdentityPoolViewer` | WIF pool / provider の取得 |
 | tfstate bucket（条件付き） | custom role `terraformStateGet`: `storage.objects.get` のみ | `resource.name.startsWith("projects/_/buckets/<bucket>/objects/gcp/")` に一致する state の本文取得 |
 | tfstate bucket | custom role `terraformStateList`: `storage.objects.list` のみ | backend の workspace 列挙。object の名前・メタデータのみで、他 stack の本文は許可しない |
@@ -97,9 +97,18 @@ terraform output -raw wif_provider_name
 terraform output -raw drift_service_account_email
 ```
 
-2026-09-05 の実環境では **15 added / 0 changed / 0 destroyed**（WIF API 3、pool / provider / SA / subject binding 4、project read binding 4、custom role 2、bucket binding 2）を適用した。import 済み 8 件は全て no-op。ローカル ADC からの SA impersonation は `iam.serviceAccounts.getAccessToken` 不足で拒否されたため、SA 自体の `gcp/` get 成功と `r2/` / `streaming/` get 拒否、GCS backend init の list 要否は **未実測**。この検証だけのために token creator を追加しない。
+2026-09-05 の実環境では **15 added / 0 changed / 0 destroyed**（WIF API 3、pool / provider / SA / subject binding 4、project read binding 4、custom role 2、bucket binding 2）を適用した。import 済み 8 件は全て no-op。ローカル ADC は通常 SA token 発行を許可されないため、ユーザー承認のもと `iam.serviceAccounts.getAccessToken` 1 件だけの一時 custom role を対象 SA / 現在の ADC に限定付与し、10 分 TTL の token で次を実測した。token と state 本文はログへ出していない。
 
-SA の `terraform plan -lock=false` が exit 0 / 2 で完走する最小権限の実証は #4932 の WIF 認証で行う。上記 storage の許可 / 拒否と init の実測も記録するまで #4931 の完了契約は未充足。認証成功後、state 本文をログへ出さず HTTP status のみを確認する。plan / apply のマスク済み出力、非 secret の output 2 件、および未検証事項を #4931 の evidence に残す。
+| 実測 | 結果 |
+|------|------|
+| `gcp/default.tfstate` 本文 get | HTTP 200 |
+| 実在する `streaming/default.tfstate` 本文 get | HTTP 403（他 stack の state を拒否） |
+| `r2/default.tfstate` get | HTTP 404。`r2/` の object は存在しないため拒否の実証には使わない |
+| gcp object list / GCS backend init | HTTP 200 / exit 0 |
+| IAM を変更せず list を禁止した downscoped token | gcp get は HTTP 200、list は HTTP 403、init は `storage.objects.list` 不足で exit 1。init には bucket list が必要 |
+| SA の `terraform plan -lock=false` | exit 1。`cloudresourcemanager.googleapis.com` が `SERVICE_DISABLED`。追加 API は未有効化 |
+
+一時 custom role / SA binding は検証後に Terraform で **0 added / 0 changed / 2 destroyed** として除去済み。IAM 伝播後、ADC の新規 token 発行が `IAM_PERMISSION_DENIED`（HTTP 403）に戻り、通常 post-plan が **No changes**（exit 0）であることを確認した。SA plan の完走は要件どおり #4932 で実証し、Cloud Resource Manager API 未有効の前提も解決してから最小権限集合を確定する。API の追加有効化を読み取り検証に混ぜない。plan / apply のマスク済み出力、非 secret の output 2 件、実測および一時権限の除去結果は #4931 の evidence に残す。
 
 ## Outputs
 

--- a/infra/terraform/gcp/README.md
+++ b/infra/terraform/gcp/README.md
@@ -70,6 +70,37 @@ plan / apply の出力と直後の **No changes** を #4929 のコメントに e
 
 取り込み後の変更経路と drift 解消原則は [ADR-0030](../../../docs/adr/0030-terraform-sole-change-path-for-gcp.md) に従う。
 
+## WIF と読み取り専用 SA
+
+`wif.tf` は GitHub Actions の drift plan 専用 SA 1 本を管理する。GitHub OIDC issuer の `repository_owner_id` を `var.github_repository_owner_id` に固定し、SA の `roles/iam.workloadIdentityUser` は `repo:daiki-beppu/youtube-automation:ref:refs/heads/main` の subject 完全一致に限定する。feature branch / fork / pull request の subject は SA を impersonate できない。CI から apply は実行しない。
+
+`terraform.tfvars` に `github_repository_owner_id`（`gh api users/daiki-beppu --jq .id`）と `tfstate_bucket`（bootstrap の `bucket_name`）を追加する。WIF 用の IAM / IAM Credentials / STS API は独立した `google_project_service.wif` で管理し、チャンネル運用の `var.apis` 6 件は維持する。
+
+| 付与先 | ロール / permission | 読み取りの目的 |
+|------|------|------|
+| project | `roles/browser` | project と billing 紐付けの取得 |
+| project | `roles/serviceusage.serviceUsageViewer` | 有効 API の取得 |
+| project | `roles/iam.securityReviewer` | project / SA / bucket IAM policy と custom role の取得 |
+| project | `roles/iam.workloadIdentityPoolViewer` | WIF pool / provider の取得 |
+| tfstate bucket（条件付き） | custom role `terraformStateGet`: `storage.objects.get` のみ | `resource.name.startsWith("projects/_/buckets/<bucket>/objects/gcp/")` に一致する state の本文取得 |
+| tfstate bucket | custom role `terraformStateList`: `storage.objects.list` のみ | backend の workspace 列挙。object の名前・メタデータのみで、他 stack の本文は許可しない |
+
+Billing の `projects.getBillingInfo` は [`resourcemanager.projects.get` で参照できる](https://docs.cloud.google.com/billing/docs/reference/rest/v1/projects/getBillingInfo)。billing account 全体の viewer は付与しない。`roles/viewer` / `roles/editor` / `roles/owner` や objectViewer で読み取り範囲を広げない。list は bucket 単位であり [resource.name では prefix 制限できない](https://docs.cloud.google.com/storage/docs/access-control/iam) ため、本文の get と分離する。
+
+ADC を保持する運用者は次の plan で **import 済み 8 件が no-op、追加が WIF 系のみ、change / destroy が 0** と確認してから適用する。保存 plan は sensitive の実値を含むため共有しない。
+
+```bash
+terraform plan -out=.terraform/wif.tfplan
+terraform apply .terraform/wif.tfplan
+terraform plan
+terraform output -raw wif_provider_name
+terraform output -raw drift_service_account_email
+```
+
+2026-09-05 の実環境では **15 added / 0 changed / 0 destroyed**（WIF API 3、pool / provider / SA / subject binding 4、project read binding 4、custom role 2、bucket binding 2）を適用した。import 済み 8 件は全て no-op。ローカル ADC からの SA impersonation は `iam.serviceAccounts.getAccessToken` 不足で拒否されたため、SA 自体の `gcp/` get 成功と `r2/` / `streaming/` get 拒否、GCS backend init の list 要否は **未実測**。この検証だけのために token creator を追加しない。
+
+SA の `terraform plan -lock=false` が exit 0 / 2 で完走する最小権限の実証は #4932 の WIF 認証で行う。上記 storage の許可 / 拒否と init の実測も記録するまで #4931 の完了契約は未充足。認証成功後、state 本文をログへ出さず HTTP status のみを確認する。plan / apply のマスク済み出力、非 secret の output 2 件、および未検証事項を #4931 の evidence に残す。
+
 ## Outputs
 
 | 名前 | 内容 |
@@ -77,6 +108,8 @@ plan / apply の出力と直後の **No changes** を #4929 のコメントに e
 | `project_id` | 確定した project ID |
 | `oauth_console_url` | Google Auth Platform 手動設定用 Console URL |
 | `enabled_apis` | 有効化した API 一覧 |
+| `wif_provider_name` | GitHub Actions auth の provider 完全名（非 secret） |
+| `drift_service_account_email` | 読み取り専用 drift SA メール（非 secret） |
 
 ## トラブルシューティング
 

--- a/infra/terraform/gcp/outputs.tf
+++ b/infra/terraform/gcp/outputs.tf
@@ -12,3 +12,13 @@ output "enabled_apis" {
   description = "有効化した API 一覧"
   value       = [for api in google_project_service.apis : api.service]
 }
+
+output "wif_provider_name" {
+  description = "GitHub Actions auth の workload_identity_provider (非 secret)"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "drift_service_account_email" {
+  description = "GitHub Actions の読み取り専用 drift SA (非 secret)"
+  value       = google_service_account.drift.email
+}

--- a/infra/terraform/gcp/terraform.tfvars.example
+++ b/infra/terraform/gcp/terraform.tfvars.example
@@ -20,3 +20,6 @@ adc_email       = "you@example.com"
 #   "generativelanguage.googleapis.com",
 #   "storage.googleapis.com",
 # ]
+
+github_repository_owner_id = "140964131"
+tfstate_bucket             = "youtube-automation-tfstate"

--- a/infra/terraform/gcp/variables.tf
+++ b/infra/terraform/gcp/variables.tf
@@ -45,3 +45,18 @@ variable "apis" {
     "storage.googleapis.com",
   ]
 }
+
+variable "github_repository_owner_id" {
+  type        = string
+  description = "GitHub repository owner の不変な numeric ID (gh api users/daiki-beppu --jq .id)"
+
+  validation {
+    condition     = can(regex("^[0-9]+$", var.github_repository_owner_id))
+    error_message = "github_repository_owner_id は GitHub の numeric ID を指定する。"
+  }
+}
+
+variable "tfstate_bucket" {
+  type        = string
+  description = "bootstrap stack の bucket_name output。gcp/ object のみを drift SA に公開する"
+}

--- a/infra/terraform/gcp/wif.tf
+++ b/infra/terraform/gcp/wif.tf
@@ -1,0 +1,90 @@
+resource "google_project_service" "wif" {
+  for_each = toset([
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+  ])
+
+  project            = google_project.this.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  project                   = google_project.this.project_id
+  workload_identity_pool_id = "github-actions-drift"
+  display_name              = "GitHub Actions drift"
+  depends_on                = [google_project_service.wif]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                            = google_project.this.project_id
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = "github"
+  attribute_mapping = {
+    "google.subject" = "assertion.sub"
+  }
+  attribute_condition = "assertion.repository_owner_id == \"${var.github_repository_owner_id}\""
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account" "drift" {
+  project      = google_project.this.project_id
+  account_id   = "terraform-drift"
+  display_name = "Read-only Terraform drift detection"
+  depends_on   = [google_project_service.wif]
+}
+
+resource "google_service_account_iam_member" "github_main" {
+  service_account_id = google_service_account.drift.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principal://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/subject/repo:daiki-beppu/youtube-automation:ref:refs/heads/main"
+}
+
+resource "google_project_iam_member" "drift_read" {
+  for_each = toset([
+    "roles/browser",
+    "roles/serviceusage.serviceUsageViewer",
+    "roles/iam.securityReviewer",
+    "roles/iam.workloadIdentityPoolViewer",
+  ])
+
+  project = google_project.this.project_id
+  role    = each.value
+  member  = google_service_account.drift.member
+}
+
+# get と list を分離し、bucket 単位の list が object 本文へのアクセスを広げないようにする。
+resource "google_project_iam_custom_role" "state_get" {
+  project     = google_project.this.project_id
+  role_id     = "terraformStateGet"
+  title       = "Terraform state object read"
+  permissions = ["storage.objects.get"]
+}
+
+resource "google_project_iam_custom_role" "state_list" {
+  project     = google_project.this.project_id
+  role_id     = "terraformStateList"
+  title       = "Terraform state object listing"
+  permissions = ["storage.objects.list"]
+}
+
+resource "google_storage_bucket_iam_member" "drift_state_get" {
+  bucket = var.tfstate_bucket
+  role   = google_project_iam_custom_role.state_get.name
+  member = google_service_account.drift.member
+
+  condition {
+    title       = "gcp-state-only"
+    description = "Other stacks may contain plaintext secrets"
+    expression  = "resource.name.startsWith(\"projects/_/buckets/${var.tfstate_bucket}/objects/gcp/\")"
+  }
+}
+
+resource "google_storage_bucket_iam_member" "drift_state_list" {
+  bucket = var.tfstate_bucket
+  role   = google_project_iam_custom_role.state_list.name
+  member = google_service_account.drift.member
+}

--- a/tests/commands/channel/test_no_setup_dotenv.py
+++ b/tests/commands/channel/test_no_setup_dotenv.py
@@ -51,7 +51,13 @@ def test_terraform_public_schema_has_no_dotenv_output_or_location_input() -> Non
     outputs = set(re.findall(r'(?m)^output\s+"([^"]+)"', (canonical / "outputs.tf").read_text(encoding="utf-8")))
     variables = set(re.findall(r'(?m)^variable\s+"([^"]+)"', (canonical / "variables.tf").read_text(encoding="utf-8")))
 
-    assert outputs == {"project_id", "oauth_console_url", "enabled_apis"}
+    assert outputs == {
+        "project_id",
+        "oauth_console_url",
+        "enabled_apis",
+        "wif_provider_name",
+        "drift_service_account_email",
+    }
     assert variables == {
         "project_id",
         "project_name",
@@ -60,4 +66,6 @@ def test_terraform_public_schema_has_no_dotenv_output_or_location_input() -> Non
         "folder_id",
         "adc_email",
         "apis",
+        "github_repository_owner_id",
+        "tfstate_bucket",
     }

--- a/tests/repo/test_terraform_gcp_wif.py
+++ b/tests/repo/test_terraform_gcp_wif.py
@@ -1,0 +1,60 @@
+"""読み取り専用 drift identity の Terraform 認可契約。"""
+
+from __future__ import annotations
+
+import re
+
+from tests.helpers.hcl import extract_block, read_file
+from tests.helpers.paths import REPO_ROOT
+
+_GCP = REPO_ROOT / "infra" / "terraform" / "gcp"
+
+
+def test_wif_accepts_only_owner_and_exact_main_subject():
+    text = read_file(_GCP / "wif.tf")
+    provider = extract_block(text, r'resource\s+"google_iam_workload_identity_pool_provider"\s+"github"')
+    assert provider is not None
+    assert '"google.subject" = "assertion.sub"' in provider
+    assert 'assertion.repository_owner_id == \\"${var.github_repository_owner_id}\\"' in provider
+    assert 'issuer_uri = "https://token.actions.githubusercontent.com"' in provider
+    binding = extract_block(text, r'resource\s+"google_service_account_iam_member"\s+"github_main"')
+    assert binding is not None
+    assert re.search(r'role\s*=\s*"roles/iam.workloadIdentityUser"', binding)
+    assert re.search(
+        r'member\s*=\s*"principal://iam.googleapis.com/\$\{google_iam_workload_identity_pool.github.name\}/subject/repo:daiki-beppu/youtube-automation:ref:refs/heads/main"',
+        binding,
+    )
+    assert "principalSet://" not in text
+
+
+def test_drift_roles_allow_reads_without_broad_or_mutating_permissions():
+    text = read_file(_GCP / "wif.tf")
+    roles = set(re.findall(r'"(roles/[^"\s]+)"', text))
+    assert roles == {
+        "roles/iam.workloadIdentityUser",
+        "roles/browser",
+        "roles/serviceusage.serviceUsageViewer",
+        "roles/iam.securityReviewer",
+        "roles/iam.workloadIdentityPoolViewer",
+    }
+    permissions = set(re.findall(r'"(storage\.[^"\s]+)"', text))
+    assert permissions == {"storage.objects.get", "storage.objects.list"}
+    get_role = extract_block(text, r'resource\s+"google_project_iam_custom_role"\s+"state_get"')
+    list_role = extract_block(text, r'resource\s+"google_project_iam_custom_role"\s+"state_list"')
+    assert get_role is not None and list_role is not None
+    assert re.search(r'permissions\s*=\s*\["storage.objects.get"\]', get_role)
+    assert re.search(r'permissions\s*=\s*\["storage.objects.list"\]', list_role)
+
+
+def test_state_get_is_limited_to_gcp_while_list_has_no_object_reads():
+    text = read_file(_GCP / "wif.tf")
+    get_binding = extract_block(text, r'resource\s+"google_storage_bucket_iam_member"\s+"drift_state_get"')
+    list_binding = extract_block(text, r'resource\s+"google_storage_bucket_iam_member"\s+"drift_state_list"')
+    assert get_binding is not None and list_binding is not None
+    for binding in (get_binding, list_binding):
+        assert re.search(r"bucket\s*=\s*var.tfstate_bucket", binding)
+        assert re.search(r"member\s*=\s*google_service_account.drift.member", binding)
+    assert re.search(r"role\s*=\s*google_project_iam_custom_role.state_get.name", get_binding)
+    assert 'resource.name.startsWith(\\"projects/_/buckets/${var.tfstate_bucket}/objects/gcp/\\")' in get_binding
+    assert re.search(r"role\s*=\s*google_project_iam_custom_role.state_list.name", list_binding)
+    assert "condition" not in list_binding


### PR DESCRIPTION
GitHub main subject に限定した WIF と読み取り専用 drift SA を追加します。tfstate の get を gcp/ prefix に限定し、backend init に必要な list 権限を独立させます。

実環境へ15件追加、既存8件は変更なし。SAでgcp state get成功・実在するstreaming state get拒否・backend init成功・list不足時init失敗を実測しました。検証用の一時getAccessToken権限2件はユーザー承認のもと追加後に剥奪し、fresh token発行403と通常plan No changesを確認済みです。[証跡](https://github.com/daiki-beppu/youtube-automation/issues/4931#issuecomment-5550604202)。SA planはCloud Resource Manager API未有効化のため、要件どおり#4932で実証します。

検証: Terraform fmt/init/validate、Ruff、changelog、focused pytest24件成功。全体pytest10581 passed/4 skipped/2 failedのうち公開schema期待値を修正・再検証し、残りは既存ローカルauthファイル配置に起因する1件です。

Closes #4931
