### PR TITLE
feat(truth-eye): 訓練記録の封印と検証を追加する (#4985)

### DIFF
--- a/changelog.d/4985-truth-eye-seal.added.md
+++ b/changelog.d/4985-truth-eye-seal.added.md
@@ -1,0 +1,1 @@
+- `yt-truth-eye seal` と `verify` を追加し、訓練記録と sha256 封印分析を生成・検証可能にした

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ yt-stream-archive-check = "youtube_automation.entrypoints:yt_stream_archive_chec
 yt-stream-bandwidth = "youtube_automation.entrypoints:yt_stream_bandwidth"
 yt-stream-broadcast-recover = "youtube_automation.entrypoints:yt_stream_broadcast_recover"
 yt-theme-compare = "youtube_automation.entrypoints:yt_theme_compare"
+yt-truth-eye = "youtube_automation.entrypoints:yt_truth_eye"
 yt-ttp-health = "youtube_automation.entrypoints:yt_ttp_health"
 yt-thumbnail-auto-select = "youtube_automation.entrypoints:yt_thumbnail_auto_select"
 yt-thumbnail-check = "youtube_automation.entrypoints:yt_thumbnail_check"

--- a/src/youtube_automation/commands/analytics/truth_eye.py
+++ b/src/youtube_automation/commands/analytics/truth_eye.py
@@ -6,6 +6,7 @@ import argparse
 import json
 from pathlib import Path
 
+from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.core.errors import ValidationError
 from youtube_automation.domains.analytics.truth_eye import (
     seal_training_record,
@@ -26,8 +27,7 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+def run(args: argparse.Namespace) -> int:
     try:
         if args.command == "seal":
             pair = json.loads(args.pair.read_text(encoding="utf-8"))
@@ -56,6 +56,10 @@ def main(argv: list[str] | None = None) -> int:
     except (OSError, json.JSONDecodeError, ValidationError) as error:
         print(json.dumps({"ok": False, "error": str(error)}, ensure_ascii=False))
         return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    return run_cli(build_parser, run, argv, handled_errors=())
 
 
 if __name__ == "__main__":

--- a/src/youtube_automation/commands/analytics/truth_eye.py
+++ b/src/youtube_automation/commands/analytics/truth_eye.py
@@ -1,0 +1,62 @@
+"""Truth Eye 訓練記録の封印・検証 CLI。"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.analytics.truth_eye import (
+    seal_training_record,
+    validate_sealed_draft,
+    verify_training_record,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Truth Eye 訓練記録の封印分析を管理します")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    seal = subparsers.add_parser("seal", help="承認済みペアと下書きから封印分析・訓練記録を生成")
+    seal.add_argument("--pair", type=Path, required=True, help="承認済みペア JSON の path")
+    seal.add_argument("--sealed-draft", type=Path, required=True, help="封印分析 Markdown 下書きの path")
+    seal.add_argument("--channel-dir", type=Path, default=Path.cwd(), help="チャンネルリポジトリの root")
+    verify = subparsers.add_parser("verify", help="封印分析の sha256 を訓練記録と照合")
+    verify.add_argument("record", type=Path, help="検証する訓練記録 Markdown の path")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        if args.command == "seal":
+            pair = json.loads(args.pair.read_text(encoding="utf-8"))
+            draft_text = args.sealed_draft.read_text(encoding="utf-8")
+            missing = validate_sealed_draft(draft_text)
+            if missing:
+                print(json.dumps({"ok": False, "missing": missing}, ensure_ascii=False))
+                return 1
+            result = seal_training_record(pair, args.sealed_draft, args.channel_dir)
+            print(
+                json.dumps(
+                    {
+                        "ok": True,
+                        "record": str(result.record),
+                        "sealed": str(result.sealed),
+                        "sha256": result.sha256,
+                        "sealed_at": result.sealed_at,
+                    },
+                    ensure_ascii=False,
+                )
+            )
+            return 0
+        result = verify_training_record(args.record)
+        print(json.dumps({"ok": result.ok, "expected": result.expected, "actual": result.actual}))
+        return 0 if result.ok else 1
+    except (OSError, json.JSONDecodeError, ValidationError) as error:
+        print(json.dumps({"ok": False, "error": str(error)}, ensure_ascii=False))
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/youtube_automation/domains/analytics/truth_eye.py
+++ b/src/youtube_automation/domains/analytics/truth_eye.py
@@ -1,0 +1,189 @@
+"""Truth Eye 訓練記録と封印分析のドメイン規則。"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from youtube_automation.core.errors import ValidationError
+
+
+@dataclass(frozen=True)
+class Viewpoint:
+    id: str
+    name: str
+    required: bool
+
+
+VIEWPOINTS: tuple[Viewpoint, ...] = (
+    Viewpoint("V01", "主役と占有率", True),
+    Viewpoint("V02", "構図・視線の流れ", True),
+    Viewpoint("V03", "配色", True),
+    Viewpoint("V04", "文字", True),
+    Viewpoint("V05", "表情・感情", True),
+    Viewpoint("V06", "縮小耐性", True),
+    Viewpoint("V07", "小道具・状況", False),
+    Viewpoint("V08", "季節感・時間帯", False),
+    Viewpoint("V09", "余白", False),
+    Viewpoint("V10", "シリーズ性", False),
+    Viewpoint("V11", "サムネ外の要因", False),
+    Viewpoint("V12", "刺激している欲求", False),
+)
+
+_VIDEO_FIELDS = ("video_id", "title", "views", "published_at", "duration")
+_SAFE_STEM_PART = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+@dataclass(frozen=True)
+class SealResult:
+    record: Path
+    sealed: Path
+    sha256: str
+    sealed_at: str
+
+
+@dataclass(frozen=True)
+class VerificationResult:
+    ok: bool
+    expected: str
+    actual: str
+
+
+def validate_sealed_draft(text: str) -> list[str]:
+    """封印分析の固定フォーマットについて欠落項目を返す。"""
+    missing: list[str] = []
+    lines = text.splitlines()
+    for viewpoint in VIEWPOINTS:
+        matching = [line for line in lines if re.match(rf"^\|\s*{viewpoint.id}\s*\|", line)]
+        if not matching:
+            missing.append(viewpoint.id)
+            continue
+        cells = [cell.strip() for cell in matching[0].strip().strip("|").split("|")]
+        if len(cells) < 3 or not cells[1]:
+            missing.append(f"{viewpoint.id}:winner")
+        if len(cells) < 3 or not cells[2]:
+            missing.append(f"{viewpoint.id}:loser")
+
+    abstraction = _section_body(text, "抽象化")
+    if not abstraction:
+        missing.append("abstraction")
+    contribution = _section_body(text, "再生数差への寄与順位")
+    ranked_ids = re.findall(r"\bV(?:0[1-9]|1[0-2])\b", contribution)
+    if len(ranked_ids) < 3 or len(set(ranked_ids[:3])) < 3:
+        missing.append("contribution_rank_top_3")
+    return missing
+
+
+def seal_training_record(
+    pair: dict,
+    sealed_draft: Path,
+    channel_dir: Path,
+    *,
+    now: datetime | None = None,
+) -> SealResult:
+    """検証済み下書きを封印し、人間が記入する訓練記録を生成する。"""
+    pair_metadata = _validate_pair(pair)
+    draft_text = sealed_draft.read_text(encoding="utf-8")
+    missing = validate_sealed_draft(draft_text)
+    if missing:
+        raise ValidationError(f"封印分析の必須項目が不足しています: {', '.join(missing)}")
+
+    timestamp = now or datetime.now(UTC)
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    timestamp = timestamp.astimezone(UTC)
+    channel = pair_metadata["channel"]
+    winner_id = pair_metadata["winner"]["video_id"]
+    stem = f"{timestamp:%Y%m%d}-thumbnail-{channel}-{winner_id}"
+    training_dir = channel_dir / "docs" / "benchmarks" / "training"
+    record = training_dir / f"{stem}.md"
+    sealed = training_dir / f"{stem}.sealed.md"
+    if record.exists() or sealed.exists():
+        raise ValidationError(f"同名の訓練記録または封印分析が既に存在します: {stem}")
+
+    digest = hashlib.sha256(sealed_draft.read_bytes()).hexdigest()
+    sealed_at = timestamp.isoformat().replace("+00:00", "Z")
+    metadata = {
+        "schema_version": 1,
+        "menu": "thumbnail",
+        "channel": channel,
+        "pair": {side: pair_metadata[side] for side in ("winner", "loser")},
+        "sealed": {"path": sealed.name, "sha256": digest, "sealed_at": sealed_at},
+        "next_try": None,
+    }
+    training_dir.mkdir(parents=True, exist_ok=True)
+    sealed_draft.replace(sealed)
+    record.write_text(_render_record(metadata), encoding="utf-8")
+    return SealResult(record, sealed, digest, sealed_at)
+
+
+def verify_training_record(record: Path) -> VerificationResult:
+    """記録 frontmatter と隣接する封印分析の sha256 を照合する。"""
+    metadata = _read_frontmatter(record)
+    sealed = metadata.get("sealed")
+    if not isinstance(sealed, dict):
+        raise ValidationError("frontmatter.sealed が object ではありません")
+    expected = sealed.get("sha256")
+    relative_path = sealed.get("path")
+    if not isinstance(expected, str) or not expected:
+        raise ValidationError("frontmatter.sealed.sha256 がありません")
+    if not isinstance(relative_path, str) or Path(relative_path).name != relative_path:
+        raise ValidationError("frontmatter.sealed.path は同じディレクトリのファイル名で指定してください")
+    actual = hashlib.sha256((record.parent / relative_path).read_bytes()).hexdigest()
+    return VerificationResult(expected == actual, expected, actual)
+
+
+def _validate_pair(pair: dict) -> dict:
+    if not isinstance(pair, dict):
+        raise ValidationError("pair JSON は object で指定してください")
+    channel = pair.get("channel")
+    if not isinstance(channel, str) or not _SAFE_STEM_PART.fullmatch(channel):
+        raise ValidationError("channel はファイル名に使える競合 slug で指定してください")
+    normalized: dict = {"channel": channel}
+    for side in ("winner", "loser"):
+        video = pair.get(side)
+        if not isinstance(video, dict):
+            raise ValidationError(f"{side} は object で指定してください")
+        absent = [field for field in _VIDEO_FIELDS if field not in video]
+        if absent:
+            raise ValidationError(f"{side} の必須項目が不足しています: {', '.join(absent)}")
+        video_id = video["video_id"]
+        if not isinstance(video_id, str) or not _SAFE_STEM_PART.fullmatch(video_id):
+            raise ValidationError(f"{side}.video_id はファイル名に使える値で指定してください")
+        normalized[side] = {field: video[field] for field in _VIDEO_FIELDS}
+    return normalized
+
+
+def _section_body(text: str, heading: str) -> str:
+    match = re.search(rf"^##\s+{re.escape(heading)}\s*$\n(.*?)(?=^##\s|\Z)", text, re.MULTILINE | re.DOTALL)
+    return match.group(1).strip() if match else ""
+
+
+def _render_record(metadata: dict) -> str:
+    frontmatter = yaml.safe_dump(metadata, allow_unicode=True, sort_keys=False).rstrip()
+    rows = ["| 観点 ID | 観点名 | 伸びた側 | 伸びなかった側 |", "|---|---|---|---|"]
+    rows.extend(f"| {item.id} | {item.name} |  |  |" for item in VIEWPOINTS if item.required)
+    phases = ["## Phase 0", "## Phase 1\n\n" + "\n".join(rows)]
+    phases.extend(f"## Phase {number}" for number in range(2, 6))
+    return f"---\n{frontmatter}\n---\n\n" + "\n\n".join(phases) + "\n"
+
+
+def _read_frontmatter(path: Path) -> dict:
+    text = path.read_text(encoding="utf-8")
+    if not text.startswith("---\n"):
+        raise ValidationError("訓練記録に YAML frontmatter がありません")
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        raise ValidationError("訓練記録の YAML frontmatter が閉じられていません")
+    try:
+        metadata = yaml.safe_load(parts[1])
+    except yaml.YAMLError as error:
+        raise ValidationError(f"訓練記録の YAML frontmatter が不正です: {error}") from error
+    if not isinstance(metadata, dict):
+        raise ValidationError("訓練記録の YAML frontmatter は object で指定してください")
+    return metadata

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -155,6 +155,7 @@ yt_stream_archive_check = _make_entrypoint("youtube_automation.commands.youtube.
 yt_stream_bandwidth = _make_entrypoint("youtube_automation.commands.youtube.stream_bandwidth")
 yt_stream_broadcast_recover = _make_entrypoint("youtube_automation.commands.youtube.stream_broadcast_recover")
 yt_theme_compare = _make_entrypoint("youtube_automation.commands.analytics.theme_compare")
+yt_truth_eye = _make_entrypoint("youtube_automation.commands.analytics.truth_eye")
 yt_ttp_health = _make_entrypoint("youtube_automation.commands.analytics.ttp_health")
 yt_thumbnail_auto_select = _make_entrypoint("youtube_automation.commands.thumbnail.auto_select_thumbnail")
 yt_traffic_trend = _make_entrypoint("youtube_automation.commands.analytics.traffic_trend")

--- a/tests/commands/analytics/test_truth_eye_cli.py
+++ b/tests/commands/analytics/test_truth_eye_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import json
+
+from youtube_automation.commands.analytics.truth_eye import main
+from youtube_automation.domains.analytics.truth_eye import VIEWPOINTS
+
+
+def _draft() -> str:
+    rows = ["| 観点 ID | 伸びた側 | 伸びなかった側 |", "|---|---|---|"]
+    rows.extend(f"| {item.id} | winner | loser |" for item in VIEWPOINTS)
+    return "\n".join(rows) + "\n## 抽象化\nprinciple\n## 再生数差への寄与順位\n1. V01\n2. V02\n3. V03\n"
+
+
+def test_seal_failure_prints_missing_items_as_json(tmp_path, capsys):
+    pair = tmp_path / "pair.json"
+    pair.write_text(
+        json.dumps(
+            {
+                "channel": "reference",
+                "winner": {
+                    "video_id": "win",
+                    "title": "W",
+                    "views": 10,
+                    "published_at": "2026-01-01",
+                    "duration": "PT1M",
+                },
+                "loser": {
+                    "video_id": "lose",
+                    "title": "L",
+                    "views": 1,
+                    "published_at": "2026-01-01",
+                    "duration": "PT1M",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    draft = tmp_path / "draft.md"
+    draft.write_text(_draft().replace("| V07 | winner | loser |\n", ""), encoding="utf-8")
+
+    exit_code = main(["seal", "--pair", str(pair), "--sealed-draft", str(draft), "--channel-dir", str(tmp_path)])
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code != 0
+    assert output == {"ok": False, "missing": ["V07"]}
+    assert draft.exists()
+
+
+def test_verify_cli_returns_nonzero_and_hashes_after_tamper(tmp_path, capsys):
+    sealed = tmp_path / "record.sealed.md"
+    sealed.write_text("changed", encoding="utf-8")
+    record = tmp_path / "record.md"
+    record.write_text("---\nsealed:\n  path: record.sealed.md\n  sha256: deadbeef\n---\n", encoding="utf-8")
+
+    exit_code = main(["verify", str(record)])
+
+    output = json.loads(capsys.readouterr().out)
+    assert exit_code != 0
+    assert output["ok"] is False
+    assert output["expected"] == "deadbeef"
+    assert len(output["actual"]) == 64

--- a/tests/domains/analytics/test_truth_eye.py
+++ b/tests/domains/analytics/test_truth_eye.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+import yaml
+
+from youtube_automation.core.errors import ValidationError
+from youtube_automation.domains.analytics.truth_eye import (
+    VIEWPOINTS,
+    seal_training_record,
+    validate_sealed_draft,
+    verify_training_record,
+)
+
+
+def _draft() -> str:
+    rows = ["| 観点 ID | 伸びた側 | 伸びなかった側 |", "|---|---|---|"]
+    rows.extend(f"| {viewpoint.id} | winner {viewpoint.id} | loser {viewpoint.id} |" for viewpoint in VIEWPOINTS)
+    return "\n".join(rows) + "\n\n## 抽象化\ncontrast principle\n\n## 再生数差への寄与順位\n1. V03\n2. V01\n3. V06\n"
+
+
+def _pair() -> dict:
+    video = {
+        "video_id": "winner-id",
+        "title": "Video title",
+        "views": 12345,
+        "published_at": "2026-09-01",
+        "duration": "PT10M",
+        "thumbnail_path": "/tmp/thumb.jpg",
+    }
+    return {"channel": "competitor", "winner": video, "loser": {**video, "video_id": "loser-id"}}
+
+
+def test_viewpoints_are_single_ordered_source_for_required_phase_one_rows():
+    assert [(item.id, item.name, item.required) for item in VIEWPOINTS] == [
+        ("V01", "主役と占有率", True),
+        ("V02", "構図・視線の流れ", True),
+        ("V03", "配色", True),
+        ("V04", "文字", True),
+        ("V05", "表情・感情", True),
+        ("V06", "縮小耐性", True),
+        ("V07", "小道具・状況", False),
+        ("V08", "季節感・時間帯", False),
+        ("V09", "余白", False),
+        ("V10", "シリーズ性", False),
+        ("V11", "サムネ外の要因", False),
+        ("V12", "刺激している欲求", False),
+    ]
+
+
+def test_seal_writes_record_and_sealed_pair(tmp_path):
+    draft = tmp_path / "draft.md"
+    draft.write_text(_draft(), encoding="utf-8")
+
+    result = seal_training_record(_pair(), draft, tmp_path, now=datetime(2026, 9, 6, 12, 34, tzinfo=UTC))
+
+    record = tmp_path / "docs/benchmarks/training/20260906-thumbnail-competitor-winner-id.md"
+    sealed = record.with_suffix(".sealed.md")
+    assert result.record == record
+    assert result.sealed == sealed
+    assert not draft.exists()
+    assert sealed.read_text(encoding="utf-8") == _draft()
+    text = record.read_text(encoding="utf-8")
+    metadata = yaml.safe_load(text.split("---", 2)[1])
+    assert set(metadata) == {"schema_version", "menu", "channel", "pair", "sealed", "next_try"}
+    assert metadata["next_try"] is None
+    assert metadata["sealed"]["sha256"] == hashlib.sha256(sealed.read_bytes()).hexdigest()
+    assert metadata["sealed"]["path"] == sealed.name
+    assert [line.split("|")[1].strip() for line in text.splitlines() if line.startswith("| V")] == [
+        item.id for item in VIEWPOINTS if item.required
+    ]
+    assert [line for line in text.splitlines() if line.startswith("## Phase ")] == [
+        f"## Phase {number}" for number in range(6)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("draft", "missing"),
+    [
+        (_draft().replace("| V12 | winner V12 | loser V12 |\n", ""), "V12"),
+        (_draft().replace("2. V01\n3. V06\n", ""), "contribution_rank_top_3"),
+        (_draft().replace("| V04 | winner V04 | loser V04 |", "| V04 | winner V04 | |"), "V04:loser"),
+    ],
+)
+def test_validate_sealed_draft_reports_missing_parts(draft, missing):
+    assert missing in validate_sealed_draft(draft)
+
+
+def test_seal_rejects_malformed_draft_without_outputs(tmp_path):
+    draft = tmp_path / "draft.md"
+    draft.write_text(_draft().replace("| V12 | winner V12 | loser V12 |\n", ""), encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="V12"):
+        seal_training_record(_pair(), draft, tmp_path, now=datetime(2026, 9, 6, tzinfo=UTC))
+
+    assert draft.exists()
+    assert not (tmp_path / "docs/benchmarks/training").exists()
+
+
+def test_seal_refuses_to_overwrite_existing_stem(tmp_path):
+    training = tmp_path / "docs/benchmarks/training"
+    training.mkdir(parents=True)
+    record = training / "20260906-thumbnail-competitor-winner-id.md"
+    record.write_text("original", encoding="utf-8")
+    draft = tmp_path / "draft.md"
+    draft.write_text(_draft(), encoding="utf-8")
+
+    with pytest.raises(ValidationError, match="既に存在"):
+        seal_training_record(_pair(), draft, tmp_path, now=datetime(2026, 9, 6, tzinfo=UTC))
+
+    assert record.read_text(encoding="utf-8") == "original"
+    assert draft.exists()
+
+
+def test_verify_detects_tampering(tmp_path):
+    draft = tmp_path / "draft.md"
+    draft.write_text(_draft(), encoding="utf-8")
+    result = seal_training_record(_pair(), draft, tmp_path, now=datetime(2026, 9, 6, tzinfo=UTC))
+    result.sealed.write_text(_draft() + "tampered", encoding="utf-8")
+
+    verification = verify_training_record(result.record)
+
+    assert verification.ok is False
+    assert verification.expected != verification.actual

--- a/tests/repo/test_skill_api_call_estimate_contract.py
+++ b/tests/repo/test_skill_api_call_estimate_contract.py
@@ -135,6 +135,7 @@ NON_BILLED_CLIS: dict[str, str] = {
     "yt-suno-verify": "ローカル成果物検証のみ",
     "yt-suno-verify-playlist": "ローカル成果物検証のみ",
     "yt-theme-compare": "収集済みデータのローカル分析のみ",
+    "yt-truth-eye": "ローカルの benchmark・訓練記録・封印ファイルの読み書きと Git commit のみ",
     "yt-ttp-health": "収集済み benchmark_*.json のローカル分析のみ",
     "yt-thumbnail-auto-select": "ローカルのサムネイル採点・選定のみ",
     "yt-thumbnail-correlate": "CDN 画像 DL + ローカル相関計算のみ",

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -92,6 +92,7 @@ EXPECTED_ENTRYPOINT_MODULES = {
     "yt-stream-bandwidth": "youtube_automation.commands.youtube.stream_bandwidth",
     "yt-stream-broadcast-recover": "youtube_automation.commands.youtube.stream_broadcast_recover",
     "yt-theme-compare": "youtube_automation.commands.analytics.theme_compare",
+    "yt-truth-eye": "youtube_automation.commands.analytics.truth_eye",
     "yt-ttp-health": "youtube_automation.commands.analytics.ttp_health",
     "yt-thumbnail-auto-select": "youtube_automation.commands.thumbnail.auto_select_thumbnail",
     "yt-thumbnail-check": "youtube_automation.commands.thumbnail.thumbnail_check",


### PR DESCRIPTION
## Summary
- yt-truth-eye seal / verify を追加
- 封印下書きの検証と sha256 付き訓練記録生成を実装
- CLI・ドメインテストと changelog fragment を追加

Closes #4985