### PR TITLE
refactor: doctorのworkspace専用診断を削除する (#4916)

### DIFF
--- a/changelog.d/4916-doctor-workspace.removed.md
+++ b/changelog.d/4916-doctor-workspace.removed.md
@@ -1,0 +1,1 @@
+- `yt-doctor` の workspace 共有 root に対する bootstrap 診断・修復と `oauth_client_sharing` 診断を削除しました。対象は `--target` → `CHANNEL_DIR` → cwd のチャンネル祖先（未設定なら cwd）で解決し、旧 `CHANNEL` / 共通 `--channel` による切り替えを行わず、診断・`--apply` は対象チャンネル内で実行します。

--- a/src/youtube_automation/application/channel_readiness/checks.py
+++ b/src/youtube_automation/application/channel_readiness/checks.py
@@ -29,10 +29,6 @@ from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from httplib2 import HttpLib2Error
 
-from youtube_automation.configuration import (
-    find_workspace_root,
-    workspace_channels,
-)
 from youtube_automation.configuration.skills import load_skill_config
 from youtube_automation.core.errors import (
     AutomationError,
@@ -129,7 +125,6 @@ class CwdSemantics(Enum):
     """apply command を実行する基準ディレクトリ。"""
 
     CHANNEL = "channel"
-    BOOTSTRAP_ROOT = "bootstrap-root"
 
 
 class _ActionMapping(Mapping):
@@ -255,7 +250,7 @@ class CheckDefinition:
     cwd_semantics: CwdSemantics
 
     def command_cwd(self, channel_dir: Path) -> Path:
-        return _bootstrap_root(channel_dir) if self.cwd_semantics is CwdSemantics.BOOTSTRAP_ROOT else channel_dir
+        return channel_dir
 
 
 def _ai_exec_action(
@@ -559,21 +554,6 @@ def _agents_skills_link_is_valid(channel_dir: Path, skills_dir: Path) -> bool:
         return False
 
 
-def _workspace_root_for_channel(channel_dir: Path) -> Path | None:
-    """登録済み workspace channel の共有 root だけを返す."""
-    resolved_channel = channel_dir.resolve()
-    workspace_root = find_workspace_root(resolved_channel)
-    if workspace_root is None:
-        return None
-    registered_channels = {path.resolve() for path in workspace_channels(workspace_root).values()}
-    return workspace_root if resolved_channel in registered_channels else None
-
-
-def _bootstrap_root(channel_dir: Path) -> Path:
-    """共有 tool / skill を検査・更新する repository root を返す."""
-    return _workspace_root_for_channel(channel_dir) or channel_dir
-
-
 # --- checks ---
 
 
@@ -637,7 +617,7 @@ def check_uv() -> CheckResult:
 
 
 def check_uv_project(channel_dir: Path) -> CheckResult:
-    pyproject_path = _bootstrap_root(channel_dir) / PYPROJECT_FILENAME
+    pyproject_path = channel_dir / PYPROJECT_FILENAME
     if not pyproject_path.exists():
         installation_mode = _running_global_installation_mode()
         if installation_mode is not None:
@@ -665,7 +645,7 @@ def check_uv_project(channel_dir: Path) -> CheckResult:
 
 
 def check_automation_package(channel_dir: Path) -> CheckResult:
-    pyproject_path = _bootstrap_root(channel_dir) / PYPROJECT_FILENAME
+    pyproject_path = channel_dir / PYPROJECT_FILENAME
     if not pyproject_path.exists():
         installation_mode = _running_global_installation_mode()
         if installation_mode is not None:
@@ -735,8 +715,7 @@ def check_automation_package(channel_dir: Path) -> CheckResult:
 
 
 def check_skills_synced(channel_dir: Path) -> CheckResult:
-    bootstrap_root = _bootstrap_root(channel_dir)
-    skills_dir = bootstrap_root / CLAUDE_SKILLS_DIR
+    skills_dir = channel_dir / CLAUDE_SKILLS_DIR
     bundled_skills = bundled_skill_names()
     for legacy_skill in LEGACY_BUNDLED_SKILLS:
         if (skills_dir / legacy_skill / SKILL_FILENAME).exists():
@@ -751,7 +730,7 @@ def check_skills_synced(channel_dir: Path) -> CheckResult:
     if missing_skill_files:
         sample = ", ".join(str(CLAUDE_SKILLS_DIR / path) for path in missing_skill_files[:5])
         return _skills_sync_failure(f"同梱 skill が未展開: {sample}")
-    if not _agents_skills_link_is_valid(bootstrap_root, skills_dir):
+    if not _agents_skills_link_is_valid(channel_dir, skills_dir):
         return _skills_sync_warning(f"{AGENTS_SKILLS_LINK} が {CLAUDE_SKILLS_DIR} を指す symlink になっていない")
     return CheckResult(
         id="skills_synced",
@@ -768,14 +747,13 @@ def check_numbered_duplicates(channel_dir: Path) -> CheckResult:
     yt-skills sync が同名上書きで管理する領域のため、`<名前> <数字>` 形式が
     現れたら外部要因 (同期サービス) による汚染とみなす (#1409 / #1410)。
     """
-    bootstrap_root = _bootstrap_root(channel_dir)
     findings: list[str] = []
     scan_targets = (
-        (".venv/bin", bootstrap_root / ".venv" / "bin", False),
-        (str(CLAUDE_SKILLS_DIR), bootstrap_root / CLAUDE_SKILLS_DIR, True),
+        (".venv/bin", channel_dir / ".venv" / "bin", False),
+        (str(CLAUDE_SKILLS_DIR), channel_dir / CLAUDE_SKILLS_DIR, True),
     )
     for label, directory, recursive in scan_targets:
-        result = scan_numbered_duplicates(directory, recursive=recursive, root_boundary=bootstrap_root)
+        result = scan_numbered_duplicates(directory, recursive=recursive, root_boundary=channel_dir)
         if result.duplicates:
             sample = ", ".join(format_duplicate_name(path) for path in result.duplicates[:3])
             findings.append(f"{label} に {len(result.duplicates)} 件 (例: {sample})")
@@ -1166,34 +1144,6 @@ def check_client_secrets(channel_dir: Path) -> CheckResult:
     return CheckResult(id="client_secrets", status="ok", message="client_secrets.json 構造妥当")
 
 
-def check_oauth_client_sharing(channel_dir: Path) -> CheckResult:
-    """per-channel OAuth client を workspace ルートで共有できる場合に案内する。"""
-    workspace_root = find_workspace_root(channel_dir)
-    channels = workspace_channels(workspace_root) if workspace_root is not None else {}
-    if workspace_root is None or channel_dir.resolve() not in {path.resolve() for path in channels.values()}:
-        return CheckResult(
-            id="oauth_client_sharing",
-            status="ok",
-            message="単一チャンネル構成のため OAuth クライアント共有診断は対象外",
-        )
-
-    per_channel_secrets = [slug for slug, path in channels.items() if (path / "auth" / "client_secrets.json").is_file()]
-    if len(per_channel_secrets) < 2:
-        return CheckResult(
-            id="oauth_client_sharing",
-            status="ok",
-            message="個別 OAuth クライアントを持つ workspace チャンネルは複数ありません",
-        )
-
-    shared_path = workspace_root / "auth" / "client_secrets.json"
-    return CheckResult(
-        id="oauth_client_sharing",
-        status="info",
-        message=(f"OAuth クライアントをルート共有（{shared_path}）へ統合可能。統合には全チャンネルの再認証が必要"),
-        data={"channels": per_channel_secrets, "shared_path": str(shared_path)},
-    )
-
-
 def _oauth_failure_action(state: OAuthCredentialState) -> dict | None:
     if not state.reauthentication_required:
         return None
@@ -1308,7 +1258,7 @@ def check_reporting_job(channel_dir: Path) -> CheckResult:
 
 def check_streaming_vps_state(channel_dir: Path) -> CheckResult:
     """Vultr 上の streaming VPS と全 GCS workspace state を突合する。"""
-    terraform_dir = _bootstrap_root(channel_dir) / "infra" / "terraform" / "streaming"
+    terraform_dir = channel_dir / "infra" / "terraform" / "streaming"
     if not terraform_dir.is_dir():
         return CheckResult(
             id="streaming_vps_state",

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -40,12 +40,6 @@ from youtube_automation.application.channel_readiness.checks import (
     _subprocess_run as _run,
 )
 from youtube_automation.commands.system.skills_sync import bundled_skill_names
-from youtube_automation.configuration import (
-    channel_dir,
-    explicit_channel_selection,
-    find_workspace_root,
-)
-from youtube_automation.core.errors import ConfigError
 
 # Public compatibility exports. Check implementations live in the readiness application module,
 # while existing callers can continue importing the result/action vocabulary here.
@@ -105,7 +99,6 @@ check_gcp_project = _domain_check("check_gcp_project")
 check_iam_aiplatform_user = _domain_check("check_iam_aiplatform_user")
 check_initial_setup_readiness = _domain_check("check_initial_setup_readiness")
 check_numbered_duplicates = _domain_check("check_numbered_duplicates")
-check_oauth_client_sharing = _domain_check("check_oauth_client_sharing")
 check_oauth_token = _domain_check("check_oauth_token")
 check_oauth_token_readonly = _domain_check("check_oauth_token_readonly")
 check_playlist_config = _domain_check("check_playlist_config")
@@ -137,35 +130,33 @@ LEGACY_BUNDLED_SKILLS = (
 
 CHECK_REGISTRY = (
     CheckDefinition(
-        "ffmpeg", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffmpeg), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
+        "ffmpeg", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffmpeg), ApplyKind.NONE, CwdSemantics.CHANNEL
     ),
     CheckDefinition(
-        "ffprobe", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffprobe), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
+        "ffprobe", BOOTSTRAP_CATEGORY, _without_channel_dir(check_ffprobe), ApplyKind.NONE, CwdSemantics.CHANNEL
     ),
-    CheckDefinition(
-        "uv", BOOTSTRAP_CATEGORY, _without_channel_dir(check_uv), ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT
-    ),
-    CheckDefinition("uv_project", BOOTSTRAP_CATEGORY, check_uv_project, ApplyKind.NONE, CwdSemantics.BOOTSTRAP_ROOT),
+    CheckDefinition("uv", BOOTSTRAP_CATEGORY, _without_channel_dir(check_uv), ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition("uv_project", BOOTSTRAP_CATEGORY, check_uv_project, ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition(
         "automation_package",
         BOOTSTRAP_CATEGORY,
         check_automation_package,
         ApplyKind.NONE,
-        CwdSemantics.BOOTSTRAP_ROOT,
+        CwdSemantics.CHANNEL,
     ),
     CheckDefinition(
         "skills_synced",
         BOOTSTRAP_CATEGORY,
         check_skills_synced,
         ApplyKind.AI_EXEC,
-        CwdSemantics.BOOTSTRAP_ROOT,
+        CwdSemantics.CHANNEL,
     ),
     CheckDefinition(
         "numbered_duplicates",
         BOOTSTRAP_CATEGORY,
         check_numbered_duplicates,
         ApplyKind.NONE,
-        CwdSemantics.BOOTSTRAP_ROOT,
+        CwdSemantics.CHANNEL,
     ),
     CheckDefinition("gcloud", API_CATEGORY, _without_channel_dir(check_gcloud), ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition(
@@ -182,9 +173,6 @@ CHECK_REGISTRY = (
         "iam_aiplatform_user", API_CATEGORY, check_iam_aiplatform_user, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL
     ),
     CheckDefinition("client_secrets", API_CATEGORY, check_client_secrets, ApplyKind.NONE, CwdSemantics.CHANNEL),
-    CheckDefinition(
-        "oauth_client_sharing", API_CATEGORY, check_oauth_client_sharing, ApplyKind.NONE, CwdSemantics.CHANNEL
-    ),
     CheckDefinition("oauth_token", API_CATEGORY, check_oauth_token, ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition(
         "oauth_token_readonly", API_CATEGORY, check_oauth_token_readonly, ApplyKind.NONE, CwdSemantics.CHANNEL
@@ -483,19 +471,14 @@ def run_apply(
 def resolve_channel_dir(target: Optional[str]) -> Path:
     if target:
         return Path(target).resolve()
+    env_dir = os.environ.get("CHANNEL_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser().resolve()
     cwd = Path.cwd().resolve()
-    try:
-        return channel_dir().resolve()
-    except ConfigError:
-        selection_requested = (
-            explicit_channel_selection() is not None
-            or bool(os.environ.get("CHANNEL"))
-            or bool(os.environ.get("CHANNEL_DIR"))
-            or find_workspace_root(cwd) is not None
-        )
-        if selection_requested:
-            raise
-        return cwd
+    for parent in (cwd, *cwd.parents):
+        if (parent / "config" / "channel").is_dir():
+            return parent
+    return cwd
 
 
 @dataclass(frozen=True)

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1157,64 +1157,6 @@ class TestSummarize:
         assert s["next_check_id"] is None
 
 
-class TestOAuthClientSharingRecommendation:
-    @staticmethod
-    def _make_channel(workspace: Path, slug: str, *, with_secret: bool = False) -> Path:
-        channel = workspace / "channels" / slug
-        (channel / "config" / "channel").mkdir(parents=True)
-        if with_secret:
-            secret = channel / "auth" / "client_secrets.json"
-            secret.parent.mkdir()
-            secret.write_text("{}", encoding="utf-8")
-        return channel
-
-    def test_info_when_multiple_workspace_channels_have_per_channel_secrets(self, tmp_path):
-        workspace = tmp_path / "workspace"
-        alpha = self._make_channel(workspace, "alpha", with_secret=True)
-        self._make_channel(workspace, "beta", with_secret=True)
-
-        result = doctor.check_oauth_client_sharing(alpha)
-
-        assert result.status == "info"
-        assert result.id == "oauth_client_sharing"
-        assert str(workspace / "auth" / "client_secrets.json") in result.message
-        assert "全チャンネルの再認証が必要" in result.message
-        assert result.data == {
-            "channels": ["alpha", "beta"],
-            "shared_path": str(workspace / "auth/client_secrets.json"),
-        }
-
-    def test_ok_when_only_one_workspace_channel_has_per_channel_secret(self, tmp_path):
-        workspace = tmp_path / "workspace"
-        alpha = self._make_channel(workspace, "alpha", with_secret=True)
-        self._make_channel(workspace, "beta")
-
-        result = doctor.check_oauth_client_sharing(alpha)
-
-        assert result.status == "ok"
-
-    def test_ok_outside_workspace(self, tmp_path):
-        channel = tmp_path / "standalone"
-        (channel / "auth").mkdir(parents=True)
-        (channel / "auth" / "client_secrets.json").write_text("{}", encoding="utf-8")
-
-        result = doctor.check_oauth_client_sharing(channel)
-
-        assert result.status == "ok"
-
-    def test_nested_standalone_repo_is_not_treated_as_workspace_channel(self, tmp_path):
-        workspace = tmp_path / "workspace"
-        alpha = self._make_channel(workspace, "alpha", with_secret=True)
-        self._make_channel(workspace, "beta", with_secret=True)
-        standalone = workspace / "standalone"
-        standalone.mkdir()
-
-        result = doctor.check_oauth_client_sharing(standalone)
-
-        assert alpha != standalone
-        assert result.status == "ok"
-
-
 class TestResolveChannelDir:
     @staticmethod
     def _workspace(tmp_path: Path) -> tuple[Path, Path]:
@@ -1243,23 +1185,22 @@ class TestResolveChannelDir:
         r = doctor.resolve_channel_dir(None)
         assert r == tmp_path.resolve()
 
-    def test_common_channel_selection_resolves_workspace_channel(self, tmp_path, monkeypatch):
+    def test_common_channel_selection_does_not_redirect_doctor(self, tmp_path, monkeypatch):
         from youtube_automation.configuration import select_channel
 
         self._clear_channel_env(monkeypatch)
-        workspace, channel = self._workspace(tmp_path)
+        workspace, _channel = self._workspace(tmp_path)
         monkeypatch.chdir(workspace)
         select_channel("alpha")
 
-        assert doctor.resolve_channel_dir(None) == channel.resolve()
+        assert doctor.resolve_channel_dir(None) == workspace.resolve()
 
-    def test_workspace_root_without_selection_is_rejected(self, tmp_path, monkeypatch):
+    def test_workspace_root_without_selection_uses_cwd(self, tmp_path, monkeypatch):
         self._clear_channel_env(monkeypatch)
         workspace, _channel = self._workspace(tmp_path)
         monkeypatch.chdir(workspace)
 
-        with pytest.raises(ConfigError, match=r"workspace ルート.*--channel"):
-            doctor.resolve_channel_dir(None)
+        assert doctor.resolve_channel_dir(None) == workspace.resolve()
 
     def test_target_remains_higher_priority_than_common_selection(self, tmp_path, monkeypatch):
         from youtube_automation.configuration import select_channel
@@ -1272,6 +1213,40 @@ class TestResolveChannelDir:
         select_channel("alpha")
 
         assert doctor.resolve_channel_dir(str(target)) == target.resolve()
+
+    @pytest.mark.parametrize("selection", ["environment", "explicit"])
+    def test_channel_dir_wins_over_legacy_selection(self, tmp_path, monkeypatch, selection):
+        from youtube_automation.configuration import select_channel
+
+        self._clear_channel_env(monkeypatch)
+        workspace, _channel = self._workspace(tmp_path)
+        target = tmp_path / "standalone"
+        target.mkdir()
+        monkeypatch.chdir(workspace)
+        monkeypatch.setenv("CHANNEL_DIR", str(target))
+        if selection == "environment":
+            monkeypatch.setenv("CHANNEL", "alpha")
+        else:
+            select_channel("alpha")
+
+        assert doctor.resolve_channel_dir(None) == target.resolve()
+
+    def test_legacy_channel_env_does_not_redirect_cwd(self, tmp_path, monkeypatch):
+        self._clear_channel_env(monkeypatch)
+        workspace, _channel = self._workspace(tmp_path)
+        monkeypatch.chdir(workspace)
+        monkeypatch.setenv("CHANNEL", "alpha")
+
+        assert doctor.resolve_channel_dir(None) == workspace.resolve()
+
+    def test_cwd_inside_channel_resolves_channel_ancestor(self, tmp_path, monkeypatch):
+        self._clear_channel_env(monkeypatch)
+        (tmp_path / "config/channel").mkdir(parents=True)
+        nested = tmp_path / "collections/live"
+        nested.mkdir(parents=True)
+        monkeypatch.chdir(nested)
+
+        assert doctor.resolve_channel_dir(None) == tmp_path.resolve()
 
     def test_unconfigured_setup_directory_still_uses_cwd(self, tmp_path, monkeypatch):
         self._clear_channel_env(monkeypatch)
@@ -1342,8 +1317,8 @@ class TestMain:
         payload = json.loads(out)
         assert payload["channel_dir"] == str(tmp_path)
         assert "summary" in payload
-        # 7 bootstrap + 14 api + 3 channel + 5 data + 1 upload = 30
-        assert len(payload["checks"]) == 30
+        # 7 bootstrap + 13 api + 3 channel + 5 data + 1 upload = 29
+        assert len(payload["checks"]) == 29
         for c in payload["checks"]:
             assert c["status"] in ("ok", "info", "warn", "fail", "unknown")
             # category フィールドが JSON に含まれていること
@@ -2232,16 +2207,6 @@ class TestBootstrapChecks:
         assert r.category == "bootstrap"
         assert "uv project" in r.message
 
-    def test_workspace_channel_uses_root_uv_project(self, monkeypatch, tmp_path):
-        workspace, channel = self._workspace_channel(tmp_path)
-        (workspace / "pyproject.toml").write_text('[project]\nname = "workspace"\n', encoding="utf-8")
-        monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: pytest.fail("uv tool list should not run"))
-
-        r = doctor.check_uv_project(channel)
-
-        assert r.status == "ok"
-        assert r.message == "uv project 初期化済み"
-
     def test_automation_package_missing_pyproject_is_fail_with_uv_init(self, monkeypatch, tmp_path):
         monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: (0, "", ""))
         r = doctor.check_automation_package(tmp_path)
@@ -2296,19 +2261,6 @@ class TestBootstrapChecks:
         assert r.status == "ok"
         assert r.category == "bootstrap"
         assert "uv project" in r.message
-
-    def test_workspace_channel_uses_root_automation_dependency(self, monkeypatch, tmp_path):
-        workspace, channel = self._workspace_channel(tmp_path)
-        (workspace / "pyproject.toml").write_text(
-            '[project]\nname = "workspace"\ndependencies = ["youtube-channels-automation"]\n',
-            encoding="utf-8",
-        )
-        monkeypatch.setattr(doctor, "_run", lambda *args, **kwargs: pytest.fail("uv tool list should not run"))
-
-        r = doctor.check_automation_package(channel)
-
-        assert r.status == "ok"
-        assert r.message == "uv project で automation パッケージ導入済み"
 
     def test_automation_package_similar_name_is_fail(self, monkeypatch, tmp_path):
         monkeypatch.setattr(
@@ -2397,31 +2349,6 @@ class TestBootstrapChecks:
         r = doctor.check_skills_synced(tmp_path)
         assert r.status == "ok"
         assert r.category == "bootstrap"
-
-    def test_workspace_channel_uses_root_shared_skills(self, tmp_path, monkeypatch):
-        workspace, channel = self._workspace_channel(tmp_path)
-        monkeypatch.setattr(doctor, "bundled_skill_names", lambda: ["channel-new", "setup"])
-        for skill_name in ["channel-new", "setup"]:
-            skill_dir = workspace / ".claude" / "skills" / skill_name
-            skill_dir.mkdir(parents=True)
-            (skill_dir / "SKILL.md").write_text(f"# {skill_name}", encoding="utf-8")
-        agents_dir = workspace / ".agents"
-        agents_dir.mkdir()
-        (agents_dir / "skills").symlink_to(Path("..") / ".claude" / "skills")
-
-        r = doctor.check_skills_synced(channel)
-
-        assert r.status == "ok"
-        assert r.category == "bootstrap"
-
-    def test_workspace_channel_scans_root_managed_directories(self, tmp_path):
-        workspace, channel = self._workspace_channel(tmp_path)
-        (workspace / ".claude" / "skills").mkdir(parents=True)
-
-        r = doctor.check_numbered_duplicates(channel)
-
-        assert r.status == "ok"
-        assert "走査できません" not in r.message
 
     def test_nested_standalone_channel_does_not_use_outer_workspace_bootstrap(self, tmp_path, monkeypatch):
         workspace, _channel = self._workspace_channel(tmp_path)
@@ -5773,20 +5700,20 @@ class TestStreamingVpsState:
 
 
 class TestRunAllChecksExtended:
-    def test_returns_30_checks(self, monkeypatch, tmp_path):
-        """7 bootstrap + 14 api + 3 channel + 5 data + 1 upload = 計 30 件."""
+    def test_returns_29_checks(self, monkeypatch, tmp_path):
+        """7 bootstrap + 13 api + 3 channel + 5 data + 1 upload = 計 29 件."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
-        assert len(results) == 30
+        assert len(results) == 29
 
-    def test_14_api_checks_present(self, monkeypatch, tmp_path):
-        """streaming VPS state 突合を含む 14 check が api カテゴリにある."""
+    def test_13_api_checks_present(self, monkeypatch, tmp_path):
+        """streaming VPS state 突合を含む 13 check が api カテゴリにある."""
         monkeypatch.setattr(doctor, "_run", lambda *a, **kw: (127, "", "missing"))
         results = doctor.run_all_checks(tmp_path)
         api_results = [r for r in results if r.category == "api"]
-        assert len(api_results) == 14
+        assert len(api_results) == 13
         assert api_results[-1].id == "streaming_vps_state"
-        assert any(r.id == "oauth_client_sharing" for r in api_results)
+        assert all(r.id != "oauth_client_sharing" for r in api_results)
         assert any(r.id == "oauth_token_readonly" for r in api_results)
 
     def test_new_check_ids_present(self, monkeypatch, tmp_path):

--- a/tests/commands/system/test_doctor_apply.py
+++ b/tests/commands/system/test_doctor_apply.py
@@ -92,7 +92,7 @@ def test_apply_executes_ai_step_and_rediagnoses(monkeypatch, tmp_path: Path, cap
     }
 
 
-def test_apply_executes_workspace_bootstrap_step_from_root(monkeypatch, tmp_path: Path, capsys) -> None:
+def test_apply_executes_bootstrap_step_in_channel_even_under_workspace(monkeypatch, tmp_path: Path, capsys) -> None:
     workspace = tmp_path / "workspace"
     channel = workspace / "channels" / "alpha"
     (channel / "config" / "channel").mkdir(parents=True)
@@ -121,7 +121,7 @@ def test_apply_executes_workspace_bootstrap_step_from_root(monkeypatch, tmp_path
     code = doctor.main(["--apply", "--json", "--target", str(channel)])
 
     assert code == 0
-    assert commands == [(["uv", "run", "yt-skills", "sync"], workspace)]
+    assert commands == [(["uv", "run", "yt-skills", "sync"], channel)]
     assert json.loads(capsys.readouterr().out)["apply"]["stop_reason"] == "completed"
 
 

--- a/tests/commands/system/test_doctor_json_contract.py
+++ b/tests/commands/system/test_doctor_json_contract.py
@@ -26,7 +26,6 @@ EXPECTED_CHECK_IDS = (
     "adc_quota_project",
     "iam_aiplatform_user",
     "client_secrets",
-    "oauth_client_sharing",
     "oauth_token",
     "oauth_token_readonly",
     "reporting_job",

--- a/tests/commands/system/test_doctor_registry.py
+++ b/tests/commands/system/test_doctor_registry.py
@@ -23,7 +23,6 @@ EXPECTED_CHECK_IDS = (
     "adc_quota_project",
     "iam_aiplatform_user",
     "client_secrets",
-    "oauth_client_sharing",
     "oauth_token",
     "oauth_token_readonly",
     "reporting_job",
@@ -67,7 +66,7 @@ def test_registry_declares_apply_and_cwd_semantics() -> None:
     assert definitions["billing_linked"].apply_kind is doctor.ApplyKind.BILLING
     assert definitions["skills_synced"].apply_kind is doctor.ApplyKind.AI_EXEC
     assert definitions["channel_config"].apply_kind is doctor.ApplyKind.NONE
-    assert definitions["skills_synced"].cwd_semantics is doctor.CwdSemantics.BOOTSTRAP_ROOT
+    assert all(definition.cwd_semantics is doctor.CwdSemantics.CHANNEL for definition in doctor.CHECK_REGISTRY)
     assert definitions["apis_enabled"].cwd_semantics is doctor.CwdSemantics.CHANNEL
 
 
@@ -87,7 +86,7 @@ def test_new_registry_declaration_drives_run_render_and_apply(monkeypatch, tmp_p
         category="example",
         run=check_example,
         apply_kind=doctor.ApplyKind.AI_EXEC,
-        cwd_semantics=doctor.CwdSemantics.BOOTSTRAP_ROOT,
+        cwd_semantics=doctor.CwdSemantics.CHANNEL,
     )
     monkeypatch.setattr(doctor, "CHECK_REGISTRY", (definition,))
     commands: list[tuple[list[str], Path]] = []
@@ -100,6 +99,6 @@ def test_new_registry_declaration_drives_run_render_and_apply(monkeypatch, tmp_p
     outcome = doctor.run_apply(channel)
 
     assert [result.id for result in outcome.results] == ["example"]
-    assert commands == [(["example", "--fix"], workspace)]
+    assert commands == [(["example", "--fix"], channel)]
     assert "=== example ===" in doctor.render_table(outcome.results, doctor.summarize(outcome.results), channel)
     assert doctor._check_result_to_dict(outcome.results[0])["category"] == "example"

--- a/tests/commands/system/test_setup_chain_state.py
+++ b/tests/commands/system/test_setup_chain_state.py
@@ -496,7 +496,7 @@ def test_unrelated_informational_doctor_check_does_not_change_tool_decision(tmp_
     manifest = state.load_manifest(MANIFEST)
     _write_file_artifacts(tmp_path, manifest["steps"][0]["outputArtifacts"])
     checks = _checks(state)
-    checks.append(doctor.CheckResult(id="oauth_client_sharing", status="info", message="shared client available"))
+    checks.append(doctor.CheckResult(id="streaming_vps_state", status="info", message="streaming module absent"))
 
     code, result = state.evaluate(tmp_path, checks, manifest, "tool")
 


### PR DESCRIPTION
doctor の workspace 専用判定を削除し、診断と修復を対象チャンネルのリポジトリ内に統一します。共有 root の bootstrap helper と `BOOTSTRAP_ROOT`、`oauth_client_sharing` の本体・登録を削除し、bootstrap 7診断と streaming の Terraform 参照先を対象チャンネルに揃えます。

対象解決は `--target` → `CHANNEL_DIR` → cwd のチャンネル祖先（未設定なら cwd）です。共通設定ローダーを呼び続けると旧 `CHANNEL` / 共通 `--channel` による選択が残るため、doctor 内で単一リポジトリの解決を行います。共通ローダーの workspace 検出本体（B5）と OAuth ファイル探索順（B3）は変更しません。

診断は `oauth_client_sharing` の1件だけ減り、29件になります。JSON・registry・setup chain の契約を更新し、旧選択による対象変更を防ぐ回帰テストと `--apply` の実行先テストを追加・更新しました。

検証:
- 既存の診断一覧・apply テストと対象解決テストで Red → Green を確認。
- 対象実装の `BOOTSTRAP_ROOT` / `oauth_client_sharing` / `find_workspace_root` 検索結果0件。
- ruff check / format、changelog 検証が成功。
- `nix develop --command uv run pytest -q`: **10,519 passed / 4 skipped**。

Closes #4916
