### PR TITLE
refactor(doctor): GCP 層を読み取り専用化する (#4933)

### DIFF
--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -123,27 +123,11 @@ uv run yt-doctor --apply --json --project-id <project-id>
 
 #### `billing_linked` — billing 未紐付け
 
-AI が利用可能な account を取得し、利用者に決定を依頼する:
-
-1. `gcloud beta billing accounts list --format=json` で利用可能 billing account を取得
-2. `open: true` のものだけを表で利用者に提示し、どれを使うか選ばせる
-3. 選択された ID を `apply_flags` へ仮追加し、必ず先に「GCP 変更 plan の承認」へ戻る。project / billing account と新たに実行可能になる全変更を再表示し、AskUserQuestion で実行が承認された後だけ次を再実行する。中止ならここで停止する:
-
-```bash
-uv run yt-doctor --json
-```
-
-billing account が 1 つも無い利用者には、Console URL (`https://console.cloud.google.com/billing`) を提示して billing account 自体の作成を依頼。
+GCP 層は上流 `infra/terraform/gcp/` が管理する。fail なら `next_action.url` の README に従って上流で plan → apply を行い、完了後に `uv run yt-doctor --json` で再診断する。
 
 #### `apis_enabled` — 必須 API 未有効
 
-`--apply` が以下を自動実行:
-
-```bash
-gcloud services enable youtube.googleapis.com youtubeanalytics.googleapis.com youtubereporting.googleapis.com aiplatform.googleapis.com generativelanguage.googleapis.com --project=<project-id>
-```
-
-billing 未紐付けで失敗する場合は `billing_linked` に戻る。
+GCP 層は上流 `infra/terraform/gcp/` が管理する。fail なら `next_action.url` の README に従って上流で plan → apply を行い、完了後に `uv run yt-doctor --json` で再診断する。
 
 #### `adc` — Application Default Credentials 未設定
 
@@ -171,15 +155,7 @@ gcloud auth application-default set-quota-project <project-id>
 
 #### `iam_aiplatform_user` — Vertex AI 権限未付与
 
-`--apply` が以下を自動実行 (active アカウントは `gcloud auth list` で取得):
-
-```bash
-gcloud projects add-iam-policy-binding <project-id> \
-  --member=user:<active-account> \
-  --role=roles/aiplatform.user \
-  --condition=None \
-  --quiet
-```
+GCP 層は上流 `infra/terraform/gcp/` が管理する。fail なら `next_action.url` の README に従って上流で plan → apply を行い、完了後に `uv run yt-doctor --json` で再診断する。
 
 #### `client_secrets` — OAuth クライアント秘密ファイル未配置
 

--- a/.claude/skills/setup/references/check-runbook.md
+++ b/.claude/skills/setup/references/check-runbook.md
@@ -130,7 +130,7 @@ AI が利用可能な account を取得し、利用者に決定を依頼する:
 3. 選択された ID を `apply_flags` へ仮追加し、必ず先に「GCP 変更 plan の承認」へ戻る。project / billing account と新たに実行可能になる全変更を再表示し、AskUserQuestion で実行が承認された後だけ次を再実行する。中止ならここで停止する:
 
 ```bash
-uv run yt-doctor --apply --json --project-id <project-id> --billing-account <billing-id>
+uv run yt-doctor --json
 ```
 
 billing account が 1 つも無い利用者には、Console URL (`https://console.cloud.google.com/billing`) を提示して billing account 自体の作成を依頼。

--- a/.claude/skills/setup/references/tool.md
+++ b/.claude/skills/setup/references/tool.md
@@ -81,7 +81,7 @@
 
 ### GCP 変更 plan の承認
 
-project ID が解決済み、または `apply_flags` へ `--project-id` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、billing account ID（決定済みの場合）、active account と、§Steps に記載した project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成のうち未解決の全コマンドを展開して表示する。
+project ID が解決済み、または `apply_flags` へ `--project-id` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、active account と、§Steps に記載した project 選択・ADC quota project・Reporting job 作成のうち未解決の全コマンドを展開して表示する。Billing 紐付け・API 有効化・IAM 付与は上流 Terraform の担当であり、この plan と doctor の実行対象に含めない。
 
 表示後、「これらは project `<project-id>` の外部 GCP 状態を変更する」と警告し、AskUserQuestion で「表示した GCP 変更を実行」/「中止」の 2 択を提示する。承認されるまで flag 付き `--apply` を実行しない。値の追加・変更は前回の承認を無効にし、必ず plan を再表示して承認を取り直す。
 

--- a/.claude/skills/setup/references/tool.md
+++ b/.claude/skills/setup/references/tool.md
@@ -74,14 +74,14 @@
 8. 承認後、収集済み決定 flag を保持する `apply_flags` を空で初期化し、`uv run yt-doctor --apply --json <apply_flags>` を 1 回実行して JSON の `apply.stop_reason` を読む。初回は flag 無しの `uv run yt-doctor --apply --json` となる
 9. `completed`: 冒頭の「完了条件」を確認し、「運用設定インタビュー」後に「完了時」を報告する
 10. `human_required`: `apply.check_id` の §Steps を参照する。`apply.next_action.reason == "authentication"` なら `apply.next_action.cmd` を AI が対話 session で起動してから、ブラウザ認証だけを `[HUMAN STEP]` として依頼する。その他は対応する `[HUMAN STEP]` を 1 つだけ依頼して停止する。認証コマンドまたは人間操作の完了後、必要な後処理と現在の `apply_flags` をすべて付けた手順 8 の再診断は AI が行う。`analytics_report` stale の例外は「完了条件」に従う
-11. `decision_required`: `apply.check_id` が `gcp_project` なら project ID、`billing_linked` なら billing account ID を利用者に 1 問で確認する。値を `apply_flags` へ仮追加または同名 flag の値を仮置換し、後述の「GCP 変更 plan の承認」で、その flag により新たに実行可能になる全コマンドと正確な project / account を再表示する。AskUserQuestion の「表示した GCP 変更を実行」/「中止」の 2 択で承認された後だけ flag を確定して再実行する。以後 `completed` まで全 flag を毎回付け、値を変更するたびに plan を再表示・再承認する。project と billing が両方決定済みなら `uv run yt-doctor --apply --json --project-id <project-id> --billing-account <billing-id>` となる
+11. `decision_required`: `apply.check_id` が `gcp_project` なら project ID を利用者に 1 問で確認する。値を `apply_flags` へ仮追加または同名 flag の値を仮置換し、後述の「GCP 変更 plan の承認」で、その flag により新たに実行可能になる全コマンドと正確な project / account を再表示する。AskUserQuestion の「表示した GCP 変更を実行」/「中止」の 2 択で承認された後だけ flag を確定して再実行する。以後 `completed` まで全 flag を毎回付け、値を変更するたびに plan を再表示・再承認する。project が決定済みなら `uv run yt-doctor --apply --json --project-id <project-id>` となる
 12. `command_failed`: `apply.check_id` / `apply.cmd` / `apply.stderr` を利用者に示し、AI が §Steps に沿って原因を診断・解消してから、現在の `apply_flags` をすべて付けて手順 8 を再実行する。認証・承認入力以外のコマンドを利用者へ委ねない
 
 `--apply` は `ai-exec` を診断順に連続実行し、各コマンド後に再診断する。AI は `apply.executed` を実行済み履歴として読み、§Steps に残る同じ `ai-exec` コマンドを重複実行してはならない。`stop_reason` が上記 4 値以外、または JSON が読めない場合は安全側に停止し、CLI 出力を示す。
 
 ### GCP 変更 plan の承認
 
-project ID が解決済み、または `apply_flags` へ `--project-id` / `--billing-account` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、billing account ID（決定済みの場合）、active account と、§Steps に記載した project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成のうち未解決の全コマンドを展開して表示する。
+project ID が解決済み、または `apply_flags` へ `--project-id` を追加・変更するたびに、次回 `--apply` が連続診断で到達し得る変更 plan を承認前に再作成する。`gcloud auth list` で active account を読み取り、正確な project ID、billing account ID（決定済みの場合）、active account と、§Steps に記載した project 選択・Billing 紐付け・API 有効化・ADC quota project・IAM 付与・Reporting job 作成のうち未解決の全コマンドを展開して表示する。
 
 表示後、「これらは project `<project-id>` の外部 GCP 状態を変更する」と警告し、AskUserQuestion で「表示した GCP 変更を実行」/「中止」の 2 択を提示する。承認されるまで flag 付き `--apply` を実行しない。値の追加・変更は前回の承認を無効にし、必ず plan を再表示して承認を取り直す。
 

--- a/changelog.d/4933-doctor-gcp-readonly.removed.md
+++ b/changelog.d/4933-doctor-gcp-readonly.removed.md
@@ -1,1 +1,2 @@
 - yt-doctor の GCP 診断を読み取り専用にし、未設定時は上流 Terraform での修復を案内する。--billing-account と GCP 変更の自動実行を削除し、--project-id によるマシン側の project 選択と ADC quota project 設定は維持する。
+- --apply の gcp_project step は、--project-id を選択しても project が解決しない場合に gcloud config set project を繰り返さず、上流 Terraform 誘導の human で停止する。

--- a/changelog.d/4933-doctor-gcp-readonly.removed.md
+++ b/changelog.d/4933-doctor-gcp-readonly.removed.md
@@ -1,0 +1,1 @@
+- yt-doctor の GCP 診断を読み取り専用にし、未設定時は上流 Terraform での修復を案内する。--billing-account と GCP 変更の自動実行を削除し、--project-id によるマシン側の project 選択と ADC quota project 設定は維持する。

--- a/src/youtube_automation/application/channel_readiness/checks.py
+++ b/src/youtube_automation/application/channel_readiness/checks.py
@@ -98,6 +98,7 @@ CHANNEL_CATEGORY = "channel"
 DATA_CATEGORY = "data"
 UPLOAD_CATEGORY = "upload"
 
+# storage は上流 tfstate 用で下流に不要。
 REQUIRED_APIS = [
     "youtube.googleapis.com",
     "youtubeanalytics.googleapis.com",
@@ -108,7 +109,6 @@ REQUIRED_APIS = [
 
 MAX_DISPLAY_VALUE_LEN = 120
 GCP_PROJECT_ID_RE = re.compile(r"[a-z][a-z0-9-]{4,28}[a-z0-9]\Z")
-BILLING_ACCOUNT_ID_RE = re.compile(r"[A-Za-z0-9]{6}-[A-Za-z0-9]{6}-[A-Za-z0-9]{6}\Z")
 _APPLY_PROJECT_ID: ContextVar[str | None] = ContextVar("doctor_apply_project_id", default=None)
 
 
@@ -118,7 +118,6 @@ class ApplyKind(Enum):
     NONE = "none"
     AI_EXEC = "ai-exec"
     PROJECT = "project"
-    BILLING = "billing"
 
 
 class CwdSemantics(Enum):
@@ -383,12 +382,6 @@ def _active_run_probe() -> Callable[..., tuple[int, str, str]]:
 def _parse_project_id(value: str) -> str:
     if not GCP_PROJECT_ID_RE.fullmatch(value):
         raise argparse.ArgumentTypeError("project ID は GCP の 6-30 文字形式で指定してください")
-    return value
-
-
-def _parse_billing_account_id(value: str) -> str:
-    if not BILLING_ACCOUNT_ID_RE.fullmatch(value):
-        raise argparse.ArgumentTypeError("billing account ID は XXXXXX-XXXXXX-XXXXXX 形式で指定してください")
     return value
 
 
@@ -836,6 +829,15 @@ def check_gcloud_account() -> CheckResult:
     )
 
 
+def _terraform_gcp_action() -> dict:
+    return {
+        "kind": "human",
+        "instructions": "GCP 層は上流 Terraform が管理する。infra/terraform/gcp/ で "
+        "terraform plan → apply してから再診断してください。",
+        "url": f"https://github.com/{UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md",
+    }
+
+
 def check_gcp_project(channel_dir: Path) -> CheckResult:
     project_id = _project_id_for(channel_dir)
     if not project_id:
@@ -843,6 +845,7 @@ def check_gcp_project(channel_dir: Path) -> CheckResult:
             id="gcp_project",
             status="fail",
             message="project_id が環境変数 / ADC quota project のいずれにも無い",
+            next_action=_terraform_gcp_action(),
         )
     code, _, err = _run(["gcloud", "projects", "describe", project_id, "--format=value(projectId)"])
     if code != 0:
@@ -850,6 +853,7 @@ def check_gcp_project(channel_dir: Path) -> CheckResult:
             id="gcp_project",
             status="fail",
             message=f"プロジェクト {project_id} が見つからない: {err.strip()}",
+            next_action=_terraform_gcp_action(),
         )
     return CheckResult(id="gcp_project", status="ok", message=f"プロジェクト {project_id} 存在")
 
@@ -878,19 +882,14 @@ def check_billing(channel_dir: Path) -> CheckResult:
             id="billing_linked",
             status="fail",
             message=f"billing 情報取得失敗: {err.strip()}",
+            next_action=_terraform_gcp_action(),
         )
     if out.strip().lower() != "true":
         return CheckResult(
             id="billing_linked",
             status="fail",
             message=f"プロジェクト {project_id} に billing 未紐付け",
-            next_action={
-                "kind": "ai-exec",
-                "cmd": (
-                    "gcloud beta billing accounts list --format=json で候補確認 → "
-                    f"gcloud beta billing projects link {project_id} --billing-account=<ID>"
-                ),
-            },
+            next_action=_terraform_gcp_action(),
         )
     return CheckResult(id="billing_linked", status="ok", message="billing 紐付け済み")
 
@@ -918,6 +917,7 @@ def check_apis_enabled(channel_dir: Path) -> CheckResult:
             id="apis_enabled",
             status="fail",
             message=f"services list 失敗: {err.strip()}",
+            next_action=_terraform_gcp_action(),
         )
     enabled = set(out.strip().splitlines())
     missing = [a for a in REQUIRED_APIS if a not in enabled]
@@ -926,7 +926,7 @@ def check_apis_enabled(channel_dir: Path) -> CheckResult:
             id="apis_enabled",
             status="fail",
             message=f"未有効 API: {', '.join(missing)}",
-            next_action=_ai_exec_action(["gcloud", "services", "enable", *missing, f"--project={project_id}"]),
+            next_action=_terraform_gcp_action(),
         )
     return CheckResult(
         id="apis_enabled",
@@ -1024,24 +1024,14 @@ def check_iam_aiplatform_user(channel_dir: Path) -> CheckResult:
             id="iam_aiplatform_user",
             status="fail",
             message=f"IAM policy 取得失敗: {err.strip()}",
+            next_action=_terraform_gcp_action(),
         )
     if not out.strip():
         return CheckResult(
             id="iam_aiplatform_user",
             status="fail",
             message=f"user:{account} に roles/aiplatform.user 未付与",
-            next_action=_ai_exec_action(
-                [
-                    "gcloud",
-                    "projects",
-                    "add-iam-policy-binding",
-                    project_id,
-                    f"--member=user:{account}",
-                    "--role=roles/aiplatform.user",
-                    "--condition=None",
-                    "--quiet",
-                ]
-            ),
+            next_action=_terraform_gcp_action(),
         )
     return CheckResult(
         id="iam_aiplatform_user",

--- a/src/youtube_automation/application/channel_readiness/checks.py
+++ b/src/youtube_automation/application/channel_readiness/checks.py
@@ -829,13 +829,15 @@ def check_gcloud_account() -> CheckResult:
     )
 
 
-def _terraform_gcp_action() -> dict:
-    return {
-        "kind": "human",
-        "instructions": "GCP 層は上流 Terraform が管理する。infra/terraform/gcp/ で "
-        "terraform plan → apply してから再診断してください。",
-        "url": f"https://github.com/{UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md",
-    }
+# GCP 層 4 check の fail は全て human 対応（上流 Terraform）へ誘導する。
+# CheckResult.__post_init__ が dict を frozen な ManualRemediation へ変換するため、
+# この dict 自体は読み取り専用として共有してよい。
+_TERRAFORM_GCP_ACTION: dict = {
+    "kind": "human",
+    "instructions": "GCP 層は上流 Terraform が管理する。infra/terraform/gcp/ で "
+    "terraform plan → apply してから再診断してください。",
+    "url": f"https://github.com/{UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md",
+}
 
 
 def check_gcp_project(channel_dir: Path) -> CheckResult:
@@ -845,7 +847,7 @@ def check_gcp_project(channel_dir: Path) -> CheckResult:
             id="gcp_project",
             status="fail",
             message="project_id が環境変数 / ADC quota project のいずれにも無い",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     code, _, err = _run(["gcloud", "projects", "describe", project_id, "--format=value(projectId)"])
     if code != 0:
@@ -853,7 +855,7 @@ def check_gcp_project(channel_dir: Path) -> CheckResult:
             id="gcp_project",
             status="fail",
             message=f"プロジェクト {project_id} が見つからない: {err.strip()}",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     return CheckResult(id="gcp_project", status="ok", message=f"プロジェクト {project_id} 存在")
 
@@ -882,14 +884,14 @@ def check_billing(channel_dir: Path) -> CheckResult:
             id="billing_linked",
             status="fail",
             message=f"billing 情報取得失敗: {err.strip()}",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     if out.strip().lower() != "true":
         return CheckResult(
             id="billing_linked",
             status="fail",
             message=f"プロジェクト {project_id} に billing 未紐付け",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     return CheckResult(id="billing_linked", status="ok", message="billing 紐付け済み")
 
@@ -917,7 +919,7 @@ def check_apis_enabled(channel_dir: Path) -> CheckResult:
             id="apis_enabled",
             status="fail",
             message=f"services list 失敗: {err.strip()}",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     enabled = set(out.strip().splitlines())
     missing = [a for a in REQUIRED_APIS if a not in enabled]
@@ -926,7 +928,7 @@ def check_apis_enabled(channel_dir: Path) -> CheckResult:
             id="apis_enabled",
             status="fail",
             message=f"未有効 API: {', '.join(missing)}",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     return CheckResult(
         id="apis_enabled",
@@ -1024,14 +1026,14 @@ def check_iam_aiplatform_user(channel_dir: Path) -> CheckResult:
             id="iam_aiplatform_user",
             status="fail",
             message=f"IAM policy 取得失敗: {err.strip()}",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     if not out.strip():
         return CheckResult(
             id="iam_aiplatform_user",
             status="fail",
             message=f"user:{account} に roles/aiplatform.user 未付与",
-            next_action=_terraform_gcp_action(),
+            next_action=_TERRAFORM_GCP_ACTION,
         )
     return CheckResult(
         id="iam_aiplatform_user",

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -31,7 +31,6 @@ from youtube_automation.application.channel_readiness.checks import (
     _ai_exec_action,
     _decision_action,
     _is_interactive_auth_command,
-    _parse_billing_account_id,
     _parse_project_id,
     _remediation_action,
     _without_channel_dir,
@@ -163,14 +162,14 @@ CHECK_REGISTRY = (
         "gcloud_account", API_CATEGORY, _without_channel_dir(check_gcloud_account), ApplyKind.NONE, CwdSemantics.CHANNEL
     ),
     CheckDefinition("gcp_project", API_CATEGORY, check_gcp_project, ApplyKind.PROJECT, CwdSemantics.CHANNEL),
-    CheckDefinition("billing_linked", API_CATEGORY, check_billing, ApplyKind.BILLING, CwdSemantics.CHANNEL),
-    CheckDefinition("apis_enabled", API_CATEGORY, check_apis_enabled, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL),
+    CheckDefinition("billing_linked", API_CATEGORY, check_billing, ApplyKind.NONE, CwdSemantics.CHANNEL),
+    CheckDefinition("apis_enabled", API_CATEGORY, check_apis_enabled, ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition("adc", API_CATEGORY, _without_channel_dir(check_adc), ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition(
         "adc_quota_project", API_CATEGORY, check_adc_quota_project, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL
     ),
     CheckDefinition(
-        "iam_aiplatform_user", API_CATEGORY, check_iam_aiplatform_user, ApplyKind.AI_EXEC, CwdSemantics.CHANNEL
+        "iam_aiplatform_user", API_CATEGORY, check_iam_aiplatform_user, ApplyKind.NONE, CwdSemantics.CHANNEL
     ),
     CheckDefinition("client_secrets", API_CATEGORY, check_client_secrets, ApplyKind.NONE, CwdSemantics.CHANNEL),
     CheckDefinition("oauth_token", API_CATEGORY, check_oauth_token, ApplyKind.NONE, CwdSemantics.CHANNEL),
@@ -342,7 +341,6 @@ def _forced_project_check(
 def _run_apply_loop(
     channel_dir: Path,
     project_id: str | None,
-    billing_account: str | None,
     executed: list[ExecutedStep],
 ) -> ApplyOutcome:
     attempted_steps = {(item.check_id, item.cmd) for item in executed}
@@ -366,41 +364,9 @@ def _run_apply_loop(
                 check=unresolved,
                 next_action=_decision_action("--project-id"),
             )
-        # remediation がある = billing 未紐付けが確定しているケースだけ --billing-account を要求する。
-        # describe 自体の失敗（権限不足など。next_action なし）は
-        # account を選んでも解決しないので human_required に落とす。
-        if apply_kind is ApplyKind.BILLING and billing_account is None and unresolved.next_action is not None:
-            return _apply_outcome(
-                results,
-                "decision_required",
-                executed,
-                check=unresolved,
-                next_action=_decision_action("--billing-account"),
-            )
         action = unresolved.next_action
-        if apply_kind is ApplyKind.PROJECT and project_id is not None:
+        if apply_kind is ApplyKind.PROJECT and project_id is not None and current_project_id != project_id:
             action = _ai_exec_action(["gcloud", "config", "set", "project", project_id])
-        elif apply_kind is ApplyKind.BILLING and billing_account is not None:
-            active_project_id = _project_id_for(channel_dir)
-            if not active_project_id:
-                return _apply_outcome(
-                    results,
-                    "decision_required",
-                    executed,
-                    check=CheckResult(id="gcp_project", status="fail", message="project ID が必要"),
-                    next_action=_decision_action("--project-id"),
-                )
-            action = _ai_exec_action(
-                [
-                    "gcloud",
-                    "beta",
-                    "billing",
-                    "projects",
-                    "link",
-                    active_project_id,
-                    f"--billing-account={billing_account}",
-                ]
-            )
         if (
             apply_kind is ApplyKind.NONE
             or not isinstance(action, AgentCommand)
@@ -452,14 +418,13 @@ def _run_apply_loop(
 def run_apply(
     channel_dir: Path,
     project_id: str | None = None,
-    billing_account: str | None = None,
 ) -> ApplyOutcome:
     """診断と ai-exec を human / 決定待ち / 完了まで連続実行する。"""
     executed: list[ExecutedStep] = []
     previous_project_id = os.environ.get("GOOGLE_CLOUD_PROJECT")
     project_id_token = _APPLY_PROJECT_ID.set(None)
     try:
-        return _run_apply_loop(channel_dir, project_id, billing_account, executed)
+        return _run_apply_loop(channel_dir, project_id, executed)
     finally:
         _APPLY_PROJECT_ID.reset(project_id_token)
         if previous_project_id is None:
@@ -842,11 +807,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         help="--apply の gcp_project step で使う project ID",
     )
     parser.add_argument(
-        "--billing-account",
-        type=_parse_billing_account_id,
-        help="--apply の billing_linked step で使う billing account ID",
-    )
-    parser.add_argument(
         "--fix-client-secrets",
         action="store_true",
         help="Downloads の OAuth client secret を auth/client_secrets.json へ移動",
@@ -878,7 +838,6 @@ def main(argv: Optional[list[str]] = None) -> int:
         outcome = run_apply(
             channel_dir,
             project_id=args.project_id,
-            billing_account=args.billing_account,
         )
         results = outcome.results
         apply_summary = outcome.summary

--- a/src/youtube_automation/commands/system/doctor.py
+++ b/src/youtube_automation/commands/system/doctor.py
@@ -365,6 +365,9 @@ def _run_apply_loop(
                 next_action=_decision_action("--project-id"),
             )
         action = unresolved.next_action
+        # gcp_project の fail は human next_action を持つため、選択済み project が
+        # それでも解決しない（存在しない ID など）ケースでは machine 層の
+        # `gcloud config set project` を繰り返さず、check の human へ落とす。
         if apply_kind is ApplyKind.PROJECT and project_id is not None and current_project_id != project_id:
             action = _ai_exec_action(["gcloud", "config", "set", "project", project_id])
         if (

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -321,6 +321,17 @@ class TestCheckGcloudAccount:
         assert r.status == "unknown"
 
 
+def _assert_terraform_gcp_action(next_action) -> None:
+    """#4933: GCP 層 check の fail は判定 fail も probe 失敗も上流 Terraform への human 誘導になる。"""
+    assert next_action is not None
+    assert next_action["kind"] == "human"
+    assert "infra/terraform/gcp/" in next_action["instructions"]
+    assert (
+        next_action["url"]
+        == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+    )
+
+
 class TestCheckGcpProject:
     def test_success(self, tmp_path, monkeypatch):
         monkeypatch.setattr(doctor, "_project_id_for", lambda channel_dir: "test-project")
@@ -339,11 +350,17 @@ class TestCheckGcpProject:
 
         assert result.id == "gcp_project"
         assert result.status == "fail"
-        assert result.next_action["kind"] == "human"
-        assert (
-            result.next_action["url"]
-            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
-        )
+        _assert_terraform_gcp_action(result.next_action)
+
+    def test_describe_failure_is_fail_with_human_action(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(doctor, "_project_id_for", lambda channel_dir: "test-project")
+        monkeypatch.setattr(doctor, "_run", lambda cmd, **kwargs: (1, "", "PERMISSION_DENIED"))
+
+        result = doctor.check_gcp_project(tmp_path)
+
+        assert result.id == "gcp_project"
+        assert result.status == "fail"
+        _assert_terraform_gcp_action(result.next_action)
 
 
 class TestCheckBilling:
@@ -365,12 +382,17 @@ class TestCheckBilling:
 
         assert result.id == "billing_linked"
         assert result.status == "fail"
-        assert result.next_action is not None
-        assert result.next_action["kind"] == "human"
-        assert (
-            result.next_action["url"]
-            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
-        )
+        _assert_terraform_gcp_action(result.next_action)
+
+    def test_probe_failure_is_fail_with_human_action(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(doctor, "_project_id_for", lambda channel_dir: "test-project")
+        monkeypatch.setattr(doctor, "_run", lambda cmd, **kwargs: (1, "", "PERMISSION_DENIED"))
+
+        result = doctor.check_billing(tmp_path)
+
+        assert result.id == "billing_linked"
+        assert result.status == "fail"
+        _assert_terraform_gcp_action(result.next_action)
 
 
 class TestCheckApisEnabled:
@@ -396,12 +418,17 @@ class TestCheckApisEnabled:
 
         assert result.id == "apis_enabled"
         assert result.status == "fail"
-        assert result.next_action is not None
-        assert result.next_action["kind"] == "human"
-        assert (
-            result.next_action["url"]
-            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
-        )
+        _assert_terraform_gcp_action(result.next_action)
+
+    def test_services_list_failure_is_fail_with_human_action(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(doctor, "_project_id_for", lambda channel_dir: "test-project")
+        monkeypatch.setattr(doctor, "_run", lambda cmd, **kwargs: (1, "", "PERMISSION_DENIED"))
+
+        result = doctor.check_apis_enabled(tmp_path)
+
+        assert result.id == "apis_enabled"
+        assert result.status == "fail"
+        _assert_terraform_gcp_action(result.next_action)
 
 
 class TestCheckAdcQuotaProject:
@@ -465,12 +492,23 @@ class TestCheckIamAiPlatformUser:
 
         assert result.id == "iam_aiplatform_user"
         assert result.status == "fail"
-        assert result.next_action is not None
-        assert result.next_action["kind"] == "human"
-        assert (
-            result.next_action["url"]
-            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+        _assert_terraform_gcp_action(result.next_action)
+
+    def test_policy_probe_failure_is_fail_with_human_action(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(doctor, "_project_id_for", lambda channel_dir: "test-project")
+        responses = iter(
+            [
+                (0, "user@example.com\n", ""),
+                (1, "", "PERMISSION_DENIED"),
+            ]
         )
+        monkeypatch.setattr(doctor, "_run", lambda cmd, **kwargs: next(responses))
+
+        result = doctor.check_iam_aiplatform_user(tmp_path)
+
+        assert result.id == "iam_aiplatform_user"
+        assert result.status == "fail"
+        _assert_terraform_gcp_action(result.next_action)
 
 
 class TestCheckADC:

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -339,7 +339,11 @@ class TestCheckGcpProject:
 
         assert result.id == "gcp_project"
         assert result.status == "fail"
-        assert result.next_action is None
+        assert result.next_action["kind"] == "human"
+        assert (
+            result.next_action["url"]
+            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+        )
 
 
 class TestCheckBilling:
@@ -362,7 +366,11 @@ class TestCheckBilling:
         assert result.id == "billing_linked"
         assert result.status == "fail"
         assert result.next_action is not None
-        assert result.next_action["kind"] == "ai-exec"
+        assert result.next_action["kind"] == "human"
+        assert (
+            result.next_action["url"]
+            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+        )
 
 
 class TestCheckApisEnabled:
@@ -389,7 +397,11 @@ class TestCheckApisEnabled:
         assert result.id == "apis_enabled"
         assert result.status == "fail"
         assert result.next_action is not None
-        assert result.next_action["kind"] == "ai-exec"
+        assert result.next_action["kind"] == "human"
+        assert (
+            result.next_action["url"]
+            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+        )
 
 
 class TestCheckAdcQuotaProject:
@@ -454,7 +466,11 @@ class TestCheckIamAiPlatformUser:
         assert result.id == "iam_aiplatform_user"
         assert result.status == "fail"
         assert result.next_action is not None
-        assert result.next_action["kind"] == "ai-exec"
+        assert result.next_action["kind"] == "human"
+        assert (
+            result.next_action["url"]
+            == f"https://github.com/{doctor.readiness_checks.UPSTREAM_REPO}/blob/main/infra/terraform/gcp/README.md"
+        )
 
 
 class TestCheckADC:

--- a/tests/commands/system/test_doctor_apply.py
+++ b/tests/commands/system/test_doctor_apply.py
@@ -152,10 +152,10 @@ def test_apply_refuses_interactive_auth_labelled_as_ai_exec_on_an_executable_che
     """#4447: apply_kind が AI_EXEC の check でも、対話 auth の argv は実行しない。
 
     `adc` / `gcloud_account` は ApplyKind.NONE で早期に止まるため、この経路は
-    実行可能な check（`apis_enabled`）でしか通らない。
+    実行可能な check（`adc_quota_project`）でしか通らない。
     """
     action = _ai_action("gcloud", "auth", "application-default", "login")
-    monkeypatch.setattr(doctor, "run_all_checks", lambda _channel_dir: [_result("apis_enabled", "fail", action)])
+    monkeypatch.setattr(doctor, "run_all_checks", lambda _channel_dir: [_result("adc_quota_project", "fail", action)])
     monkeypatch.setattr(
         doctor,
         "_run_apply_command",
@@ -167,7 +167,7 @@ def test_apply_refuses_interactive_auth_labelled_as_ai_exec_on_an_executable_che
     assert code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["apply"]["stop_reason"] == "human_required"
-    assert payload["apply"]["check_id"] == "apis_enabled"
+    assert payload["apply"]["check_id"] == "adc_quota_project"
 
 
 def test_apply_stops_for_project_decision_without_project_id(monkeypatch, tmp_path: Path, capsys) -> None:
@@ -286,115 +286,48 @@ def test_project_id_does_not_mutate_when_project_check_is_already_ok(monkeypatch
     assert payload["apply"]["executed"] == []
 
 
-def test_apply_stops_for_billing_decision_without_account(monkeypatch, tmp_path: Path, capsys) -> None:
+@pytest.mark.parametrize("check_id", ["billing_linked", "apis_enabled", "iam_aiplatform_user"])
+def test_apply_stops_at_gcp_human_before_oauth(monkeypatch, tmp_path: Path, capsys, check_id: str) -> None:
     action = {
-        "kind": "ai-exec",
-        "cmd": "gcloud beta billing projects link yt-example --billing-account=<ID>",
+        "kind": "human",
+        "instructions": "Terraform plan → apply",
+        "url": "https://example.com/infra/terraform/gcp/README.md",
     }
     monkeypatch.setattr(
         doctor,
         "run_all_checks",
-        lambda _channel_dir: [_result("billing_linked", "fail", action)],
+        lambda _: [
+            _result(check_id, "fail", action),
+            _result("client_secrets", "fail", {"kind": "human", "instructions": "OAuth setup"}),
+        ],
     )
-    monkeypatch.setattr(
-        doctor,
-        "_run_apply_command",
-        lambda _argv, _cwd: (_ for _ in ()).throw(AssertionError("billing decision must not run")),
-    )
-
-    code = doctor.main(["--apply", "--json", "--target", str(tmp_path)])
-
-    assert code == 0
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["apply"]["stop_reason"] == "decision_required"
-    assert payload["apply"]["check_id"] == "billing_linked"
-    assert payload["apply"]["next_action"] == {
-        "kind": "decision",
-        "flag": "--billing-account",
-    }
-
-
-def test_apply_requires_human_when_billing_probe_failed(monkeypatch, tmp_path: Path, capsys) -> None:
-    """describe 失敗（next_action なし）は --billing-account では解決しないため human_required に落とす。"""
-    monkeypatch.setattr(
-        doctor,
-        "run_all_checks",
-        lambda _channel_dir: [_result("billing_linked", "fail")],
-    )
-    monkeypatch.setattr(
-        doctor,
-        "_run_apply_command",
-        lambda _argv, _cwd: (_ for _ in ()).throw(AssertionError("billing probe failure must not run")),
-    )
+    commands = []
+    monkeypatch.setattr(doctor, "_run_apply_command", lambda argv, cwd: commands.append(argv) or (0, "", ""))
 
     code = doctor.main(["--apply", "--json", "--target", str(tmp_path)])
 
     assert code == 0
     payload = json.loads(capsys.readouterr().out)
     assert payload["apply"]["stop_reason"] == "human_required"
-    assert payload["apply"]["check_id"] == "billing_linked"
-    assert payload["apply"]["next_action"] is None
+    assert payload["apply"]["check_id"] == check_id
+    assert payload["apply"]["next_action"] == action
+    assert payload["apply"]["executed"] == []
+    assert commands == []
 
 
-def test_apply_uses_billing_account_then_continues(monkeypatch, tmp_path: Path, capsys) -> None:
-    action = {
-        "kind": "ai-exec",
-        "cmd": "gcloud beta billing projects link yt-example --billing-account=<ID>",
-    }
-    diagnoses = iter(
-        [
-            [_result("billing_linked", "fail", action)],
-            [_result("billing_linked")],
-        ]
-    )
-    commands: list[tuple[list[str], Path]] = []
-    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "yt-example")
-    monkeypatch.setattr(doctor, "run_all_checks", lambda _channel_dir: next(diagnoses))
-    monkeypatch.setattr(
-        doctor,
-        "_run_apply_command",
-        lambda argv, cwd: commands.append((argv, cwd)) or (0, "", ""),
-    )
-
-    code = doctor.main(
-        [
-            "--apply",
-            "--json",
-            "--billing-account",
-            "ABCDEF-123456-ABCDEF",
-            "--target",
-            str(tmp_path),
-        ]
-    )
-
-    assert code == 0
-    assert commands == [
-        (
-            [
-                "gcloud",
-                "beta",
-                "billing",
-                "projects",
-                "link",
-                "yt-example",
-                "--billing-account=ABCDEF-123456-ABCDEF",
-            ],
-            tmp_path,
-        )
-    ]
-    payload = json.loads(capsys.readouterr().out)
-    assert payload["apply"]["stop_reason"] == "completed"
-    assert payload["apply"]["executed"][0]["cmd"] == (
-        "gcloud beta billing projects link yt-example --billing-account=ABCDEF-123456-ABCDEF"
-    )
+def test_apply_rejects_removed_billing_flag(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.setattr(doctor, "run_all_checks", lambda _: [_result("ready")])
+    with pytest.raises(SystemExit) as error:
+        doctor.main(["--apply", "--billing-account", "ABCDEF-123456-ABCDEF", "--target", str(tmp_path)])
+    assert error.value.code == 2
 
 
 def test_apply_stops_with_failed_command_details(monkeypatch, tmp_path: Path, capsys) -> None:
-    action = _ai_action("gcloud", "services", "enable", "example.googleapis.com")
+    action = _ai_action("gcloud", "auth", "application-default", "set-quota-project", "yt-example")
     monkeypatch.setattr(
         doctor,
         "run_all_checks",
-        lambda _channel_dir: [_result("apis_enabled", "fail", action)],
+        lambda _channel_dir: [_result("adc_quota_project", "fail", action)],
     )
     monkeypatch.setattr(
         doctor,
@@ -407,7 +340,7 @@ def test_apply_stops_with_failed_command_details(monkeypatch, tmp_path: Path, ca
     assert code == 1
     payload = json.loads(capsys.readouterr().out)
     assert payload["apply"]["stop_reason"] == "command_failed"
-    assert payload["apply"]["check_id"] == "apis_enabled"
+    assert payload["apply"]["check_id"] == "adc_quota_project"
     assert payload["apply"]["cmd"] == action["cmd"]
     assert payload["apply"]["stderr"] == "permission denied"
 
@@ -487,7 +420,6 @@ def test_apply_keeps_pre_install_bootstrap_out_of_scope(monkeypatch, tmp_path: P
     [
         ("--project-id", "--quiet"),
         ("--project-id", "INVALID_PROJECT"),
-        ("--billing-account", "account;rm"),
     ],
 )
 def test_apply_rejects_invalid_decision_values(monkeypatch, flag: str, value: str) -> None:
@@ -500,3 +432,20 @@ def test_apply_rejects_invalid_decision_values(monkeypatch, flag: str, value: st
         doctor.main(["--apply", flag, value])
 
     assert error.value.code == 2
+
+
+def test_apply_missing_project_stops_after_machine_selection(monkeypatch, tmp_path: Path, capsys) -> None:
+    monkeypatch.delenv("GOOGLE_CLOUD_PROJECT", raising=False)
+    monkeypatch.setattr(doctor, "_adc_quota_project", lambda: None)
+    monkeypatch.setattr(doctor, "_run", lambda argv, **kwargs: (1, "", "not found"))
+    monkeypatch.setattr(doctor, "run_all_checks", lambda directory: [doctor.check_gcp_project(directory)])
+    commands = []
+    monkeypatch.setattr(doctor, "_run_apply_command", lambda argv, cwd: commands.append(argv) or (0, "", ""))
+
+    code = doctor.main(["--apply", "--project-id", "yt-example", "--target", str(tmp_path)])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["apply"]["stop_reason"] == "human_required"
+    assert payload["apply"]["next_action"]["kind"] == "human"
+    assert commands == [["gcloud", "config", "set", "project", "yt-example"]]

--- a/tests/commands/system/test_doctor_apply.py
+++ b/tests/commands/system/test_doctor_apply.py
@@ -315,6 +315,28 @@ def test_apply_stops_at_gcp_human_before_oauth(monkeypatch, tmp_path: Path, caps
     assert commands == []
 
 
+def test_apply_requires_human_when_billing_probe_failed(monkeypatch, tmp_path: Path, capsys) -> None:
+    """#4933: describe 自体の失敗（権限不足など）も上流 Terraform 誘導で止め、GCP を変更しない。"""
+    monkeypatch.setenv("GOOGLE_CLOUD_PROJECT", "yt-example")
+    monkeypatch.setattr(doctor, "_run", lambda argv, **kwargs: (1, "", "PERMISSION_DENIED"))
+    monkeypatch.setattr(doctor, "run_all_checks", lambda directory: [doctor.check_billing(directory)])
+    monkeypatch.setattr(
+        doctor,
+        "_run_apply_command",
+        lambda _argv, _cwd: (_ for _ in ()).throw(AssertionError("billing probe failure must not run")),
+    )
+
+    code = doctor.main(["--apply", "--json", "--target", str(tmp_path)])
+
+    assert code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["apply"]["stop_reason"] == "human_required"
+    assert payload["apply"]["check_id"] == "billing_linked"
+    assert payload["apply"]["next_action"]["kind"] == "human"
+    assert payload["apply"]["next_action"]["url"].endswith("/infra/terraform/gcp/README.md")
+    assert payload["apply"]["executed"] == []
+
+
 def test_apply_rejects_removed_billing_flag(monkeypatch, tmp_path: Path, capsys) -> None:
     monkeypatch.setattr(doctor, "run_all_checks", lambda _: [_result("ready")])
     with pytest.raises(SystemExit) as error:

--- a/tests/commands/system/test_doctor_json_contract.py
+++ b/tests/commands/system/test_doctor_json_contract.py
@@ -179,8 +179,8 @@ def test_remediation_action_union_owns_public_serialization(
 def test_manual_remediation_fallback_should_drop_internal_action_fields() -> None:
     """ai-exec/human のどちらにも該当しない dict でも argv / auto_apply を公開しない。"""
     action = doctor._remediation_action(
-        {"kind": "decision", "flag": "--billing-account", "argv": ["gcloud", "beta"], "auto_apply": False}
+        {"kind": "decision", "flag": "--project-id", "argv": ["gcloud", "beta"], "auto_apply": False}
     )
 
     assert isinstance(action, doctor.ManualRemediation)
-    assert action.to_public_dict() == {"kind": "decision", "flag": "--billing-account"}
+    assert action.to_public_dict() == {"kind": "decision", "flag": "--project-id"}

--- a/tests/commands/system/test_doctor_registry.py
+++ b/tests/commands/system/test_doctor_registry.py
@@ -63,7 +63,6 @@ def test_registry_declares_apply_and_cwd_semantics() -> None:
     definitions = {definition.id: definition for definition in doctor.CHECK_REGISTRY}
 
     assert definitions["gcp_project"].apply_kind is doctor.ApplyKind.PROJECT
-    assert definitions["billing_linked"].apply_kind is doctor.ApplyKind.BILLING
     assert definitions["skills_synced"].apply_kind is doctor.ApplyKind.AI_EXEC
     assert definitions["channel_config"].apply_kind is doctor.ApplyKind.NONE
     assert all(definition.cwd_semantics is doctor.CwdSemantics.CHANNEL for definition in doctor.CHECK_REGISTRY)

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -361,9 +361,8 @@ def test_setup_skill_branches_on_all_apply_stop_reasons() -> None:
     assert "`apply.check_id`" in startup
     assert "`apply.cmd` / `apply.stderr`" in startup
     assert "--project-id <project-id>" in startup
-    assert "--billing-account <billing-id>" in startup
     assert "以後 `completed` まで全 flag を毎回付け" in startup
-    assert "uv run yt-doctor --apply --json --project-id <project-id> --billing-account <billing-id>" in startup
+    assert "uv run yt-doctor --apply --json --project-id <project-id>" in startup
 
 
 def test_setup_skill_requires_approval_before_apply_mutations() -> None:
@@ -383,7 +382,7 @@ def test_setup_skill_reapproves_project_scoped_plan_after_decisions() -> None:
     startup = text.split("## 起動時のチェック", 1)[1].split("## 認証コマンドと人間操作の責務", 1)[0]
     plan = startup.split("### GCP 変更 plan の承認", 1)[1]
 
-    assert "`--project-id` / `--billing-account` を追加・変更するたび" in plan
+    assert "`--project-id` を追加・変更するたび" in plan
     assert "正確な project ID" in plan
     assert "active account" in plan
     for mutation in ("Billing 紐付け", "API 有効化", "ADC quota project", "IAM 付与", "Reporting job 作成"):

--- a/tests/commands/system/test_setup_skill.py
+++ b/tests/commands/system/test_setup_skill.py
@@ -448,13 +448,6 @@ def test_setup_skill_delegates_minimum_directory_generation_to_setup() -> None:
     assert "OAuth クライアント JSON の配置先 `auth/`" in text
 
 
-def test_setup_skill_enables_doctor_required_apis() -> None:
-    text = _setup_text()
-
-    for api_name in doctor.REQUIRED_APIS:
-        assert api_name in text
-
-
 def test_setup_skill_suggests_gcp_project_id_from_channel_name() -> None:
     text = _setup_text()
     assert "`config/channel/meta.json` の `channel.name`" in text
@@ -476,15 +469,12 @@ def test_setup_skill_requires_explicit_project_creation_approval() -> None:
     assert "作成が承認されるまで次のコマンドを実行しない" in section
 
 
-def test_setup_project_and_billing_sections_route_through_plan_approval() -> None:
+def test_setup_project_section_routes_through_plan_approval() -> None:
     text = _setup_text()
     project = text.split("#### `gcp_project`", 1)[1].split("#### `billing_linked`", 1)[0]
-    billing = text.split("#### `billing_linked`", 1)[1].split("#### `apis_enabled`", 1)[0]
-
-    for section in (project, billing):
-        assert "必ず先に「GCP 変更 plan の承認」へ戻る" in section
-        assert "AskUserQuestion で実行が承認された後だけ" in section
-        assert "中止ならここで停止する" in section
+    assert "必ず先に「GCP 変更 plan の承認」へ戻る" in project
+    assert "AskUserQuestion で実行が承認された後だけ" in project
+    assert "中止ならここで停止する" in project
 
 
 def test_setup_skill_suggests_oauth_app_and_client_names() -> None:


### PR DESCRIPTION
doctor の GCP 4 check が失敗した場合、上流 Terraform README での人間による対応へ誘導し、GCP を自動変更しないようにします。billing flag・action enum・変更分岐を削除し、setup の呼び出し例と既存契約を追従させます。project 選択と quota project 操作は維持し、選択後も project が存在しなければ human で停止します。

検証: TDD、focused pytest 69件、ruff check/format、changelog 成功。full pytest -n 4 は10541 passed / 4 skipped / 1 failed（既存ローカルauthファイル配置による不在契約の環境衝突）。

Closes #4933
