### PR TITLE
refactor: OAuthのworkspace共有認証候補を削除する (#4917)

### DIFF
--- a/changelog.d/4917-oauth-workspace.removed.md
+++ b/changelog.d/4917-oauth-workspace.removed.md
@@ -1,0 +1,1 @@
+- OAuth client の探索候補から旧 workspace root の `auth/client_secrets.json` を削除しました。チャンネルの `auth/`、submodule 互換の `automation/auth/`、main worktree の `auth/` の順に探索します。明示 `CLIENT_SECRETS_DIR`、secret fallback、token / backups の扱いは維持します。

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -130,9 +130,7 @@ cd ../../..
 
 1. `<channel_dir>/auth/client_secrets.json`（推奨）
 2. `<channel_dir>/automation/auth/client_secrets.json`（submodule 互換フォールバック）
-3. `<workspace_root>/auth/client_secrets.json`
-   - `channel_dir` が workspace 配下のチャンネルとして解決できる場合のみ候補に加わる
-4. `<main_worktree_root>/auth/client_secrets.json`
+3. `<main_worktree_root>/auth/client_secrets.json`
    - git worktree では gitignore された `auth/` が複製されないため、main 作業ツリー側の実体を最後のフォールバックとして参照する（#1721）
 
 いずれのファイルも存在しない場合は、1Password / `CLIENT_SECRETS_JSON` による secret fallback を試みる。

--- a/src/youtube_automation/infrastructure/auth/youtube.py
+++ b/src/youtube_automation/infrastructure/auth/youtube.py
@@ -25,7 +25,6 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
-from youtube_automation.configuration import find_workspace_root, workspace_channels
 from youtube_automation.core.errors import AuthError, ConfigError, ValidationError, YouTubeAPIError
 from youtube_automation.infrastructure import secrets as secret_store
 from youtube_automation.infrastructure.auth.client_secrets import validate_desktop_client_config
@@ -57,11 +56,6 @@ def client_secrets_file_candidates(channel_dir: Path) -> list[Path]:
         channel_dir / "auth" / "client_secrets.json",
         channel_dir / "automation" / "auth" / "client_secrets.json",
     ]
-    workspace_root = find_workspace_root(channel_dir)
-    if workspace_root is not None and channel_dir.resolve() in {
-        path.resolve() for path in workspace_channels(workspace_root).values()
-    }:
-        candidates.append(workspace_root / "auth" / "client_secrets.json")
     # git worktree では gitignore された auth/ が複製されないため、
     # main 作業ツリー側の実体を最後のフォールバックとして参照する（#1721）
     main_root = main_worktree_root(channel_dir)

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -661,15 +661,19 @@ class TestClientSecrets:
         r = doctor.check_client_secrets(tmp_path)
         assert r.status == "ok"
 
-    def test_uses_workspace_root_fallback(self, tmp_path):
+    def test_does_not_use_workspace_root_fallback(self, tmp_path, monkeypatch):
         workspace = tmp_path / "workspace"
         channel = workspace / "channels" / "alpha"
         (channel / "config" / "channel").mkdir(parents=True)
         self._write_valid_client_secrets(workspace / "auth" / "client_secrets.json")
 
+        monkeypatch.setattr(
+            "youtube_automation.infrastructure.secrets.get_secret",
+            lambda _name: (_ for _ in ()).throw(ConfigError("secret unavailable")),
+        )
         r = doctor.check_client_secrets(channel)
 
-        assert r.status == "ok"
+        assert r.status == "fail"
 
     def test_rejects_client_secrets_directory(self, tmp_path):
         (tmp_path / "auth" / "client_secrets.json").mkdir(parents=True)

--- a/tests/infrastructure/auth/test_oauth_worktree_fallback.py
+++ b/tests/infrastructure/auth/test_oauth_worktree_fallback.py
@@ -146,52 +146,6 @@ class TestMainWorktreeRoot:
 
 
 class TestClientSecretsCandidates:
-    def test_workspace_root_auth_is_fallback_after_channel_candidates(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
-        workspace = tmp_path / "workspace"
-        channel = workspace / "channels" / "alpha"
-        (channel / "config" / "channel").mkdir(parents=True)
-
-        assert client_secrets_file_candidates(channel) == [
-            channel / "auth" / "client_secrets.json",
-            channel / "automation" / "auth" / "client_secrets.json",
-            workspace / "auth" / "client_secrets.json",
-        ]
-
-    def test_resolve_prefers_channel_file_over_workspace_fallback(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
-        workspace = tmp_path / "workspace"
-        channel = workspace / "channels" / "alpha"
-        (channel / "config" / "channel").mkdir(parents=True)
-        for root in (workspace, channel):
-            (root / "auth").mkdir(parents=True, exist_ok=True)
-            (root / "auth" / "client_secrets.json").write_text(json.dumps(_CLIENT_SECRETS), encoding="utf-8")
-
-        assert resolve_client_secrets_path(channel) == channel / "auth" / "client_secrets.json"
-
-    def test_resolve_falls_back_to_workspace_file(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
-        workspace = tmp_path / "workspace"
-        channel = workspace / "channels" / "alpha"
-        (channel / "config" / "channel").mkdir(parents=True)
-        (workspace / "auth").mkdir()
-        (workspace / "auth" / "client_secrets.json").write_text(json.dumps(_CLIENT_SECRETS), encoding="utf-8")
-
-        assert resolve_client_secrets_path(channel) == workspace / "auth" / "client_secrets.json"
-
-    def test_nested_standalone_repo_does_not_use_workspace_fallback(self, tmp_path, monkeypatch):
-        monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
-        workspace = tmp_path / "workspace"
-        workspace_channel = workspace / "channels" / "alpha"
-        (workspace_channel / "config" / "channel").mkdir(parents=True)
-        standalone = workspace / "standalone"
-        standalone.mkdir()
-
-        assert client_secrets_file_candidates(standalone) == [
-            standalone / "auth" / "client_secrets.json",
-            standalone / "automation" / "auth" / "client_secrets.json",
-        ]
-
     def test_worktree_appends_main_auth_fallback_last(self, worktree_pair):
         main_root, worktree = worktree_pair
         candidates = client_secrets_file_candidates(worktree)

--- a/tests/test_oauth_onboarding_contract.py
+++ b/tests/test_oauth_onboarding_contract.py
@@ -150,8 +150,8 @@ def test_setup_entrypoints_do_not_keep_stale_oauth_contract() -> None:
 def _make_workspace_channel_worktree(tmp_path: Path) -> Path:
     """workspace channel かつ linked worktree の channel_dir を作る。
 
-    workspace root fallback と main worktree fallback の両方が候補に載る唯一の構造で、
-    `client_secrets_file_candidates()` の全 4 候補を一度に観測できる。
+    旧 workspace の配下でも候補が増えず、main worktree fallback を含む
+    `client_secrets_file_candidates()` の全 3 候補だけが返ることを観測する。
     """
     main_root = tmp_path / "main"
     gitdir = main_root / ".git" / "worktrees" / "alpha"
@@ -170,14 +170,12 @@ def test_client_secrets_resolution_order_matches_oauth_setup(tmp_path: Path, mon
 
     monkeypatch.delenv("CLIENT_SECRETS_DIR", raising=False)
     channel = _make_workspace_channel_worktree(tmp_path)
-    workspace_root = channel.parents[1]
     main_root = tmp_path / "main"
 
     candidates = client_secrets_file_candidates(channel)
     assert candidates == [
         channel / "auth" / "client_secrets.json",
         channel / "automation" / "auth" / "client_secrets.json",
-        workspace_root / "auth" / "client_secrets.json",
         main_root.resolve() / "auth" / "client_secrets.json",
     ]
 
@@ -185,13 +183,13 @@ def test_client_secrets_resolution_order_matches_oauth_setup(tmp_path: Path, mon
     documented_tokens = (
         "<channel_dir>/auth/",
         "<channel_dir>/automation/auth/",
-        "<workspace_root>/auth/",
         "<main_worktree_root>/auth/",
     )
     assert len(documented_tokens) == len(candidates)
 
     oauth_setup = (REPO_ROOT / "docs" / "oauth-setup.md").read_text(encoding="utf-8")
     resolution_section = oauth_setup.split("`client_secrets.json` の解決順", 1)[1].split("## 動作確認", 1)[0]
+    assert "<workspace_root>/auth/" not in resolution_section
     positions = []
     for token in documented_tokens:
         assert token in resolution_section, f"docs/oauth-setup.md is missing {token!r}"


### PR DESCRIPTION
OAuth client の探索候補から旧 workspace root の `auth/client_secrets.json` を削除します。明示 `CLIENT_SECRETS_DIR` がない場合の候補列を、チャンネルの `auth/` → submodule 互換の `automation/auth/` → main worktree の `auth/` に揃え、OAuth セットアップ文書と onboarding 契約も更新します。

main worktree fallback、明示 override、secret fallback、token / backups の挙動は維持します。doctor の認証診断も同じ候補列を利用するため、共有 root の認証ファイルを採用しない回帰テストに更新しました。

検証:
- 候補列と doctor 診断の回帰テストで Red → Green。
- OAuth 関連・onboarding・doctor client secrets の144件が成功。
- ruff check / format、changelog 検証が成功。
- `infrastructure/auth/youtube.py` の `workspace` 参照0件。
- 全体テスト（`PYTEST_ADDOPTS="-n 4" nix develop --command uv run pytest -q`）: **10,515 passed / 4 skipped**。

Closes #4917
