### PR TITLE
docs(gcp): 公開ガイドを上流 Terraform の案内に統一 (#4935)

### DIFF
--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -30,14 +30,14 @@
 
 空フォルダでの prerequisites、`uv init`、automation package と skill の導入は、公開ガイド [`docs/tool-setup.md`](docs/tool-setup.md) を正本とする。`/setup --tool` による GCP / OAuth / ADC の本人操作と完了確認は、[`docs/oauth-setup.md`](docs/oauth-setup.md) を正本とする。本書には同じコマンドや OAuth GUI 手順を複製しない。
 
-公開ガイドの推奨ルートを完了すると、automation CLI、同期済み skill、API 認証、動画アップロード前提が揃う。その後、この onboarding の §3 に進み、新規チャンネルなら `/setup --channel` を実行する。手動 bootstrap / Terraform、secret 解決順、トラブルシューティングも同じ公開ガイドの上級者向け節を参照する。
+公開ガイドの推奨ルートを完了すると、automation CLI、同期済み skill、API 認証、動画アップロード前提が揃う。その後、この onboarding の §3 に進み、新規チャンネルなら `/setup --channel` を実行する。GCP 層は上流の [`infra/terraform/gcp/README.md`](infra/terraform/gcp/README.md)、secret 解決順と OAuth のトラブルシューティングは公開ガイドを参照する。
 
 ### 2.4 初期設定後の GCP 課金確認
 
-`/setup` で Billing を紐付けたあとの実際の利用料金は、リポジトリ内の推定値ではなく **Google Cloud Billing** を正として確認する。
+Terraform で Billing を紐付けたあとの実際の利用料金は、リポジトリ内の推定値ではなく **Google Cloud Billing** を正として確認する。
 
 1. 下流チャンネルリポジトリで `uv run yt-doctor --json` を実行し、`checks` 内の `id` が `gcp_project` の項目から対象の project ID を確認する。
-2. [Google Cloud Console の Billing](https://console.cloud.google.com/billing) を開き、`/setup` で対象プロジェクトに紐付けた Billing account を選ぶ。
+2. [Google Cloud Console の Billing](https://console.cloud.google.com/billing) を開き、Terraform で対象プロジェクトに紐付けた Billing account を選ぶ。
 3. **Reports** で期間（Time range）を指定し、**Projects** を手順 1 の project ID に絞る。まず **Service**、必要に応じて **SKU** でグループ化または絞り込み、どのサービス・SKU がその期間の料金を発生させたか確認する。画面の見方は [Cloud Billing Reports の公式手順](https://cloud.google.com/billing/docs/how-to/reports) を参照する。
 4. USD を含む単価を確認する場合は、同じ Billing account の **Pricing** で対象の Service / SKU を検索し、表示時点の `List price`（契約単価がある場合は `Contract price`）を確認する。価格は選択した Billing account の通貨で表示されるため、通貨も併せて確認する。参照方法と各列の意味は [Pricing の公式手順](https://cloud.google.com/billing/docs/how-to/pricing-table) を参照する。
 

--- a/changelog.d/4935-gcp-onboarding.changed.md
+++ b/changelog.d/4935-gcp-onboarding.changed.md
@@ -1,0 +1,1 @@
+- 公開 OAuth ガイドと ONBOARDING の GCP 層を上流 Terraform README への案内に統一し、廃止済み bootstrap と重複する GCP トラブルシューティングを削除した。

--- a/docs/oauth-setup.md
+++ b/docs/oauth-setup.md
@@ -12,7 +12,7 @@ skill / CLI ごとの実効 scope と read-only token の設計は [`oauth-scope
 
 ### 5. GCP / ADC / OAuth を完了する
 
-setup は project 選択、Billing 紐付け、必要 API の有効化、ADC quota project、IAM、Reporting job を診断順に進める。外部の GCP 状態を変える前には、対象 project・account・実行コマンドを表示して承認を求める。
+setup は GCP / ADC / OAuth / Reporting job を診断順に確認する。project / billing / API / IAM の不足は、後述の GCP 層の正本へ誘導する。GCP 層を Terraform で整えてから setup を再実行し、ADC / OAuth のローカル認証を進める。
 
 認証 CLI は setup 自身が対話 session で起動する。利用者がターミナルへ別途コマンドをコピーして実行する必要はない。
 
@@ -42,17 +42,11 @@ Google Auth Platform の GUI は API で自動化できないため、setup が 
 
 ## 上級者向け代替ルートと参照情報
 
-推奨ルートを使わず GCP project を手動管理したい場合に限り、以下の Terraform 経路を使う。`client_secrets.json` の解決順、Vertex AI の project / location 解決、セキュリティ、トラブルシューティングもこの後に記載する。この経路は廃止しないが、初回利用者の標準手順ではない。
+### GCP 層（project / billing / API / IAM）
 
-ここに掲載するコマンドも、原則として Claude デスクトップアプリへ「対象 project と変更内容を確認してから、この手順を実行してください」と依頼する。利用者が直接ターミナルへ入力するのは、組織の運用規則で AI エージェントの実行が許可されない場合に限る。
+first-party の共有 GCP 構成は、上流の [`infra/terraform/gcp/README.md`](../infra/terraform/gcp/README.md) を正本として Terraform で管理する。`yt-doctor` は GCP 層の検証と正本への誘導のみを行い、project / billing / API / IAM を変更しない。
 
-### 上流 Terraform: GCP 層の唯一の変更経路
-
-GCP 層（project / billing / API / IAM）の変更経路は上流専属の [`infra/terraform/gcp/README.md`](../infra/terraform/gcp/README.md) だけである（[ADR-0030](adr/0030-terraform-sole-change-path-for-gcp.md)）。GCS backend を指定して init し、既存リソースの import を完了してから apply する。下流チャンネルリポジトリには Terraform 資産を配布しない。external user は上流リポジトリを clone し、自分の tfvars で `infra/terraform/gcp/` を apply する。
-
-gcloud で project を作成・変更する半自動スクリプト経路は廃止した。マシン層（gcloud login / ADC / quota project / project 選択）とチャンネル層（OAuth client / `client_secrets.json` / `token.json` / Reporting job）は引き続き `/setup --tool` が担当する。
-
-この Terraform 経路でも `client_secrets.json` の手動配置を行う。次節はその手動経路向けであり、推奨のルート 0 は `/setup` の Download JSON → `done` → `yt-doctor --fix-client-secrets` → JSON 再診断を使う。
+external user は上流リポジトリを clone し、同じ README に従って自分の tfvars で apply する。Terraform 資産は下流チャンネルリポジトリへ配布しない。GCP 層の構築・変更・トラブルシューティングは上流 README、OAuth の本人操作と secret 解決順は本ガイドを参照する。
 
 ---
 
@@ -157,31 +151,6 @@ Vertex AI で以下を利用する。`aiplatform.googleapis.com` が有効化さ
 ---
 
 ## トラブルシューティング
-
-### GCP 層共通
-
-#### `Permission denied` / 認証エラー
-`gcloud auth application-default login` で ADC を更新。必要なら quota project を固定:
-```bash
-gcloud auth application-default set-quota-project <project-id>
-```
-
-#### `roles/aiplatform.user` 付与でエラー
-IAM 付与権限がない。Organization / Project オーナー権限を持つアカウントで実行すること。
-
-#### プロジェクト作成上限に達した
-GCP のプロジェクト作成は 1 アカウントあたり上限あり（初期は少ない）。不要プロジェクトを削除するか、上限緩和申請。
-
-#### `billingEnabled` エラー（Vertex AI / aiplatform 有効化時）
-Billing account が紐付いていない。上流 `infra/terraform/gcp/` の `billing_account` を設定して apply する。
-
-### terraform 固有
-
-#### `already exists but is not managed by this terraform configuration`
-`project_id` が既存の共有プロジェクトを指し、`imports.tf` が読み込まれていることを確認する。プロジェクトを新規作成して回避せず、[`infra/terraform/gcp/README.md`](../infra/terraform/gcp/README.md) の import 手順に戻る。
-
-#### `Error 400: ... not enabled for billing`
-`aiplatform.googleapis.com` には Billing が必須。`billing_account` を正しく指定。
 
 ### YouTube OAuth 固有
 

--- a/tests/repo/test_b6_integration_contract.py
+++ b/tests/repo/test_b6_integration_contract.py
@@ -407,7 +407,7 @@ def test_built_sdist_contains_only_approved_members(tmp_path: Path) -> None:
         "plans/",
         "site/",
     )
-    # allowlist へ明示した member（例: GCP 層の唯一の変更経路である infra README）だけが例外になる
+    # allowlist へ明示した member（例: GCP 層の上流 README）だけが forbidden prefix の例外になる
     assert not [member for member in members if member.startswith(forbidden_prefixes) and member not in allowed_exact]
     forbidden_names = {
         "client_secrets.json",

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1440,6 +1440,14 @@ def test_public_setup_guide_owns_installation_and_oauth_completion() -> None:
     assert "Download JSON" not in onboarding_setup
 
 
+def test_oauth_module_docstring_documents_download_json_route() -> None:
+    oauth_handler = _read("src/youtube_automation/infrastructure/auth/youtube.py")
+    module_docstring = oauth_handler.split('"""', 2)[1]
+    for expected in ("Download JSON", "yt-doctor --fix-client-secrets"):
+        assert expected in module_docstring
+    assert "secret を発行して auth/client_secrets.json に配置" not in module_docstring
+
+
 def test_channel_new_regeneration_documents_ttp_wf_new_readiness_gate() -> None:
     regeneration_mode = _read(".claude/skills/setup/references/regeneration-mode.md")
     rules = _read(".claude/skills/setup/references/config-generation-rules.md")

--- a/tests/repo/test_skill_docs_consistency.py
+++ b/tests/repo/test_skill_docs_consistency.py
@@ -1440,26 +1440,6 @@ def test_public_setup_guide_owns_installation_and_oauth_completion() -> None:
     assert "Download JSON" not in onboarding_setup
 
 
-def test_oauth_module_and_setup_guide_distinguish_automatic_and_manual_routes() -> None:
-    oauth_handler = _read("src/youtube_automation/infrastructure/auth/youtube.py")
-    module_docstring = oauth_handler.split('"""', 2)[1]
-    for expected in ("Download JSON", "yt-doctor --fix-client-secrets"):
-        assert expected in module_docstring
-    assert "secret を発行して auth/client_secrets.json に配置" not in module_docstring
-
-    oauth_setup = _read("docs/oauth-setup.md")
-    route_zero = oauth_setup.split("## 推奨ルート", 1)[1].split("## 上級者向け", 1)[0]
-    for expected in ("Download JSON", "done", "yt-doctor --fix-client-secrets", "yt-doctor --apply --json"):
-        assert expected in route_zero
-    assert "client_secrets.json` 配置は PKCE / GUI 制約で AI 実行不可" not in route_zero
-
-    # #4934: gcloud 半自動化の「ルート A」は廃止し、GCP 層の代替ルートは上流 Terraform 1 本に絞る
-    manual_route = oauth_setup.split("### 上流 Terraform", 1)[1].split("## Google Auth Platform 手動設定", 1)[0]
-    assert "この Terraform 経路でも `client_secrets.json` の手動配置を行う" in manual_route
-    assert "infra/terraform/gcp/README.md" in manual_route
-    assert "gcp-bootstrap" not in oauth_setup
-
-
 def test_channel_new_regeneration_documents_ttp_wf_new_readiness_gate() -> None:
     regeneration_mode = _read(".claude/skills/setup/references/regeneration-mode.md")
     rules = _read(".claude/skills/setup/references/config-generation-rules.md")

--- a/tests/test_oauth_onboarding_contract.py
+++ b/tests/test_oauth_onboarding_contract.py
@@ -82,3 +82,19 @@ def test_client_secrets_resolution_order_matches_oauth_setup(tmp_path: Path, mon
         assert token in resolution_section, f"docs/oauth-setup.md is missing {token!r}"
         positions.append(resolution_section.index(token))
     assert positions == sorted(positions), "docs/oauth-setup.md lists the candidates out of implementation order"
+
+
+def test_public_gcp_guides_reference_upstream_instead_of_removed_assets() -> None:
+    """Public entrypoints must resolve to the upstream owner after asset removal."""
+    upstream = REPO_ROOT / "infra/terraform/gcp/README.md"
+    for relative, target in (
+        ("ONBOARDING.md", "infra/terraform/gcp/README.md"),
+        ("docs/oauth-setup.md", "../infra/terraform/gcp/README.md"),
+    ):
+        guide = REPO_ROOT / relative
+        text = guide.read_text(encoding="utf-8")
+        assert f"]({target})" in text
+        assert (guide.parent / target).resolve() == upstream
+        assert upstream.is_file()
+        assert "gcp-bootstrap" not in text
+        assert "references/terraform-gcp" not in text


### PR DESCRIPTION
OAuth setup と ONBOARDING の GCP 層を、first-party / external のどちらも上流 Terraform README へ誘導する案内に統一します。旧 bootstrap ルートとGCP変更トラブルシューティングを除去し、Console の手動手順と認証情報の解決順は維持します。

検証: lint/format/changelog成功、site check/build/73 tests成功、生成HTMLの上流リンク確認成功。関連pytest101 passed、full10522 passed/4 skipped。いずれも既存ローカルauthファイル配置による不在契約1件のみ失敗。

Closes #4935
