### PR TITLE
refactor: 共通チャンネル選択とworkspace検出を削除する (#4919)

### DIFF
--- a/changelog.d/4919-channel-option.removed.md
+++ b/changelog.d/4919-channel-option.removed.md
@@ -1,0 +1,1 @@
+- 全 yt-* の共通 --channel / CHANNEL による選択と workspace 自動検出を削除し、CHANNEL_DIR → cwd 祖先の設定解決に統一しました。各コマンド固有の --channel と競合チャンネル向け旧引数の拒否は維持します。

--- a/src/youtube_automation/commands/channel/channel_export.py
+++ b/src/youtube_automation/commands/channel/channel_export.py
@@ -13,7 +13,7 @@ import tempfile
 from pathlib import Path
 
 from youtube_automation.commands._shared.cli_harness import run_cli
-from youtube_automation.configuration import find_workspace_root, load_config, reset
+from youtube_automation.configuration import load_config, reset
 from youtube_automation.core.errors import ChannelRegistryError, ConfigError
 from youtube_automation.infrastructure.analytics.channel_registry import (
     DEFAULT_CHANNEL_REGISTRY,
@@ -63,10 +63,14 @@ assets/stock/**/*.ogg
 
 
 def _workspace_root(start: Path) -> Path:
-    detected = find_workspace_root(start)
-    if detected is not None:
-        return detected
     current = start.expanduser().resolve()
+    # 移行用 CLI の削除まで、旧 workspace 検出を export 内に閉じ込める。
+    for parent in (current, *current.parents):
+        channels_root = parent / "channels"
+        if channels_root.is_dir() and any(
+            (channel / "config" / "channel").is_dir() for channel in channels_root.iterdir()
+        ):
+            return parent
     for parent in (current, *current.parents):
         if (parent / "channels").is_dir():
             return parent

--- a/src/youtube_automation/configuration/__init__.py
+++ b/src/youtube_automation/configuration/__init__.py
@@ -4,10 +4,6 @@
     load_config() -> ChannelConfig   # シングルトン取得（初回に glob ロード + .env ロード）
     load_schedule_config()           # config/channel/schedule.json の型付きローダー
     channel_dir() -> Path            # config/channel/ を含むプロジェクトルート解決
-    explicit_channel_selection()     # CLI の明示 channel slug を参照
-    find_workspace_root()            # cwd 祖先から workspace root を検出
-    workspace_channels()             # workspace の slug と channel dir を列挙
-    select_channel()                 # CLI の明示 channel slug を初回解決へ渡す
     reset() -> None                  # シングルトン state をリセット（テスト用）
     ChannelConfig                    # 合成ルート dataclass（型ヒント用）
     CommunityDraft                   # `community_draft` セクション（型ヒント用）
@@ -21,13 +17,9 @@ from youtube_automation.configuration.community_draft import CommunityDraft
 from youtube_automation.configuration.distrokid import Distrokid
 from youtube_automation.configuration.loader import (
     channel_dir,
-    explicit_channel_selection,
-    find_workspace_root,
     load_config,
     load_schedule_config,
     reset,
-    select_channel,
-    workspace_channels,
 )
 from youtube_automation.configuration.model import ChannelConfig
 from youtube_automation.configuration.pinned_comment import PinnedComment
@@ -42,11 +34,7 @@ __all__ = [
     "ScheduleConfig",
     "Shorts",
     "channel_dir",
-    "explicit_channel_selection",
-    "find_workspace_root",
     "load_config",
     "load_schedule_config",
     "reset",
-    "select_channel",
-    "workspace_channels",
 ]

--- a/src/youtube_automation/configuration/loader.py
+++ b/src/youtube_automation/configuration/loader.py
@@ -74,7 +74,6 @@ logger = logging.getLogger(__name__)
 
 _instance: ChannelConfig | None = None
 _channel_dir: Path | None = None
-_explicit_channel: str | None = None
 
 __all__ = ["load_schedule_config", "resolve_existing_target_dir"]
 
@@ -106,42 +105,6 @@ _REQUIRED_KEYS_BY_SECTION: dict[str, list[str]] = {
 }
 
 
-def workspace_channels(workspace_root: Path) -> dict[str, Path]:
-    """workspace 直下の有効な channel slug とディレクトリを返す."""
-    channels_root = workspace_root / "channels"
-    if not channels_root.is_dir():
-        return {}
-    return {
-        path.name: path
-        for path in sorted(channels_root.iterdir(), key=lambda candidate: candidate.name)
-        if path.is_dir() and (path / "config" / "channel").is_dir()
-    }
-
-
-def find_workspace_root(start: Path | None = None) -> Path | None:
-    """start から祖先を遡り、最初の multi-channel workspace を返す."""
-    current = (start or Path.cwd()).expanduser().resolve()
-    for parent in [current, *current.parents]:
-        if workspace_channels(parent):
-            return parent
-    return None
-
-
-def select_channel(slug: str | None) -> None:
-    """CLI の明示的な ``--channel`` 選択を初回 config 解決へ渡す."""
-    global _explicit_channel, _instance, _channel_dir
-    if _instance is not None or _channel_dir is not None:
-        raise ConfigError("チャンネル設定の解決後に --channel を変更することはできません")
-    if slug is not None and not slug.strip():
-        raise ConfigError("--channel には空でない channel slug を指定してください")
-    _explicit_channel = slug
-
-
-def explicit_channel_selection() -> str | None:
-    """共通 CLI wrapper が受け取った明示 channel slug を返す."""
-    return _explicit_channel
-
-
 def _find_channel_ancestor(start: Path) -> Path | None:
     current = start.expanduser().resolve()
     for parent in [current, *current.parents]:
@@ -150,60 +113,14 @@ def _find_channel_ancestor(start: Path) -> Path | None:
     return None
 
 
-def _resolve_slug(slug: str, workspace_root: Path | None, *, source: str) -> Path:
-    if workspace_root is None:
-        raise ConfigError(f"{source}={slug!r} を解決できる workspace が見つかりません")
-    candidates = workspace_channels(workspace_root)
-    if slug not in candidates:
-        available = ", ".join(candidates) or "(なし)"
-        raise ConfigError(
-            f"{source}={slug!r} に対応するチャンネルが見つかりません: {workspace_root / 'channels'}. 候補: {available}"
-        )
-    return candidates[slug]
-
-
 def _resolve_channel_dir() -> Path:
-    """設定ルートを ``--channel`` → env → cwd の優先順で安全に解決する."""
-    cwd = Path.cwd()
-    cwd_channel = _find_channel_ancestor(cwd)
-    env_dir_raw = os.environ.get("CHANNEL_DIR")
-    env_dir = Path(env_dir_raw).expanduser() if env_dir_raw else None
-    workspace_root = find_workspace_root(cwd)
-    if workspace_root is None and env_dir is not None:
-        workspace_root = find_workspace_root(env_dir)
-
-    env_slug = os.environ.get("CHANNEL")
-    validate_env_channel = _explicit_channel is None or env_dir is not None
-    env_channel = (
-        _resolve_slug(env_slug, workspace_root, source="CHANNEL") if env_slug and validate_env_channel else None
-    )
-    if env_channel is not None and env_dir is not None and env_channel.resolve() != env_dir.resolve():
-        raise ConfigError(
-            "CHANNEL と CHANNEL_DIR が異なるチャンネルを指しています: "
-            f"CHANNEL={env_slug!r} -> {env_channel.resolve()}, CHANNEL_DIR={env_dir_raw!r} -> {env_dir.resolve()}"
-        )
-
-    if _explicit_channel is not None:
-        explicit_channel = _resolve_slug(_explicit_channel, workspace_root, source="--channel")
-        if cwd_channel is not None and cwd_channel.resolve() != explicit_channel.resolve():
-            logger.warning(
-                "--channel=%s (%s) を採用します。cwd は別チャンネル %s を指しています",
-                _explicit_channel,
-                explicit_channel,
-                cwd_channel,
-            )
-        return explicit_channel
-    if env_channel is not None:
-        return env_channel
-    if env_dir is not None:
-        return env_dir
+    """設定ルートを CHANNEL_DIR → cwd 祖先の優先順で解決する."""
+    env_dir = os.environ.get("CHANNEL_DIR")
+    if env_dir:
+        return Path(env_dir).expanduser()
+    cwd_channel = _find_channel_ancestor(Path.cwd())
     if cwd_channel is not None:
         return cwd_channel
-    if workspace_root is not None:
-        available = ", ".join(workspace_channels(workspace_root))
-        raise ConfigError(
-            f"workspace ルートでは --channel <slug> または CHANNEL=<slug> を指定してください. 候補: {available}"
-        )
     raise ConfigError("CHANNEL_DIR 環境変数を設定するか、config/channel/ を持つディレクトリ配下で実行してください")
 
 
@@ -215,13 +132,11 @@ def channel_dir() -> Path:
     return _channel_dir
 
 
-def reset(*, preserve_channel_selection: bool = False) -> None:
-    """シングルトン state をリセットし、必要なら CLI の明示選択を保持する."""
-    global _explicit_channel, _instance, _channel_dir
+def reset() -> None:
+    """シングルトン state をリセットする."""
+    global _instance, _channel_dir
     _instance = None
     _channel_dir = None
-    if not preserve_channel_selection:
-        _explicit_channel = None
 
 
 def load_config() -> ChannelConfig:

--- a/src/youtube_automation/domains/uploads/playlists.py
+++ b/src/youtube_automation/domains/uploads/playlists.py
@@ -463,7 +463,7 @@ class PlaylistManager:
 
         # dry_run でなければ config を再読み込み（書き戻し後の playlist_id を反映）
         if not dry_run:
-            reset(preserve_channel_selection=True)
+            reset()
             self.config = load_config()
 
         print("\n=== Step 2: 既存動画の割り当て ===")

--- a/src/youtube_automation/entrypoints.py
+++ b/src/youtube_automation/entrypoints.py
@@ -2,67 +2,17 @@
 
 from __future__ import annotations
 
-import sys
 from collections.abc import Callable
 from importlib import import_module
 from typing import cast
 
 from youtube_automation.cli_stdio import configure_utf8_stdio
 
-_CHANNEL_OPTION_CONFLICTS = {
-    "youtube_automation.commands.channel.channel_export",
-    "youtube_automation.commands.analytics.benchmark_collector",
-    "youtube_automation.commands.analytics.fetch_benchmark_comments",
-    "youtube_automation.commands.analytics.video_analyze",
-    "youtube_automation.commands.system.codex_canary_notify",
-    "youtube_automation.commands.system.channels",
-    "youtube_automation.commands.thumbnail.compare_thumbnails",
-}
-
-
-def _consume_channel_option(argv: list[str]) -> str | None:
-    """共通 ``--channel`` を argv から除去し、指定 slug を返す."""
-    slug: str | None = None
-    index = 1
-    while index < len(argv):
-        argument = argv[index]
-        if argument == "--":
-            break
-        if argument == "--channel":
-            if index + 1 >= len(argv) or argv[index + 1].startswith("-"):
-                from youtube_automation.core.errors import ConfigError
-
-                raise ConfigError("--channel には channel slug が必要です")
-            value = argv[index + 1]
-            del argv[index : index + 2]
-        elif argument.startswith("--channel="):
-            value = argument.partition("=")[2]
-            del argv[index]
-        else:
-            index += 1
-            continue
-        if not value:
-            from youtube_automation.core.errors import ConfigError
-
-            raise ConfigError("--channel には空でない channel slug を指定してください")
-        if slug is not None:
-            from youtube_automation.core.errors import ConfigError
-
-            raise ConfigError("--channel は複数回指定できません")
-        slug = value
-    return slug
-
 
 def _run(module_path: str, function_name: str = "main") -> object:
     """Configure CLI stdio before importing and running the real command."""
 
     configure_utf8_stdio()
-    if module_path not in _CHANNEL_OPTION_CONFLICTS:
-        channel = _consume_channel_option(sys.argv)
-        if channel is not None:
-            from youtube_automation.configuration import select_channel
-
-            select_channel(channel)
     target = getattr(import_module(module_path), function_name)
     if not callable(target):
         raise TypeError(f"{module_path}:{function_name} is not callable")

--- a/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
+++ b/src/youtube_automation/infrastructure/analytics/dashboard_refresh.py
@@ -38,10 +38,7 @@ def _channel_context(channel: Path) -> Iterator[None]:
     from youtube_automation.configuration import reset as reset_config
 
     previous_dir = os.environ.get("CHANNEL_DIR")
-    previous_slug = os.environ.get("CHANNEL")
     os.environ["CHANNEL_DIR"] = str(channel)
-    # 残存 CHANNEL は単一リポジトリでは解決できず ConfigError になるため、切替中だけ退避する
-    os.environ.pop("CHANNEL", None)
     reset_config()
     try:
         yield
@@ -50,10 +47,6 @@ def _channel_context(channel: Path) -> Iterator[None]:
             os.environ.pop("CHANNEL_DIR", None)
         else:
             os.environ["CHANNEL_DIR"] = previous_dir
-        if previous_slug is None:
-            os.environ.pop("CHANNEL", None)
-        else:
-            os.environ["CHANNEL"] = previous_slug
         reset_config()
 
 

--- a/tests/commands/system/test_doctor.py
+++ b/tests/commands/system/test_doctor.py
@@ -1233,51 +1233,12 @@ class TestResolveChannelDir:
         r = doctor.resolve_channel_dir(None)
         assert r == tmp_path.resolve()
 
-    def test_common_channel_selection_does_not_redirect_doctor(self, tmp_path, monkeypatch):
-        from youtube_automation.configuration import select_channel
-
-        self._clear_channel_env(monkeypatch)
-        workspace, _channel = self._workspace(tmp_path)
-        monkeypatch.chdir(workspace)
-        select_channel("alpha")
-
-        assert doctor.resolve_channel_dir(None) == workspace.resolve()
-
     def test_workspace_root_without_selection_uses_cwd(self, tmp_path, monkeypatch):
         self._clear_channel_env(monkeypatch)
         workspace, _channel = self._workspace(tmp_path)
         monkeypatch.chdir(workspace)
 
         assert doctor.resolve_channel_dir(None) == workspace.resolve()
-
-    def test_target_remains_higher_priority_than_common_selection(self, tmp_path, monkeypatch):
-        from youtube_automation.configuration import select_channel
-
-        self._clear_channel_env(monkeypatch)
-        workspace, _channel = self._workspace(tmp_path)
-        target = tmp_path / "explicit-target"
-        target.mkdir()
-        monkeypatch.chdir(workspace)
-        select_channel("alpha")
-
-        assert doctor.resolve_channel_dir(str(target)) == target.resolve()
-
-    @pytest.mark.parametrize("selection", ["environment", "explicit"])
-    def test_channel_dir_wins_over_legacy_selection(self, tmp_path, monkeypatch, selection):
-        from youtube_automation.configuration import select_channel
-
-        self._clear_channel_env(monkeypatch)
-        workspace, _channel = self._workspace(tmp_path)
-        target = tmp_path / "standalone"
-        target.mkdir()
-        monkeypatch.chdir(workspace)
-        monkeypatch.setenv("CHANNEL_DIR", str(target))
-        if selection == "environment":
-            monkeypatch.setenv("CHANNEL", "alpha")
-        else:
-            select_channel("alpha")
-
-        assert doctor.resolve_channel_dir(None) == target.resolve()
 
     def test_legacy_channel_env_does_not_redirect_cwd(self, tmp_path, monkeypatch):
         self._clear_channel_env(monkeypatch)

--- a/tests/configuration/test_config_loader.py
+++ b/tests/configuration/test_config_loader.py
@@ -7,7 +7,6 @@ sample_channel の新構造化は S3（コミット 3）で実施する予定。
 from __future__ import annotations
 
 import json
-import logging
 from pathlib import Path
 
 import pytest
@@ -15,11 +14,8 @@ import pytest
 from youtube_automation.configuration import (
     ChannelConfig,
     channel_dir,
-    find_workspace_root,
     load_config,
     reset,
-    select_channel,
-    workspace_channels,
 )
 from youtube_automation.configuration.loader import load_config_from_path
 from youtube_automation.core.errors import ConfigError
@@ -1801,121 +1797,14 @@ def test_channel_dir_ancestor_search(tmp_path, monkeypatch):
     assert channel_dir().resolve() != (ch / "config" / "channel").resolve()
 
 
-def test_workspace_detection_and_channel_listing(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "beta", "alpha")
-    nested = workspace / "channels" / "alpha" / "collections" / "planning"
-    nested.mkdir(parents=True)
-    monkeypatch.chdir(nested)
-
-    assert find_workspace_root() == workspace.resolve()
-    assert list(workspace_channels(workspace)) == ["alpha", "beta"]
-
-
-def test_explicit_channel_selects_workspace_slug(tmp_path, monkeypatch):
+def test_channel_dir_env_ignores_legacy_slug(tmp_path, monkeypatch):
     workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-    select_channel("beta")
-
-    assert channel_dir() == (workspace / "channels" / "beta").resolve()
-
-
-def test_explicit_channel_selection_is_available_through_public_configuration_api() -> None:
-    import youtube_automation.configuration as configuration
-
-    configuration.select_channel("alpha")
-
-    assert configuration.explicit_channel_selection() == "alpha"
-
-
-def test_config_reset_can_preserve_explicit_channel_selection(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-    select_channel("beta")
-    assert channel_dir() == (workspace / "channels" / "beta").resolve()
-
-    reset(preserve_channel_selection=True)
-
-    assert channel_dir() == (workspace / "channels" / "beta").resolve()
-
-
-def test_channel_env_selects_workspace_slug(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-    monkeypatch.setenv("CHANNEL", "alpha")
-
-    assert channel_dir() == (workspace / "channels" / "alpha").resolve()
-
-
-def test_explicit_channel_takes_priority_over_channel_env(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-    monkeypatch.setenv("CHANNEL", "missing")
-    select_channel("beta")
-
-    assert channel_dir() == (workspace / "channels" / "beta").resolve()
-
-
-def test_matching_channel_and_channel_dir_are_accepted(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    alpha = workspace / "channels" / "alpha"
-    monkeypatch.chdir(workspace)
-    monkeypatch.setenv("CHANNEL", "alpha")
-    monkeypatch.setenv("CHANNEL_DIR", str(alpha))
-
-    assert channel_dir() == alpha.resolve()
-
-
-def test_cwd_inside_workspace_channel_resolves_without_explicit_selection(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    nested = workspace / "channels" / "alpha" / "collections" / "planning"
-    nested.mkdir(parents=True)
-    monkeypatch.chdir(nested)
-
-    assert channel_dir() == (workspace / "channels" / "alpha").resolve()
-
-
-def test_channel_and_channel_dir_conflict_lists_both_targets(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    alpha = workspace / "channels" / "alpha"
     beta = workspace / "channels" / "beta"
-    monkeypatch.chdir(workspace)
+    monkeypatch.chdir(workspace / "channels" / "alpha")
     monkeypatch.setenv("CHANNEL", "alpha")
     monkeypatch.setenv("CHANNEL_DIR", str(beta))
 
-    with pytest.raises(ConfigError) as error:
-        channel_dir()
-
-    assert str(alpha.resolve()) in str(error.value)
-    assert str(beta.resolve()) in str(error.value)
-
-
-def test_explicit_channel_warns_when_cwd_points_to_another_channel(tmp_path, monkeypatch, caplog):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace / "channels" / "alpha")
-    select_channel("beta")
-
-    with caplog.at_level(logging.WARNING):
-        resolved = channel_dir()
-
-    assert resolved == (workspace / "channels" / "beta").resolve()
-    assert "cwd は別チャンネル" in caplog.text
-
-
-def test_unknown_channel_slug_lists_candidates(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-    monkeypatch.setenv("CHANNEL", "missing")
-
-    with pytest.raises(ConfigError, match=r"候補: alpha, beta"):
-        channel_dir()
-
-
-def test_workspace_root_requires_channel_selection(tmp_path, monkeypatch):
-    workspace = _setup_workspace(tmp_path, "alpha", "beta")
-    monkeypatch.chdir(workspace)
-
-    with pytest.raises(ConfigError, match=r"--channel.*候補: alpha, beta"):
-        channel_dir()
+    assert channel_dir() == beta
 
 
 # ----- comments.generator section -------------------------------------------
@@ -2668,3 +2557,21 @@ def test_scheduled_automation_invalid_raises(tmp_path, monkeypatch, scheduled, m
 
     with pytest.raises(ConfigError, match=message):
         load_config()
+
+
+def test_cwd_channel_ignores_legacy_slug(tmp_path, monkeypatch):
+    workspace = _setup_workspace(tmp_path, "alpha", "beta")
+    alpha = workspace / "channels" / "alpha"
+    monkeypatch.chdir(alpha)
+    monkeypatch.setenv("CHANNEL", "beta")
+
+    assert channel_dir() == alpha.resolve()
+
+
+def test_legacy_slug_cannot_select_from_parent_directory(tmp_path, monkeypatch):
+    workspace = _setup_workspace(tmp_path, "alpha")
+    monkeypatch.chdir(workspace)
+    monkeypatch.setenv("CHANNEL", "alpha")
+
+    with pytest.raises(ConfigError, match="CHANNEL_DIR"):
+        channel_dir()

--- a/tests/configuration/test_configuration_migration_contract.py
+++ b/tests/configuration/test_configuration_migration_contract.py
@@ -105,13 +105,9 @@ def test_configuration_public_api_preserves_the_specified_exports():
         "ScheduleConfig",
         "Shorts",
         "channel_dir",
-        "explicit_channel_selection",
-        "find_workspace_root",
         "load_config",
         "load_schedule_config",
         "reset",
-        "select_channel",
-        "workspace_channels",
     ]
     assert configuration.ChannelConfig is ChannelConfig
     assert configuration.CommunityDraft is CommunityDraft

--- a/tests/contracts/architecture/test_repository_reorganization_contract.py
+++ b/tests/contracts/architecture/test_repository_reorganization_contract.py
@@ -185,13 +185,9 @@ PUBLIC_CONFIGURATION_SYMBOLS = {
     "ScheduleConfig",
     "Shorts",
     "channel_dir",
-    "explicit_channel_selection",
-    "find_workspace_root",
     "load_config",
     "load_schedule_config",
     "reset",
-    "select_channel",
-    "workspace_channels",
 }
 
 LAYER_FORBIDDEN_IMPORTS = {

--- a/tests/infrastructure/analytics/test_dashboard_refresh.py
+++ b/tests/infrastructure/analytics/test_dashboard_refresh.py
@@ -86,7 +86,6 @@ def test_collect_channel_restores_environment_and_configuration_after_success(
         assert days == 30
         assert depth == "standard"
         assert os.environ["CHANNEL_DIR"] == str(channel)
-        assert "CHANNEL" not in os.environ
         (channel / "data").mkdir(parents=True)
         return {"success": True}
 
@@ -108,7 +107,7 @@ def test_channel_context_resolves_channel_dir_when_stale_channel_slug_remains(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """単一リポジトリでは残存 CHANNEL を解決できないため、切替中は退避されていなければならない."""
+    """CHANNEL が残っていても、収集対象は CHANNEL_DIR で解決する."""
     channel = tmp_path / "selected"
     (channel / "config" / "channel").mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
@@ -422,7 +421,6 @@ def test_collect_channel_restores_environment_and_raises_automation_error(
         assert days == 30
         assert depth == "standard"
         assert os.environ["CHANNEL_DIR"] == str(tmp_path / "selected")
-        assert "CHANNEL" not in os.environ
         return {
             "success": False,
             "error": "reporting collection failed",

--- a/tests/test_cli_stdio.py
+++ b/tests/test_cli_stdio.py
@@ -178,15 +178,13 @@ def test_cli_entrypoint_configures_utf8_before_importing_target(monkeypatch):
     assert stderr_buffer.getvalue().decode("utf-8") == "import 時エラー — 続行\n"
 
 
-def test_cli_entrypoint_consumes_channel_before_importing_target(monkeypatch):
+def test_cli_entrypoint_preserves_channel_for_target(monkeypatch):
     from youtube_automation import entrypoints
-    from youtube_automation.configuration import loader
 
     monkeypatch.setattr(sys, "argv", ["yt-dummy", "--channel", "alpha", "--dry-run"])
 
     def fake_import_module(_module_name: str) -> object:
-        assert loader._explicit_channel == "alpha"
-        assert sys.argv == ["yt-dummy", "--dry-run"]
+        assert sys.argv == ["yt-dummy", "--channel", "alpha", "--dry-run"]
 
         class TargetModule:
             @staticmethod

--- a/tests/test_codex_image_batch.py
+++ b/tests/test_codex_image_batch.py
@@ -247,41 +247,17 @@ def test_batch_reports_config_failure_after_environment_is_ready(tmp_path: Path)
     assert not (tmp_path / "codex.log").exists()
 
 
-@pytest.mark.parametrize(
-    ("channel_slug", "diagnostic"),
-    [
-        (None, "workspace ルートでは --channel <slug> または CHANNEL=<slug> を指定してください"),
-        ("missing", "CHANNEL='missing' に対応するチャンネルが見つかりません"),
-    ],
-)
-def test_batch_rejects_missing_or_wrong_workspace_channel_before_jobs(
-    tmp_path: Path,
-    channel_slug: str | None,
-    diagnostic: str,
-) -> None:
-    workspace = tmp_path / "workspace"
-    _workspace_channel(workspace, "alpha")
-    manifest = _manifest(tmp_path, ["one", "two"])
-
-    result = _run_batch(tmp_path, manifest, cwd=workspace, channel_slug=channel_slug)
-
-    assert result.returncode != 0
-    assert diagnostic in result.stderr
-    assert "候補: alpha" in result.stderr
-    assert not (tmp_path / "codex.log").exists()
-    assert not (tmp_path / "runner-state.json").exists()
-
-
-def test_batch_resolves_channel_slug_from_workspace_root(tmp_path: Path) -> None:
+def test_batch_requires_channel_dir_outside_configured_directory(tmp_path: Path) -> None:
     workspace = tmp_path / "workspace"
     _workspace_channel(workspace, "alpha")
     manifest = _manifest(tmp_path, ["one", "two"])
 
     result = _run_batch(tmp_path, manifest, cwd=workspace, channel_slug="alpha")
 
-    assert result.returncode == 0, result.stderr
-    state = json.loads((tmp_path / "runner-state.json").read_text())
-    assert sorted(state["calls"]) == ["one", "two"]
+    assert result.returncode != 0
+    assert "CHANNEL_DIR" in result.stderr
+    assert not (tmp_path / "codex.log").exists()
+    assert not (tmp_path / "runner-state.json").exists()
 
 
 def test_batch_finishes_remaining_jobs_and_reports_failures(tmp_path: Path) -> None:

--- a/tests/test_entrypoints.py
+++ b/tests/test_entrypoints.py
@@ -5,54 +5,11 @@ from __future__ import annotations
 import sys
 from collections.abc import Callable
 from types import SimpleNamespace
-from unittest.mock import Mock
 
 import pytest
 
 from youtube_automation import entrypoints
 from youtube_automation.commands._shared.arguments import CompetitorArgumentParser
-from youtube_automation.core.errors import ConfigError
-
-
-def test_consume_channel_rejects_missing_value_without_mutating_argv() -> None:
-    argv = ["yt-command", "--dry-run", "--channel"]
-
-    with pytest.raises(ConfigError, match="channel slug が必要"):
-        entrypoints._consume_channel_option(argv)
-
-    assert argv == ["yt-command", "--dry-run", "--channel"]
-
-
-def test_consume_channel_rejects_empty_equals_value() -> None:
-    argv = ["yt-command", "--channel="]
-
-    with pytest.raises(ConfigError, match="空でない channel slug"):
-        entrypoints._consume_channel_option(argv)
-
-    assert argv == ["yt-command"]
-
-
-def test_consume_channel_rejects_duplicates_after_consuming_options() -> None:
-    argv = ["yt-command", "--channel", "alpha", "--channel=beta", "--dry-run"]
-
-    with pytest.raises(ConfigError, match="複数回指定"):
-        entrypoints._consume_channel_option(argv)
-
-    assert argv == ["yt-command", "--dry-run"]
-
-
-def test_consume_channel_accepts_equals_form_and_removes_only_that_option() -> None:
-    argv = ["yt-command", "--channel=alpha", "--dry-run"]
-
-    assert entrypoints._consume_channel_option(argv) == "alpha"
-    assert argv == ["yt-command", "--dry-run"]
-
-
-def test_consume_channel_stops_at_double_dash_and_preserves_tail() -> None:
-    argv = ["yt-command", "--dry-run", "--", "--channel", "target-value"]
-
-    assert entrypoints._consume_channel_option(argv) is None
-    assert argv == ["yt-command", "--dry-run", "--", "--channel", "target-value"]
 
 
 def test_run_rejects_non_callable_module_attribute(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -76,7 +33,6 @@ def test_competitor_cli_rejects_channel_without_selecting_self_channel(
     capsys: pytest.CaptureFixture[str],
     cli_entrypoint: Callable[[], object],
 ) -> None:
-    select_channel = Mock()
     parser = CompetitorArgumentParser()
     monkeypatch.setattr(sys, "argv", ["yt-command", "--channel", "competitor-x"])
     monkeypatch.setattr(entrypoints, "configure_utf8_stdio", lambda: None)
@@ -85,10 +41,8 @@ def test_competitor_cli_rejects_channel_without_selecting_self_channel(
         "import_module",
         lambda _path: SimpleNamespace(main=lambda: parser.parse_args()),
     )
-    monkeypatch.setattr("youtube_automation.configuration.select_channel", select_channel)
 
     with pytest.raises(SystemExit, match="2"):
         cli_entrypoint()
 
     assert "--channel は --competitor に変わりました" in capsys.readouterr().err
-    select_channel.assert_not_called()


### PR DESCRIPTION
全 CLI に先回りしていた共通 `--channel` 消費と `CHANNEL` によるチャンネル選択を削除し、設定の解決を `CHANNEL_DIR` → cwd 祖先へ統一しました。canary の `--channel` はコマンド自身へ届きます。

削除対象の共通検出 API に export CLI が依存していたため、承認済みの仕様調整として export 専用の検出へ一時移設しています。この処理は #4921 で export CLI とともに削除します。dashboard の暫定的な `CHANNEL` 退避も解決側の廃止に合わせて撤去しました。競合チャンネル parser の旧 option 拒否は維持します。

検証: focused 1,252 件成功、全テスト 10,483 件成功・4 件スキップ（`PYTEST_ADDOPTS='-n 4' nix develop --command uv run pytest -q`）。ruff check / format、changelog fragment、Python compileall を通過。専用型チェッカーは未導入です。

Closes #4919
