### PR TITLE
fix: Windows の hook 起動を互換化する (#5091)

### DIFF
--- a/.claude/skills/automation/references/guard_secret_edit.py
+++ b/.claude/skills/automation/references/guard_secret_edit.py
@@ -30,7 +30,9 @@ def main() -> int:
     parser.add_argument("--protect-lockfiles", action="store_true", help="Also reject repository lockfile edits")
     args = parser.parse_args()
     try:
-        file_path = edit_path(json.load(sys.stdin))
+        # ``json.loads`` auto-detects UTF-8/16/32 byte encodings and their BOMs.
+        # Claude Code Desktop on Windows may not encode hook stdin as UTF-8.
+        file_path = edit_path(json.loads(sys.stdin.buffer.read()))
     except ValueError:
         print("BLOCKED: 編集対象を確認できません。PreToolUse JSON 入力を確認してください。", file=sys.stderr)
         return 2

--- a/changelog.d/5091-windows-hooks.fixed.md
+++ b/changelog.d/5091-windows-hooks.fixed.md
@@ -1,0 +1,1 @@
+- Windows 版 Claude Code Desktop の BOM 付きフック入力を解釈し、`fcntl` がない環境でも SessionStart を起動できるようにした。

--- a/changelog.d/5091-windows-hooks.fixed.md
+++ b/changelog.d/5091-windows-hooks.fixed.md
@@ -1,1 +1,2 @@
 - Windows 版 Claude Code Desktop の BOM 付きフック入力を解釈し、`fcntl` がない環境でも SessionStart を起動できるようにした。
+- SessionStart の多重起動防止を共通の `infrastructure.file_lock` へ寄せ、Windows でも `msvcrt` で実際に排他制御が効くようにした。

--- a/src/youtube_automation/commands/system/session_start.py
+++ b/src/youtube_automation/commands/system/session_start.py
@@ -3,10 +3,14 @@
 from __future__ import annotations
 
 import argparse
-import fcntl
 import os
 import subprocess
 from pathlib import Path
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - exercised by an import subprocess
+    fcntl = None  # type: ignore[assignment]
 
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.commands.system.automation_update import _load_pyproject, _resolve_repo_root
@@ -95,11 +99,12 @@ def _run(_: argparse.Namespace) -> int:
         lock_path = root / ".automation-run" / "session-update.lock"
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         with lock_path.open("w", encoding="utf-8") as lock:
-            try:
-                fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            except BlockingIOError:
-                print(f"{_PREFIX} 別 session が追従中です")
-                return 0
+            if fcntl is not None:
+                try:
+                    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    print(f"{_PREFIX} 別 session が追従中です")
+                    return 0
             check = _command(["uv", "run", "yt-automation-update", "check"], root, timeout=_CHECK_TIMEOUT_SECONDS)
             if check.returncode != 1:
                 return 0

--- a/src/youtube_automation/commands/system/session_start.py
+++ b/src/youtube_automation/commands/system/session_start.py
@@ -7,16 +7,12 @@ import os
 import subprocess
 from pathlib import Path
 
-try:
-    import fcntl
-except ImportError:  # pragma: no cover - exercised by an import subprocess
-    fcntl = None  # type: ignore[assignment]
-
 from youtube_automation.commands._shared.cli_harness import run_cli
 from youtube_automation.commands.system.automation_update import _load_pyproject, _resolve_repo_root
 from youtube_automation.commands.system.automation_update_followup import migrate_action, render_action
 from youtube_automation.commands.system.automation_update_refs import _detect_pin
 from youtube_automation.core.errors import ConfigError
+from youtube_automation.infrastructure.file_lock import try_file_lock
 
 _PREFIX = "[yt-session-start]"
 _CHECK_TIMEOUT_SECONDS = 3
@@ -96,15 +92,11 @@ def _run(_: argparse.Namespace) -> int:
         pin = _detect_pin(_load_pyproject(root / "pyproject.toml"))
         if pin.kind == "sha":
             return 0
-        lock_path = root / ".automation-run" / "session-update.lock"
-        lock_path.parent.mkdir(parents=True, exist_ok=True)
-        with lock_path.open("w", encoding="utf-8") as lock:
-            if fcntl is not None:
-                try:
-                    fcntl.flock(lock, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                except BlockingIOError:
-                    print(f"{_PREFIX} 別 session が追従中です")
-                    return 0
+        # try_file_lock は `<path>.lock` を lock file にするため、`session-update.lock` を共有し続ける。
+        with try_file_lock(root / ".automation-run" / "session-update") as acquired:
+            if not acquired:
+                print(f"{_PREFIX} 別 session が追従中です")
+                return 0
             check = _command(["uv", "run", "yt-automation-update", "check"], root, timeout=_CHECK_TIMEOUT_SECONDS)
             if check.returncode != 1:
                 return 0

--- a/src/youtube_automation/infrastructure/file_lock.py
+++ b/src/youtube_automation/infrastructure/file_lock.py
@@ -56,6 +56,41 @@ def file_lock(path: Path) -> Iterator[None]:
                 _release_lock(lock_file)
 
 
+@contextlib.contextmanager
+def try_file_lock(path: Path) -> Iterator[bool]:
+    """Try to lock ``path`` without waiting, yielding whether the lock was taken.
+
+    ``file_lock`` と同じ lock file・同じ platform 実装を使う non-blocking 版で、
+    Windows でも ``msvcrt`` の byte-range lock で実際に排他制御が効く。
+    """
+    if _fcntl is None and _msvcrt is None:
+        acquired = _IN_PROCESS_LOCK.acquire(blocking=False)
+        try:
+            yield acquired
+        finally:
+            if acquired:
+                _IN_PROCESS_LOCK.release()
+        return
+
+    if not _IN_PROCESS_LOCK.acquire(blocking=False):
+        yield False
+        return
+    try:
+        lock_path = path.with_suffix(path.suffix + _LOCK_FILE_SUFFIX)
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as lock_file:
+            _prepare_lock_file(lock_file)
+            if not _try_acquire_lock(lock_file):
+                yield False
+                return
+            try:
+                yield True
+            finally:
+                _release_lock(lock_file)
+    finally:
+        _IN_PROCESS_LOCK.release()
+
+
 def _prepare_lock_file(lock_file: BinaryIO) -> None:
     lock_file.seek(0, 2)
     size = lock_file.tell()
@@ -72,6 +107,25 @@ def _acquire_lock(lock_file: BinaryIO, *, wait_forever: bool = False) -> None:
     if _msvcrt is not None:
         _acquire_msvcrt_lock(lock_file, wait_forever=wait_forever)
         return
+    raise RuntimeError("platform file locks are unavailable")
+
+
+def _try_acquire_lock(lock_file: BinaryIO) -> bool:
+    if _fcntl is not None:
+        try:
+            _fcntl.flock(lock_file.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB)
+        except BlockingIOError:
+            return False
+        return True
+    if _msvcrt is not None:
+        lock_file.seek(0)
+        try:
+            _msvcrt.locking(lock_file.fileno(), _msvcrt.LK_NBLCK, _LOCK_REGION_BYTES)
+        except OSError as error:
+            if _is_msvcrt_lock_contention(error):
+                return False
+            raise
+        return True
     raise RuntimeError("platform file locks are unavailable")
 
 

--- a/tests/commands/system/test_session_start.py
+++ b/tests/commands/system/test_session_start.py
@@ -3,11 +3,34 @@ from __future__ import annotations
 import fcntl
 import os
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
+from tests.helpers.paths import REPO_ROOT
 from youtube_automation.commands.system import session_start
+
+
+def test_module_import_succeeds_without_fcntl() -> None:
+    code = """
+import builtins
+original_import = builtins.__import__
+def import_without_fcntl(name, *args, **kwargs):
+    if name == "fcntl":
+        raise ImportError("No module named 'fcntl'")
+    return original_import(name, *args, **kwargs)
+builtins.__import__ = import_without_fcntl
+from youtube_automation.commands.system import session_start
+assert session_start.fcntl is None
+"""
+
+    environment = os.environ | {"PYTHONPATH": str(REPO_ROOT / "src")}
+    completed = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=False, env=environment
+    )
+
+    assert completed.returncode == 0, completed.stderr
 
 
 def _repo(tmp_path: Path, pin: str) -> Path:

--- a/tests/commands/system/test_session_start.py
+++ b/tests/commands/system/test_session_start.py
@@ -22,7 +22,8 @@ def import_without_fcntl(name, *args, **kwargs):
     return original_import(name, *args, **kwargs)
 builtins.__import__ = import_without_fcntl
 from youtube_automation.commands.system import session_start
-assert session_start.fcntl is None
+from youtube_automation.infrastructure import file_lock
+assert session_start.try_file_lock is file_lock.try_file_lock
 """
 
     environment = os.environ | {"PYTHONPATH": str(REPO_ROOT / "src")}

--- a/tests/infrastructure/test_file_lock.py
+++ b/tests/infrastructure/test_file_lock.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import builtins
 import contextlib
+import errno
 import importlib
 import sys
 import threading
@@ -77,6 +78,76 @@ def test_file_lock_releases_msvcrt_lock_when_body_raises(tmp_path: Path, monkeyp
                 raise ValueError("critical section failed")
 
     assert calls == [(fake_msvcrt.LK_NBLCK, 1), (fake_msvcrt.LK_UNLCK, 1)]
+
+
+def test_try_file_lock_takes_msvcrt_lock_when_fcntl_is_unavailable(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Given fcntl なし / msvcrt あり
+    When non-blocking ロックを取得・解放する
+    Then Windows でも msvcrt の排他ロックを取得し、取得成功を返す。
+    """
+    calls: list[tuple[int, int]] = []
+    fake_msvcrt = ModuleType("msvcrt")
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+    fake_msvcrt.locking = lambda _fd, mode, size: calls.append((mode, size))
+
+    with _import_file_lock_without(monkeypatch, {"fcntl"}, msvcrt_module=fake_msvcrt) as module:
+        with module.try_file_lock(tmp_path / "session-update") as acquired:
+            assert acquired
+
+    assert calls == [(fake_msvcrt.LK_NBLCK, 1), (fake_msvcrt.LK_UNLCK, 1)]
+    assert (tmp_path / "session-update.lock").exists()
+
+
+def test_try_file_lock_reports_contention_without_blocking_on_windows(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given Windows で他プロセスが同じロックを保持している
+    When non-blocking ロックを試す
+    Then 待機せず取得失敗を返し、解放も行わない。
+    """
+    calls: list[int] = []
+    sleeps: list[float] = []
+    fake_msvcrt = ModuleType("msvcrt")
+    fake_msvcrt.LK_NBLCK = 1
+    fake_msvcrt.LK_UNLCK = 2
+
+    def locking(_descriptor: int, mode: int, _size: int) -> None:
+        calls.append(mode)
+        raise OSError(errno.EACCES, "lock contention")
+
+    fake_msvcrt.locking = locking
+
+    with _import_file_lock_without(monkeypatch, {"fcntl"}, msvcrt_module=fake_msvcrt) as module:
+        monkeypatch.setattr(module.time, "sleep", sleeps.append)
+        with module.try_file_lock(tmp_path / "session-update") as acquired:
+            assert not acquired
+
+    assert calls == [fake_msvcrt.LK_NBLCK]
+    assert sleeps == []
+
+
+def test_try_file_lock_reports_contention_between_threads_without_platform_locks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Given fcntl / msvcrt の双方がない環境で先行ロックが保持されている
+    When 別スレッドが non-blocking ロックを試す
+    Then 待機せず取得失敗を返す。
+    """
+    outcomes: list[bool] = []
+
+    def try_lock() -> None:
+        with module.try_file_lock(tmp_path / "session-update") as acquired:
+            outcomes.append(acquired)
+
+    with _import_file_lock_without(monkeypatch, {"fcntl", "msvcrt"}) as module:
+        with module.try_file_lock(tmp_path / "session-update") as acquired:
+            assert acquired
+            contender = threading.Thread(target=try_lock)
+            contender.start()
+            contender.join()
+
+    assert outcomes == [False]
 
 
 def test_file_descriptor_lock_retries_windows_contention_until_acquired(

--- a/tests/repo/test_guard_secret_edit.py
+++ b/tests/repo/test_guard_secret_edit.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import pytest
+
+from tests.helpers.paths import REPO_ROOT
+
+_SCRIPT = REPO_ROOT / ".claude" / "skills" / "automation" / "references" / "guard_secret_edit.py"
+
+
+@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16"])
+def test_guard_accepts_non_secret_edit_payload_with_bom_encoding(encoding: str) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Edit",
+        "tool_input": {"file_path": "C:/tmp/x.py"},
+    }
+
+    completed = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        input=json.dumps(payload).encode(encoding),
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr.decode(errors="replace")

--- a/tests/repo/test_guard_secret_edit.py
+++ b/tests/repo/test_guard_secret_edit.py
@@ -11,8 +11,12 @@ from tests.helpers.paths import REPO_ROOT
 _SCRIPT = REPO_ROOT / ".claude" / "skills" / "automation" / "references" / "guard_secret_edit.py"
 
 
-@pytest.mark.parametrize("encoding", ["utf-8-sig", "utf-16"])
-def test_guard_accepts_non_secret_edit_payload_with_bom_encoding(encoding: str) -> None:
+# Claude Code Desktop が渡しうる BOM 付き / BOM なしの UTF-8・UTF-16・UTF-32 を網羅する。
+@pytest.mark.parametrize(
+    "encoding",
+    ["utf-8-sig", "utf-16", "utf-16-le", "utf-16-be", "utf-32", "utf-32-le", "utf-32-be"],
+)
+def test_guard_accepts_non_secret_edit_payload_with_non_utf8_encoding(encoding: str) -> None:
     payload = {
         "hook_event_name": "PreToolUse",
         "tool_name": "Edit",


### PR DESCRIPTION
Closes #5091

## 概要
- Claude Code Desktop が UTF-8/16/32 と BOM 付きで渡す PreToolUse JSON をバイト列から自動判別する
- Windows のように `fcntl` がない環境でも `yt-session-start` を import・起動可能にする
- Windows 互換性の回帰テストを追加する

## 検証
- `uv run --no-sync pytest tests/repo/test_guard_secret_edit.py tests/commands/system/test_session_start.py -q`
- `uv run --no-sync ruff check .claude/skills/automation/references/guard_secret_edit.py src/youtube_automation/commands/system/session_start.py tests/repo/test_guard_secret_edit.py tests/commands/system/test_session_start.py`
- `python .github/scripts/validate-changelog-fragments.py`
- `git diff --check`

## 動画エビデンス
- 対象外: ブラウザ UI の変更ではなく、Windows hook stdin と Python import の互換性修正。代わりに BOM 入力と `fcntl` 不在を subprocess テストで検証。
