### PR TITLE
fix: Windows の secret パスを保護する (#5092)

### DIFF
--- a/.claude/skills/automation/references/guard_secret_edit.py
+++ b/.claude/skills/automation/references/guard_secret_edit.py
@@ -22,7 +22,7 @@ def edit_path(payload: object) -> str:
     file_path = tool_input.get("file_path")
     if not isinstance(file_path, str) or not file_path.strip() or "\x00" in file_path:
         raise ValueError("Expected a nonempty file_path")
-    return os.path.normpath(file_path)
+    return os.path.normpath(file_path).replace("\\", "/")
 
 
 def main() -> int:

--- a/changelog.d/5092-windows-secret-paths.fixed.md
+++ b/changelog.d/5092-windows-secret-paths.fixed.md
@@ -1,0 +1,1 @@
+- Windows のパス区切りで渡された `auth/client_secrets.json` と `auth/token.json` も secret edit guard で拒否するようにした。

--- a/tests/repo/test_guard_secret_edit.py
+++ b/tests/repo/test_guard_secret_edit.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import ntpath
+import os
+import runpy
 import subprocess
 import sys
 
@@ -31,3 +34,38 @@ def test_guard_accepts_non_secret_edit_payload_with_non_utf8_encoding(encoding: 
     )
 
     assert completed.returncode == 0, completed.stderr.decode(errors="replace")
+
+
+@pytest.mark.parametrize("secret", [r"C:\channel\auth\client_secrets.json", r"C:\channel\auth\token.json"])
+def test_guard_rejects_windows_secret_paths(secret: str) -> None:
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Write",
+        "tool_input": {"file_path": secret},
+    }
+
+    completed = subprocess.run(
+        [sys.executable, str(_SCRIPT)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2
+    assert "BLOCKED" in completed.stderr
+
+
+def test_windows_normpath_output_remains_compatible_with_secret_suffixes(monkeypatch: pytest.MonkeyPatch) -> None:
+    namespace = runpy.run_path(str(_SCRIPT), run_name="guard_secret_edit_test")
+    monkeypatch.setattr(os.path, "normpath", ntpath.normpath)
+
+    normalized = namespace["edit_path"](
+        {
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": r"C:\channel\auth\client_secrets.json"},
+        }
+    )
+
+    assert normalized.endswith("auth/client_secrets.json")


### PR DESCRIPTION
Closes #5092

## 概要
- hook の対象パスを OS 固有の正規化後にスラッシュ区切りへ統一する
- Windows 形式の `auth/client_secrets.json` と `auth/token.json` が必ず拒否される回帰テストを追加する
- `ntpath.normpath` を使い、Linux CI 上でも Windows 固有の正規化経路を検証する

## 検証
- `uv run --no-sync pytest tests/repo/test_guard_secret_edit.py -q`
- `uv run --no-sync ruff check .claude/skills/automation/references/guard_secret_edit.py tests/repo/test_guard_secret_edit.py`
- `python .github/scripts/validate-changelog-fragments.py`
- `git diff --check`

## 動画エビデンス
- 対象外: ブラウザ UI の変更ではなく、Windows パスの secret 判定修正。代わりに Windows 形式の両認証ファイルと `ntpath` 経路をテストで検証。
