### PR TITLE
chore(suno-helper): ext-v0.4.1

### DIFF
--- a/extensions/suno-helper/package.json
+++ b/extensions/suno-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "suno-helper",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "description": "/suno が生成した Style/Lyrics を Suno の Advanced タブに順次注入し Generate を連続実行する補助拡張 (WXT + React + TS)。",
   "type": "module",


### PR DESCRIPTION
Suno Helper を 0.4.0 から 0.4.1 に更新します。曲採用・停止・Studio export の修正を配布します。3拡張の verify-extensions.sh（frozen install / build / zip / lockfile 差分確認）は成功。差分は Suno Helper の version 1行のみです。配布 ZIP は Suno Helper 0.4.1、DistroKid Helper 0.3.1、Community Helper 0.3.0。