### PR TITLE
fix(ci): 本体リリースだけに CHANGELOG 昇格を要求する (#5105)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,7 +352,7 @@ jobs:
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
           echo "Changed files:"
           echo "$changed"
-          if [[ "$HEAD_REF" == release/* ]]; then
+          if [[ "$HEAD_REF" == release/v* ]]; then
             if ! echo "$changed" | grep -q '^CHANGELOG\.md$'; then
               echo "::error::Release PRs must update CHANGELOG.md."
               exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ YouTube チャンネル運営を自動化するツールキット。`youtube-cha
 - スクリプトは該当 skill の `.claude/skills/<skill>/references/` 配下に置く。ルート直下に `scripts/` を設けない
 - skill の実体は常に `.claude/skills/` 側（`.agents/skills` は Codex 用 symlink — 編集しない）。SKILL.md frontmatter は `purpose:` が必須で、`description:` は double-quoted 必須（値内の `: ` が strict YAML で誤解釈される）。検証は `uv run yt-skills lint`
 - `.claude/skills/` と `.claude/CLAUDE.template.md` は wheel に force-include される。バージョン bump は `pyproject.toml::version` のみ（`__version__` は動的読込）
-- 品質ゲート（ruff / CHANGELOG / any 型）はローカル git hook ではなく CI で担保。通常 PR の変更履歴は `changelog.d/<issue>-<slug>.<type>.md` に追加し、`CHANGELOG.md` を直接編集しない（`release/*` の release prepare だけが例外）
+- 品質ゲート（ruff / CHANGELOG / any 型）はローカル git hook ではなく CI で担保。通常 PR の変更履歴は `changelog.d/<issue>-<slug>.<type>.md` に追加し、`CHANGELOG.md` を直接編集しない（`release/v*` の release prepare だけが例外）
 - fragment の `<type>` は added / changed / deprecated / removed / fixed / security / migration の 7 種のみ（commit の `docs` / `ci` / `chore` は type として使えない）。本文は全非空行を `- ` 始まりの bullet にする。書式の正本は `changelog.d/README.md`、検証は `python .github/scripts/validate-changelog-fragments.py`
 - TypeScript は `dashboard/` のローカル表示層（ADR-0013）、`audio-studio/` のローカル音源編集表示層（ADR-0028）、`site/` の公開リリースノート静的サイト（ADR-0023）、`extensions/` の閉じた境界だけで許可する。他の TypeScript 実装・tayk core・削除済み `packages/` の復活は禁止（`docs/adr/0021-separate-repo-restart.md`）。dashboard / audio-studio から `extensions/shared-ui` を import しない
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -344,7 +344,7 @@ devShell の運用:
 
 通常の PR は `changelog.d/<issue>-<slug>.<type>.md` という PR 固有ファイルへ変更履歴を
 書き、リリース prepare で `uv run yt-changelog-compile` を実行して `[Unreleased]` へ
-集約する。通常 PR では `CHANGELOG.md` を直接編集しない。直接編集は `release/*` の release prepare だけが例外（`CLAUDE.md` の規約）。CI が後方互換のため直接編集を受理することは、通常 PR での推奨手順を変えない。
+集約する。通常 PR では `CHANGELOG.md` を直接編集しない。直接編集は `release/v*` の release prepare だけが例外（`CLAUDE.md` の規約）。CI が後方互換のため直接編集を受理することは、通常 PR での推奨手順を変えない。
 
 `<type>` は added / changed / deprecated / removed / fixed / security / migration のいずれかで、本文は全非空行を `- ` 始まりの bullet にする。書式の正本は [changelog.d/README.md](../changelog.d/README.md)。`python .github/scripts/validate-changelog-fragments.py` で全 fragment を検証する。
 

--- a/tests/repo/test_changelog_ci_contract.py
+++ b/tests/repo/test_changelog_ci_contract.py
@@ -95,7 +95,7 @@ _EXPECTED_RUN_LINES = [
     "set -eu",
     'if [[ ",${PR_LABELS}," == *",skip-changelog,"* ]]; then',
     'changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")',
-    'if [[ "$HEAD_REF" == release/* ]]; then',
+    'if [[ "$HEAD_REF" == release/v* ]]; then',
     "if echo \"$changed\" | grep -q '^CHANGELOG\\.md$'; then",
     f"if ! echo \"$changed\" | grep -qE '{_PATH_FILTER_PATTERN}'; then",
     f"if ! echo \"$changed\" | grep -qE '{_CHANGELOG_FRAGMENT_PATTERN}'; then",
@@ -193,7 +193,7 @@ def test_claude_requires_fragments_and_forbids_direct_changelog_edits() -> None:
 
     assert "通常 PR の変更履歴は `changelog.d/<issue>-<slug>.<type>.md` に追加" in claude
     assert "`CHANGELOG.md` を直接編集しない" in claude
-    assert "`release/*` の release prepare だけが例外" in claude
+    assert "`release/v*` の release prepare だけが例外" in claude
 
 
 def test_ci_workflow_declares_changelog_job_for_pull_requests_only() -> None:
@@ -265,7 +265,7 @@ def test_ci_workflow_changelog_job_checks_expected_paths_and_messages() -> None:
         ),
         (
             ("CHANGELOG.md",),
-            "release/1.2.3",
+            "release/v1.2.3",
             0,
             "Release CHANGELOG update found",
         ),
@@ -460,3 +460,23 @@ def test_readme_lists_every_fragment_type() -> None:
 
     for section in SECTION_ORDER:
         assert f"`{section}`" in readme, f"changelog.d/README.md に type `{section}` の記載が無い"
+
+
+@pytest.mark.parametrize(
+    ("head_ref", "changed_files", "expected_code"),
+    [
+        ("release/ext-v0.4.1", ("extensions/suno-helper/package.json",), 0),
+        ("release/ext-v0.4.1", ("pyproject.toml",), 1),
+        ("release/ext-v0.4.1", ("CHANGELOG.md",), 1),
+    ],
+)
+def test_release_series_changelog_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    head_ref: str,
+    changed_files: tuple[str, ...],
+    expected_code: int,
+) -> None:
+    """拡張の版数更新を許可し、本体変更や CHANGELOG 直接編集の混入は拒否する。"""
+    result = _run_changelog_gate(tmp_path, monkeypatch, changed_files=changed_files, head_ref=head_ref)
+    assert result.returncode == expected_code, result.stdout + result.stderr


### PR DESCRIPTION
拡張リリース release/ext-v0.4.1 が本体用の CHANGELOG 昇格必須判定で失敗していました。本体の release/v* だけに昇格チェックを適用し、拡張は通常の対象パス判定を通します。拡張ブランチに Python 変更や CHANGELOG 直接編集を混ぜた場合は引き続き拒否します。開発文書も同じ対象に揃えました。CI の shell を実行する回帰テストを追加し、changelog contract 全28件が成功しています。#5103 のリリースを妨げる不整合の修正です。